### PR TITLE
chore: release v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6](https://github.com/web-infra-dev/rspack-resolver/compare/rspack_resolver-v0.3.5...rspack_resolver-v0.3.6) - 2024-12-13
+
+### Fixed
+
+- alias match request end with slash (#35)
+
 ## [0.3.5](https://github.com/web-infra-dev/rspack-resolver/compare/rspack_resolver-v0.3.4...rspack_resolver-v0.3.5) - 2024-10-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_resolver"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members  = ["napi"]
 resolver = "2"
 
 [package]
-version      = "0.3.5"
+version      = "0.3.6"
 name         = "rspack_resolver"
 authors      = ["Rspack"]
 categories   = ["development-tools"]


### PR DESCRIPTION
## 🤖 New release
* `rspack_resolver`: 0.3.5 -> 0.3.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.6](https://github.com/web-infra-dev/rspack-resolver/compare/rspack_resolver-v0.3.5...rspack_resolver-v0.3.6) - 2024-12-13

### Fixed

- alias match request end with slash (#35)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).