### PR TITLE
Implements a virtual filesystem layer

### DIFF
--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -137,17 +137,17 @@ impl<T> VirtualFileSystem<T> {
 impl<T: FileSystem> FileSystem for VirtualFileSystem<T> {
     fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
         cfg_if! {
-            if #[cfg(feature = "yarn_pnp")] {
-              if self.options.enable_pnp {
-                  return match VPath::from(path)? {
-                      VPath::Zip(info) => self.pnp_lru.read(info.physical_base_path(), info.zip_path),
-                      VPath::Virtual(info) => std::fs::read(info.physical_base_path()),
-                      VPath::Native(path) => std::fs::read(&path),
-                  }
-              }
-          }}
-  
-        self.internal_fs.read(path)          
+          if #[cfg(feature = "yarn_pnp")] {
+            if self.options.enable_pnp {
+                return match VPath::from(path)? {
+                    VPath::Zip(info) => self.pnp_lru.read(info.physical_base_path(), info.zip_path),
+                    VPath::Virtual(info) => std::fs::read(info.physical_base_path()),
+                    VPath::Native(path) => std::fs::read(&path),
+                }
+            }
+        }}
+
+        self.internal_fs.read(path)
     }
 
     fn read_to_string(&self, path: &Path) -> io::Result<String> {
@@ -204,13 +204,8 @@ impl<T: FileSystem> FileSystem for VirtualFileSystem<T> {
 }
 
 /// Operating System
+#[derive(Default)]
 pub struct FileSystemOs;
-
-impl Default for FileSystemOs {
-    fn default() -> Self {
-        Self {}
-    }
-}
 
 fn buffer_to_string(bytes: Vec<u8>) -> io::Result<String> {
     // `simdutf8` is faster than `std::str::from_utf8` which `fs::read_to_string` uses internally

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -7,6 +7,8 @@ use std::{
 #[cfg(feature = "yarn_pnp")]
 use pnp::fs::{LruZipCache, VPath, VPathInfo, ZipCache};
 
+use crate::ResolveOptions;
+
 /// File System abstraction used for `ResolverGeneric`
 pub trait FileSystem {
     /// See [std::fs::read]
@@ -95,6 +97,15 @@ pub struct FileSystemOptions {
     pub enable_pnp: bool,
 }
 
+impl From<&ResolveOptions> for FileSystemOptions {
+    fn from(options: &ResolveOptions) -> Self {
+        Self {
+            #[cfg(feature = "yarn_pnp")]
+            enable_pnp: options.enable_pnp,
+        }
+    }
+}
+
 impl Default for FileSystemOptions {
     fn default() -> Self {
         Self {
@@ -104,20 +115,100 @@ impl Default for FileSystemOptions {
     }
 }
 
-/// Operating System
-pub struct FileSystemOs {
+pub struct VirtualFileSystem<T> {
     options: FileSystemOptions,
+    internal_fs: T,
+
     #[cfg(feature = "yarn_pnp")]
     pnp_lru: LruZipCache<Vec<u8>>,
 }
 
-impl Default for FileSystemOs {
-    fn default() -> Self {
+impl<T> VirtualFileSystem<T> {
+    pub fn new_with_options(internal_fs: T, options: FileSystemOptions) -> Self {
         Self {
-            options: FileSystemOptions::default(),
+            options,
+            internal_fs,
             #[cfg(feature = "yarn_pnp")]
             pnp_lru: LruZipCache::new(50, pnp::fs::open_zip_via_read_p),
         }
+    }
+}
+
+impl<T: FileSystem> FileSystem for VirtualFileSystem<T> {
+    fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
+        cfg_if! {
+            if #[cfg(feature = "yarn_pnp")] {
+              if self.options.enable_pnp {
+                  return match VPath::from(path)? {
+                      VPath::Zip(info) => self.pnp_lru.read(info.physical_base_path(), info.zip_path),
+                      VPath::Virtual(info) => std::fs::read(info.physical_base_path()),
+                      VPath::Native(path) => std::fs::read(&path),
+                  }
+              }
+          }}
+  
+        self.internal_fs.read(path)          
+    }
+
+    fn read_to_string(&self, path: &Path) -> io::Result<String> {
+        cfg_if! {
+            if #[cfg(feature = "yarn_pnp")] {
+                if self.options.enable_pnp {
+                    return match VPath::from(path)? {
+                        VPath::Zip(info) => self.pnp_lru.read_to_string(info.physical_base_path(), info.zip_path),
+                        VPath::Virtual(info) => self.internal_fs.read_to_string(&info.physical_base_path()),
+                        VPath::Native(path) => self.internal_fs.read_to_string(&path),
+                    }
+                }
+            }
+        }
+
+        self.internal_fs.read_to_string(path)
+    }
+
+    fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+        cfg_if! {
+            if #[cfg(feature = "yarn_pnp")] {
+                if self.options.enable_pnp {
+                    return match VPath::from(path)? {
+                        VPath::Zip(info) => self.pnp_lru.file_type(info.physical_base_path(), info.zip_path).map(FileMetadata::from),
+                        VPath::Virtual(info) => self.internal_fs.metadata(&info.physical_base_path()),
+                        VPath::Native(path) => self.internal_fs.metadata(&path),
+                    }
+                }
+            }
+        }
+
+        self.internal_fs.metadata(path)
+    }
+
+    fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+        self.internal_fs.symlink_metadata(path)
+    }
+
+    fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        cfg_if! {
+            if #[cfg(feature = "yarn_pnp")] {
+                if self.options.enable_pnp {
+                    return match VPath::from(path)? {
+                        VPath::Zip(info) => self.internal_fs.canonicalize(&info.physical_base_path().join(info.zip_path)),
+                        VPath::Virtual(info) => self.internal_fs.canonicalize(&info.physical_base_path()),
+                        VPath::Native(path) => self.internal_fs.canonicalize(&path),
+                    }
+                }
+            }
+        }
+
+        self.internal_fs.canonicalize(path)
+    }
+}
+
+/// Operating System
+pub struct FileSystemOs;
+
+impl Default for FileSystemOs {
+    fn default() -> Self {
+        Self {}
     }
 }
 
@@ -136,42 +227,15 @@ fn buffer_to_string(bytes: Vec<u8>) -> io::Result<String> {
 
 impl FileSystem for FileSystemOs {
     fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
-        cfg_if! {
-          if #[cfg(feature = "yarn_pnp")] {
-            if self.options.enable_pnp {
-                return match VPath::from(path)? {
-                    VPath::Zip(info) => self.pnp_lru.read(info.physical_base_path(), info.zip_path),
-                    VPath::Virtual(info) => std::fs::read(info.physical_base_path()),
-                    VPath::Native(path) => std::fs::read(&path),
-                }
-            }
-        }}
-
         std::fs::read(path)
     }
+
     fn read_to_string(&self, path: &Path) -> io::Result<String> {
         let buffer = self.read(path)?;
         buffer_to_string(buffer)
     }
 
     fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
-        cfg_if! {
-            if #[cfg(feature = "yarn_pnp")] {
-                if self.options.enable_pnp {
-                    return match VPath::from(path)? {
-                        VPath::Zip(info) => self
-                            .pnp_lru
-                            .file_type(info.physical_base_path(), info.zip_path)
-                            .map(FileMetadata::from),
-                        VPath::Virtual(info) => {
-                            fs::metadata(info.physical_base_path()).map(FileMetadata::from)
-                        }
-                        VPath::Native(path) => fs::metadata(path).map(FileMetadata::from),
-                    }
-                }
-            }
-        }
-
         fs::metadata(path).map(FileMetadata::from)
     }
 
