### PR TITLE
feat: Revert  vfs logic

### DIFF
--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -7,8 +7,6 @@ use std::{
 #[cfg(feature = "yarn_pnp")]
 use pnp::fs::{LruZipCache, VPath, VPathInfo, ZipCache};
 
-use crate::ResolveOptions;
-
 /// File System abstraction used for `ResolverGeneric`
 pub trait FileSystem {
     /// See [std::fs::read]
@@ -97,15 +95,6 @@ pub struct FileSystemOptions {
     pub enable_pnp: bool,
 }
 
-impl From<&ResolveOptions> for FileSystemOptions {
-    fn from(options: &ResolveOptions) -> Self {
-        Self {
-            #[cfg(feature = "yarn_pnp")]
-            enable_pnp: options.enable_pnp,
-        }
-    }
-}
-
 impl Default for FileSystemOptions {
     fn default() -> Self {
         Self {
@@ -115,97 +104,22 @@ impl Default for FileSystemOptions {
     }
 }
 
-pub struct VirtualFileSystem<T> {
+/// Operating System
+pub struct FileSystemOs {
     options: FileSystemOptions,
-    internal_fs: T,
-
     #[cfg(feature = "yarn_pnp")]
     pnp_lru: LruZipCache<Vec<u8>>,
 }
 
-impl<T> VirtualFileSystem<T> {
-    pub fn new_with_options(internal_fs: T, options: FileSystemOptions) -> Self {
+impl Default for FileSystemOs {
+    fn default() -> Self {
         Self {
-            options,
-            internal_fs,
+            options: FileSystemOptions::default(),
             #[cfg(feature = "yarn_pnp")]
             pnp_lru: LruZipCache::new(50, pnp::fs::open_zip_via_read_p),
         }
     }
 }
-
-impl<T: FileSystem> FileSystem for VirtualFileSystem<T> {
-    fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
-        cfg_if! {
-          if #[cfg(feature = "yarn_pnp")] {
-            if self.options.enable_pnp {
-                return match VPath::from(path)? {
-                    VPath::Zip(info) => self.pnp_lru.read(info.physical_base_path(), info.zip_path),
-                    VPath::Virtual(info) => std::fs::read(info.physical_base_path()),
-                    VPath::Native(path) => std::fs::read(&path),
-                }
-            }
-        }}
-
-        self.internal_fs.read(path)
-    }
-
-    fn read_to_string(&self, path: &Path) -> io::Result<String> {
-        cfg_if! {
-            if #[cfg(feature = "yarn_pnp")] {
-                if self.options.enable_pnp {
-                    return match VPath::from(path)? {
-                        VPath::Zip(info) => self.pnp_lru.read_to_string(info.physical_base_path(), info.zip_path),
-                        VPath::Virtual(info) => self.internal_fs.read_to_string(&info.physical_base_path()),
-                        VPath::Native(path) => self.internal_fs.read_to_string(&path),
-                    }
-                }
-            }
-        }
-
-        self.internal_fs.read_to_string(path)
-    }
-
-    fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
-        cfg_if! {
-            if #[cfg(feature = "yarn_pnp")] {
-                if self.options.enable_pnp {
-                    return match VPath::from(path)? {
-                        VPath::Zip(info) => self.pnp_lru.file_type(info.physical_base_path(), info.zip_path).map(FileMetadata::from),
-                        VPath::Virtual(info) => self.internal_fs.metadata(&info.physical_base_path()),
-                        VPath::Native(path) => self.internal_fs.metadata(&path),
-                    }
-                }
-            }
-        }
-
-        self.internal_fs.metadata(path)
-    }
-
-    fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
-        self.internal_fs.symlink_metadata(path)
-    }
-
-    fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
-        cfg_if! {
-            if #[cfg(feature = "yarn_pnp")] {
-                if self.options.enable_pnp {
-                    return match VPath::from(path)? {
-                        VPath::Zip(info) => self.internal_fs.canonicalize(&info.physical_base_path().join(info.zip_path)),
-                        VPath::Virtual(info) => self.internal_fs.canonicalize(&info.physical_base_path()),
-                        VPath::Native(path) => self.internal_fs.canonicalize(&path),
-                    }
-                }
-            }
-        }
-
-        self.internal_fs.canonicalize(path)
-    }
-}
-
-/// Operating System
-#[derive(Default)]
-pub struct FileSystemOs;
 
 fn buffer_to_string(bytes: Vec<u8>) -> io::Result<String> {
     // `simdutf8` is faster than `std::str::from_utf8` which `fs::read_to_string` uses internally
@@ -222,15 +136,42 @@ fn buffer_to_string(bytes: Vec<u8>) -> io::Result<String> {
 
 impl FileSystem for FileSystemOs {
     fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
+        cfg_if! {
+          if #[cfg(feature = "yarn_pnp")] {
+            if self.options.enable_pnp {
+                return match VPath::from(path)? {
+                    VPath::Zip(info) => self.pnp_lru.read(info.physical_base_path(), info.zip_path),
+                    VPath::Virtual(info) => std::fs::read(info.physical_base_path()),
+                    VPath::Native(path) => std::fs::read(&path),
+                }
+            }
+        }}
+
         std::fs::read(path)
     }
-
     fn read_to_string(&self, path: &Path) -> io::Result<String> {
         let buffer = self.read(path)?;
         buffer_to_string(buffer)
     }
 
     fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+        cfg_if! {
+            if #[cfg(feature = "yarn_pnp")] {
+                if self.options.enable_pnp {
+                    return match VPath::from(path)? {
+                        VPath::Zip(info) => self
+                            .pnp_lru
+                            .file_type(info.physical_base_path(), info.zip_path)
+                            .map(FileMetadata::from),
+                        VPath::Virtual(info) => {
+                            fs::metadata(info.physical_base_path()).map(FileMetadata::from)
+                        }
+                        VPath::Native(path) => fs::metadata(path).map(FileMetadata::from),
+                    }
+                }
+            }
+        }
+
         fs::metadata(path).map(FileMetadata::from)
     }
 
