### PR TITLE
feat: remove send + sync constraint

### DIFF
--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -8,7 +8,7 @@ use std::{
 use pnp::fs::{LruZipCache, VPath, VPathInfo, ZipCache};
 
 /// File System abstraction used for `ResolverGeneric`
-pub trait FileSystem: Send + Sync {
+pub trait FileSystem {
     /// See [std::fs::read_to_string]
     ///
     /// # Errors


### PR DESCRIPTION
I don't why send + sync trait exist here, but we need use resolver in single_thread environment, so remove send + sync constraint