### PR TITLE
Draft: fix benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +63,21 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "backtrace"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -231,26 +255,8 @@ dependencies = [
  "oorandom",
  "serde",
  "serde_json",
+ "tokio",
  "walkdir",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -350,12 +356,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "either"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +395,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "half"
@@ -648,6 +654,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,26 +760,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,15 +831,21 @@ dependencies = [
  "normalize-path",
  "once_cell",
  "pnp",
- "rayon",
  "rustc-hash",
  "serde",
  "serde_json",
  "simdutf8",
  "thiserror",
+ "tokio",
  "tracing",
  "vfs",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -1039,6 +1040,16 @@ checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tokio"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+dependencies = [
+ "backtrace",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,11 +93,11 @@ simdutf8 = { version = "0.1.4", features = ["aarch64_neon"] }
 pnp = { version = "0.9.0", optional = true }
 
 document-features = { version = "0.2.8", optional = true }
-tokio = { version = "1.42.0", features = ["rt", "rt-multi-thread"] }
 
 [dev-dependencies]
 vfs            = "0.12.0"                                        # for testing with in memory file system
 criterion2     = { version = "1.0.0", default-features = false, features = ["async_tokio"]}
+tokio = { version = "1.42.0", features = ["rt", "rt-multi-thread"] }
 normalize-path = { version = "0.2.1" }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,11 +93,11 @@ simdutf8 = { version = "0.1.4", features = ["aarch64_neon"] }
 pnp = { version = "0.9.0", optional = true }
 
 document-features = { version = "0.2.8", optional = true }
+tokio = { version = "1.42.0", features = ["rt", "rt-multi-thread"] }
 
 [dev-dependencies]
 vfs            = "0.12.0"                                        # for testing with in memory file system
-rayon          = { version = "1.10.0" }
-criterion2     = { version = "1.0.0", default-features = false }
+criterion2     = { version = "1.0.0", default-features = false, features = ["async_tokio"]}
 normalize-path = { version = "0.2.1" }
 
 [features]

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -167,7 +167,8 @@ fn bench_resolver(c: &mut Criterion) {
     let mut group = c.benchmark_group("resolver");
 
     group.bench_with_input(BenchmarkId::from_parameter("single-thread"), &data, |b, data| {
-        let runner = runtime::Builder::new_current_thread().build().expect("failed to create tokio runtime");
+        let runner =
+            runtime::Builder::new_current_thread().build().expect("failed to create tokio runtime");
         b.to_async(runner).iter(|| async {
             let oxc_resolver = oxc_resolver();
             for (path, request) in data {
@@ -194,7 +195,9 @@ fn bench_resolver(c: &mut Criterion) {
         BenchmarkId::from_parameter("resolve-from-symlinks"),
         &symlinks_range,
         |b, data| {
-            let runner = runtime::Builder::new_current_thread().build().expect("failed to create tokio runtime");
+            let runner = runtime::Builder::new_current_thread()
+                .build()
+                .expect("failed to create tokio runtime");
             b.to_async(runner).iter(|| async {
                 let oxc_resolver = oxc_resolver();
                 for i in data.clone() {
@@ -216,7 +219,11 @@ fn bench_resolver(c: &mut Criterion) {
                 let oxc_resolver = Arc::new(oxc_resolver());
 
                 let handles = data.clone().map(|i| {
-                    create_async_resolve_task(oxc_resolver.clone(), symlink_test_dir.clone(), format!("./file{i}").to_string())
+                    create_async_resolve_task(
+                        oxc_resolver.clone(),
+                        symlink_test_dir.clone(),
+                        format!("./file{i}").to_string(),
+                    )
                 });
                 for handle in handles {
                     let _ = handle.await;

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -156,8 +156,8 @@ fn bench_resolver(c: &mut Criterion) {
     let mut group = c.benchmark_group("resolver");
 
     group.bench_with_input(BenchmarkId::from_parameter("single-thread"), &data, |b, data| {
-        let oxc_resolver = oxc_resolver();
         b.iter(|| {
+            let oxc_resolver = oxc_resolver();
             for (path, request) in data {
                 _ = oxc_resolver.resolve(path, request);
             }
@@ -165,8 +165,8 @@ fn bench_resolver(c: &mut Criterion) {
     });
 
     group.bench_with_input(BenchmarkId::from_parameter("multi-thread"), &data, |b, data| {
-        let oxc_resolver = oxc_resolver();
         b.iter(|| {
+            let oxc_resolver = oxc_resolver();
             data.par_iter().for_each(|(path, request)| {
                 _ = oxc_resolver.resolve(path, request);
             });
@@ -177,8 +177,8 @@ fn bench_resolver(c: &mut Criterion) {
         BenchmarkId::from_parameter("resolve from symlinks"),
         &symlinks_range,
         |b, data| {
-            let oxc_resolver = oxc_resolver();
             b.iter(|| {
+                let oxc_resolver = oxc_resolver();
                 for i in data.clone() {
                     assert!(
                         oxc_resolver.resolve(&symlink_test_dir, &format!("./file{i}")).is_ok(),


### PR DESCRIPTION
Currently, all runs in each benchmark test use the same resolver instance, which has a built-in cache. As a result, except for the first run, all subsequent runs hit the cache and execute significantly faster. This causes the benchmark results to fail to accurately reflect its performance.

https://github.com/web-infra-dev/rspack-resolver/blob/e3d5975252a6b4b83a17ddb967115a21aa439502/benches/resolver.rs#L158-L165

Here are the benchmark results from the main branch:

<img width="1312" alt="main" src="https://github.com/user-attachments/assets/76519470-961d-4a98-8e2a-7cf6b611d8ad" />


If we create a new resolver instance in each run, the benchmark results will look like this:

<img width="1312" alt="bench-without-cache" src="https://github.com/user-attachments/assets/1eb3dd63-b9db-4b6d-b1c4-36db5a4d6ede" />

(branch: [nilptr/fix/bench-without-cache](https://github.com/nilptr/rspack-resolver/tree/nilptr/fix/bench-without-cache))

Since we want to compare the performance with async fs version, I feel it's better to fix the benchmarks first.

Also, as we need to use Tokio as the async runtime, it would be better to start switching to Tokio as the multi-thread runner. This will make it easier for us to make comparisons.

Finally, I added a multi-threaded version of the "resolve from symlinks" benchmark case, which better demonstrates the potential of async fs.

Here are the benchmark results from the source branch:

<img width="1312" alt="bench-without-cache-tokio" src="https://github.com/user-attachments/assets/74d19560-fe34-4f72-948f-07a46e1b73fb" />

The multi-thread benchmark case takes twice as long, while the others remain mostly unchanged. Probably because Tokio's scheduling strategy is not as efficient as Rayon’s.