@@ -239,6 +180,20 @@ impl FileSystem for FileSystemOs {
     }
 
     fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        cfg_if! {
+            if #[cfg(feature = "yarn_pnp")] {
+                if self.options.enable_pnp {
+                    return match VPath::from(path)? {
+                        VPath::Zip(info) => {
+                            dunce::canonicalize(info.physical_base_path().join(info.zip_path))
+                        }
+                        VPath::Virtual(info) => dunce::canonicalize(info.physical_base_path()),
+                        VPath::Native(path) => dunce::canonicalize(path),
+                    }
+                }
+            }
+        }
+
         cfg_if! {
             if #[cfg(not(target_os = "wasi"))]{
                 dunce::canonicalize(path)

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -115,7 +115,7 @@ impl Default for FileSystemOptions {
     }
 }
 
-pub struct PnpFileSystem<T> {
+pub struct VirtualFileSystem<T> {
     options: FileSystemOptions,
     internal_fs: T,
 
@@ -123,7 +123,7 @@ pub struct PnpFileSystem<T> {
     pnp_lru: LruZipCache<Vec<u8>>,
 }
 
-impl<T> PnpFileSystem<T> {
+impl<T> VirtualFileSystem<T> {
     pub fn new_with_options(internal_fs: T, options: FileSystemOptions) -> Self {
         Self {
             options,
@@ -134,7 +134,7 @@ impl<T> PnpFileSystem<T> {
     }
 }
 
-impl<T: FileSystem> FileSystem for PnpFileSystem<T> {
+impl<T: FileSystem> FileSystem for VirtualFileSystem<T> {
     fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
         cfg_if! {
           if #[cfg(feature = "yarn_pnp")] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,6 @@ use std::{
 };
 
 use dashmap::{mapref::one::Ref, DashMap};
-use file_system::{FileSystemOptions, VirtualFileSystem};
 use rustc_hash::FxHashSet;
 use serde_json::Value as JSONValue;
 
@@ -115,7 +114,7 @@ pub type Resolver = ResolverGeneric<FileSystemOs>;
 /// Generic implementation of the resolver, can be configured by the [FileSystem] trait
 pub struct ResolverGeneric<Fs> {
     options: ResolveOptions,
-    cache: Arc<Cache<VirtualFileSystem<Fs>>>,
+    cache: Arc<Cache<Fs>>,
     #[cfg(feature = "yarn_pnp")]
     pnp_cache: Arc<DashMap<CachedPath, Option<pnp::Manifest>>>,
 }
@@ -134,14 +133,9 @@ impl<Fs: FileSystem + Default> Default for ResolverGeneric<Fs> {
 
 impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
     pub fn new(options: ResolveOptions) -> Self {
-        let fs_options = FileSystemOptions::from(&options);
-
         Self {
             options: options.sanitize(),
-            cache: Arc::new(Cache::new(VirtualFileSystem::new_with_options(
-                Fs::default(),
-                fs_options,
-            ))),
+            cache: Arc::new(Cache::new(Fs::default())),
             #[cfg(feature = "yarn_pnp")]
             pnp_cache: Arc::new(DashMap::default()),
         }
@@ -150,14 +144,9 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
 
 impl<Fs: FileSystem> ResolverGeneric<Fs> {
     pub fn new_with_file_system(file_system: Fs, options: ResolveOptions) -> Self {
-        let fs_options = FileSystemOptions::from(&options);
-
         Self {
             options: options.sanitize(),
-            cache: Arc::new(Cache::new(VirtualFileSystem::new_with_options(
-                file_system,
-                fs_options,
-            ))),
+            cache: Arc::new(Cache::new(file_system)),
             #[cfg(feature = "yarn_pnp")]
             pnp_cache: Arc::new(DashMap::default()),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,14 +72,14 @@ use std::{
 };
 
 use dashmap::{mapref::one::Ref, DashMap};
-use file_system::FileSystemOptions;
+use file_system::{FileSystemOptions, VirtualFileSystem};
 use rustc_hash::FxHashSet;
 use serde_json::Value as JSONValue;
 
 pub use crate::{
     builtins::NODEJS_BUILTINS,
     error::{JSONError, ResolveError, SpecifierError},
-    file_system::{FileMetadata, FileSystem, FileSystemOs, PnpFileSystem},
+    file_system::{FileMetadata, FileSystem, FileSystemOs},
     options::{
         Alias, AliasValue, EnforceExtension, ResolveOptions, Restriction, TsconfigOptions,
         TsconfigReferences,
@@ -115,7 +115,7 @@ pub type Resolver = ResolverGeneric<FileSystemOs>;
 /// Generic implementation of the resolver, can be configured by the [FileSystem] trait
 pub struct ResolverGeneric<Fs> {
     options: ResolveOptions,
-    cache: Arc<Cache<PnpFileSystem<Fs>>>,
+    cache: Arc<Cache<VirtualFileSystem<Fs>>>,
     #[cfg(feature = "yarn_pnp")]
     pnp_cache: Arc<DashMap<CachedPath, Option<pnp::Manifest>>>,
 }
@@ -138,7 +138,10 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
 
         Self {
             options: options.sanitize(),
-            cache: Arc::new(Cache::new(PnpFileSystem::new_with_options(Fs::default(), fs_options))),
+            cache: Arc::new(Cache::new(VirtualFileSystem::new_with_options(
+                Fs::default(),
+                fs_options,
+            ))),
             #[cfg(feature = "yarn_pnp")]
             pnp_cache: Arc::new(DashMap::default()),
         }
@@ -151,7 +154,10 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
 
         Self {
             options: options.sanitize(),
-            cache: Arc::new(Cache::new(PnpFileSystem::new_with_options(file_system, fs_options))),
+            cache: Arc::new(Cache::new(VirtualFileSystem::new_with_options(
+                file_system,
+                fs_options,
+            ))),
             #[cfg(feature = "yarn_pnp")]
             pnp_cache: Arc::new(DashMap::default()),
         }

--- a/src/tests/incorrect_description_file.rs
+++ b/src/tests/incorrect_description_file.rs
@@ -36,7 +36,7 @@ fn incorrect_description_file_2() {
         message: String::from("EOF while parsing a value at line 1 column 0"),
         line: 1,
         column: 0,
-        content: Some(String::new()),
+        content: Some("".to_string()),
     });
     assert!(matches!(resolution, Err(ResolveError::JSON(_))));
 }


### PR DESCRIPTION
This reverts commit 018a357 and c970407b.
since we still to support pnp logic in fs, vfs is no needed