### PR TITLE
fix: abs path in main fields

### DIFF
--- a/fixtures/invalid/node_modules/a/dist/index.js
+++ b/fixtures/invalid/node_modules/a/dist/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+	hello: 42
+}

--- a/fixtures/invalid/node_modules/a/package.json
+++ b/fixtures/invalid/node_modules/a/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "a",
+	"main": "/dist/index.js",
+	"version": "1.0.0"
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,9 @@ mod tsconfig;
 #[cfg(test)]
 mod tests;
 
+use dashmap::{mapref::one::Ref, DashMap};
+use rustc_hash::FxHashSet;
+use serde_json::Value as JSONValue;
 use std::{
     borrow::Cow,
     cmp::Ordering,
@@ -70,10 +73,6 @@ use std::{
     path::{Component, Path, PathBuf},
     sync::Arc,
 };
-use std::fmt::format;
-use dashmap::{mapref::one::Ref, DashMap};
-use rustc_hash::FxHashSet;
-use serde_json::Value as JSONValue;
 
 pub use crate::{
     builtins::NODEJS_BUILTINS,
@@ -544,13 +543,13 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
             {
                 // b. If "main" is a falsy value, GOTO 2.
                 for main_field in package_json.main_fields(&self.options.main_fields) {
-
                     // ref https://github.com/webpack/enhanced-resolve/blob/main/lib/MainFieldPlugin.js#L66-L67
-                    let main_field = if main_field.starts_with("./") || main_field.starts_with("../"){
-                        Cow::Borrowed(main_field)
-                    }else{
-                        Cow::Owned(format!("./{main_field}"))
-                    };
+                    let main_field =
+                        if main_field.starts_with("./") || main_field.starts_with("../") {
+                            Cow::Borrowed(main_field)
+                        } else {
+                            Cow::Owned(format!("./{main_field}"))
+                        };
 
                     // c. let M = X + (json main field)
                     let main_field_path = cached_path.path().normalize_with(main_field.as_ref());

--- a/src/tests/simple.rs
+++ b/src/tests/simple.rs
@@ -10,9 +10,9 @@ fn resolve_abs_main() {
     let dirname = env::current_dir().unwrap().join("fixtures");
     let f = dirname.join("invalid/main.js");
     // a's main field id `/dist/index.js`
-    let resolved_path = resolver.resolve(&f, "a").unwrap().path();
+    let resolution = resolver.resolve(&f, "a").unwrap();
 
-    assert_eq!(resolved_path, dirname.join("invalid/node_modules/a/dist/index.js"));
+    assert_eq!(resolution.path(), dirname.join("invalid/node_modules/a/dist/index.js"));
 }
 
 #[test]

--- a/src/tests/simple.rs
+++ b/src/tests/simple.rs
@@ -5,6 +5,17 @@ use std::env;
 use crate::Resolver;
 
 #[test]
+fn resolve_abs_main() {
+    let resolver = Resolver::default();
+    let dirname = env::current_dir().unwrap().join("fixtures");
+    let f = dirname.join("invalid/main.js");
+    // a's main field id `/dist/index.js`
+    let resolved_path = resolver.resolve(&f, "a").unwrap().path();
+
+    assert_eq!(resolved_path, dirname.join("invalid/node_modules/a/dist/index.js"));
+}
+
+#[test]
 fn simple() {
     // mimic `enhanced-resolve/test/simple.test.js`
     let dirname = env::current_dir().unwrap().join("fixtures");


### PR DESCRIPTION
close: https://github.com/web-infra-dev/rspack/issues/9531 

some legacy npm packages [eg](https://unpkg.com/browse/vue-code-diff@1.2.0/package.json), set main fields as absolute path. it fails rspack-resovler.

according to [enhanced-resolver](https://github.com/webpack/enhanced-resolve/blob/main/lib/MainFieldPlugin.js#L66-L67) preappend `./` to absolute path.
