### PR TITLE
feat: pub all FileMetadata field

### DIFF
--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -60,9 +60,9 @@ pub trait FileSystem {
 /// Metadata information about a file
 #[derive(Debug, Clone, Copy)]
 pub struct FileMetadata {
-    pub(crate) is_file: bool,
-    pub(crate) is_dir: bool,
-    pub(crate) is_symlink: bool,
+    pub is_file: bool,
+    pub is_dir: bool,
+    pub is_symlink: bool,
 }
 
 impl FileMetadata {


### PR DESCRIPTION
need to convert FileMetadata to napi(object), so need to expose FileMetadata fields
```rs
#[napi(object)]
struct NapiFileMetadata {
  pub is_file: bool,
  pub is_dir: bool,
  pub is_symlink: bool,
}
impl From<FileMetadata> for NapiFileMetadata {
  fn from(value: FileMetadata) -> Self {
      Self {
        is_dir: value.is_file,
        is_dir: value.is_dir,
        is_symlink: value.is_symlink
      }
  }
}
```