@@ -180,20 +244,6 @@ impl FileSystem for FileSystemOs {
     }
 
     fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
-        cfg_if! {
-            if #[cfg(feature = "yarn_pnp")] {
-                if self.options.enable_pnp {
-                    return match VPath::from(path)? {
-                        VPath::Zip(info) => {
-                            dunce::canonicalize(info.physical_base_path().join(info.zip_path))
-                        }
-                        VPath::Virtual(info) => dunce::canonicalize(info.physical_base_path()),
-                        VPath::Native(path) => dunce::canonicalize(path),
-                    }
-                }
-            }
-        }
-
         cfg_if! {
             if #[cfg(not(target_os = "wasi"))]{
                 dunce::canonicalize(path)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ use std::{
 };
 
 use dashmap::{mapref::one::Ref, DashMap};
+use file_system::{FileSystemOptions, VirtualFileSystem};
 use rustc_hash::FxHashSet;
 use serde_json::Value as JSONValue;
 
@@ -114,7 +115,7 @@ pub type Resolver = ResolverGeneric<FileSystemOs>;
 /// Generic implementation of the resolver, can be configured by the [FileSystem] trait
 pub struct ResolverGeneric<Fs> {
     options: ResolveOptions,
-    cache: Arc<Cache<Fs>>,
+    cache: Arc<Cache<VirtualFileSystem<Fs>>>,
     #[cfg(feature = "yarn_pnp")]
     pnp_cache: Arc<DashMap<CachedPath, Option<pnp::Manifest>>>,
 }
@@ -133,9 +134,11 @@ impl<Fs: FileSystem + Default> Default for ResolverGeneric<Fs> {
 
 impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
     pub fn new(options: ResolveOptions) -> Self {
+        let fs_options = FileSystemOptions::from(&options);
+
         Self {
             options: options.sanitize(),
-            cache: Arc::new(Cache::new(Fs::default())),
+            cache: Arc::new(Cache::new(VirtualFileSystem::new_with_options(Fs::default(), fs_options))),
             #[cfg(feature = "yarn_pnp")]
             pnp_cache: Arc::new(DashMap::default()),
         }
@@ -144,9 +147,11 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
 
 impl<Fs: FileSystem> ResolverGeneric<Fs> {
     pub fn new_with_file_system(file_system: Fs, options: ResolveOptions) -> Self {
+        let fs_options = FileSystemOptions::from(&options);
+
         Self {
             options: options.sanitize(),
-            cache: Arc::new(Cache::new(file_system)),
+            cache: Arc::new(Cache::new(VirtualFileSystem::new_with_options(file_system, fs_options))),
             #[cfg(feature = "yarn_pnp")]
             pnp_cache: Arc::new(DashMap::default()),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,10 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
 
         Self {
             options: options.sanitize(),
-            cache: Arc::new(Cache::new(VirtualFileSystem::new_with_options(Fs::default(), fs_options))),
+            cache: Arc::new(Cache::new(VirtualFileSystem::new_with_options(
+                Fs::default(),
+                fs_options,
+            ))),
             #[cfg(feature = "yarn_pnp")]
             pnp_cache: Arc::new(DashMap::default()),
         }
@@ -151,7 +154,10 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
 
         Self {
             options: options.sanitize(),
-            cache: Arc::new(Cache::new(VirtualFileSystem::new_with_options(file_system, fs_options))),
+            cache: Arc::new(Cache::new(VirtualFileSystem::new_with_options(
+                file_system,
+                fs_options,
+            ))),
             #[cfg(feature = "yarn_pnp")]
             pnp_cache: Arc::new(DashMap::default()),
         }

--- a/src/tests/incorrect_description_file.rs
+++ b/src/tests/incorrect_description_file.rs
@@ -36,7 +36,7 @@ fn incorrect_description_file_2() {
         message: String::from("EOF while parsing a value at line 1 column 0"),
         line: 1,
         column: 0,
-        content: Some("".to_string()),
+        content: Some(String::new()),
     });
     assert!(matches!(resolution, Err(ResolveError::JSON(_))));
 }


### PR DESCRIPTION
@hardfist 

> oh i find a integration problem here, right now yarn pnp depends on the FileSystem provide pnp support, but rspack provide fs bindings which means when users pass custom filesystem to rspack, it may not support FileSystem so the resolver will break, can we move the logic from FileSystem to resolve(which seems what webpack's doing)

This PR migrates the PnP-specific code under a new passthrough `FileSystem` implementation. This new struct, called `VirtualFileSystem`, takes a nested filesystem as parameter (by default a regular `FileSystemOs` struct) and forwards the filesystem operations to it when they are detected as targeting regular files/folders. This design makes it possible to pass any kind of filesystem to `ResolverGeneric::new_with_file_system` and still have free zip support.