### PR TITLE
chore: release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/web-infra-dev/rspack-resolver/compare/rspack_resolver-v0.3.4...rspack_resolver-v0.3.5) - 2024-10-21
+
+### Fixed
+
+- resolve mathjs error when using `extensionAlias` ([#31](https://github.com/web-infra-dev/rspack-resolver/pull/31))
+
 ## [0.3.4](https://github.com/web-infra-dev/rspack-resolver/compare/rspack_resolver-v0.3.3...rspack_resolver-v0.3.4) - 2024-10-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_resolver"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members  = ["napi"]
 resolver = "2"
 
 [package]
-version      = "0.3.4"
+version      = "0.3.5"
 name         = "rspack_resolver"
 authors      = ["Rspack"]
 categories   = ["development-tools"]


### PR DESCRIPTION
## 🤖 New release
* `rspack_resolver`: 0.3.4 -> 0.3.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.5](https://github.com/web-infra-dev/rspack-resolver/compare/rspack_resolver-v0.3.4...rspack_resolver-v0.3.5) - 2024-10-21

### Fixed

- resolve mathjs error when using `extensionAlias` ([#31](https://github.com/web-infra-dev/rspack-resolver/pull/31))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).