### PR TITLE
feat: support pass closure to restriction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -901,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -912,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rspack_napi_resolver"
@@ -942,6 +942,7 @@ dependencies = [
  "once_cell",
  "pnp",
  "rayon",
+ "regex",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ document-features = { version = "0.2.8", optional = true }
 
 [dev-dependencies]
 vfs            = "0.12.0"                                        # for testing with in memory file system
+regex          = "1.11.1"
 rayon          = { version = "1.10.0" }
 criterion2     = { version = "2.0.0", default-features = false, package = "codspeed-criterion-compat" }
 normalize-path = { version = "0.2.1" }

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,10 +65,6 @@ pub enum ResolveError {
     #[error("{0:?}")]
     JSON(JSONError),
 
-    /// Restricted by `ResolveOptions::restrictions`
-    #[error(r#"Path "{0}" restricted by {0}"#)]
-    Restriction(PathBuf, PathBuf),
-
     #[error(r#"Invalid module "{0}" specifier is not a valid subpath for the "exports" resolution of {1}"#)]
     InvalidModuleSpecifier(String, PathBuf),
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::Arc;
 use std::{fmt, path::PathBuf};
 
 /// Module Resolution Options
@@ -418,10 +419,19 @@ where
 }
 
 /// Value for [ResolveOptions::restrictions]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum Restriction {
     Path(PathBuf),
-    RegExp(String),
+    Fn(Arc<dyn Fn(&Path) -> bool + Sync + Send>),
+}
+
+impl std::fmt::Debug for Restriction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Path(path) => write!(f, "Path({path:?})"),
+            Self::Fn(_) => write!(f, "Fn(<function>)"),
+        }
+    }
 }
 
 /// Tsconfig Options for [ResolveOptions::tsconfig]

--- a/src/tests/restrictions.rs
+++ b/src/tests/restrictions.rs
@@ -1,16 +1,48 @@
 //! <https://github.com/webpack/enhanced-resolve/blob/main/test/restrictions.test.js>
 
+use std::sync::Arc;
+
+use regex::Regex;
+
 use crate::{ResolveError, ResolveOptions, Resolver, Restriction};
 
-// TODO: regex
-// * should respect RegExp restriction
-// * should try to find alternative #1
-// * should try to find alternative #2
-// * should try to find alternative #3
-
-// should respect string restriction
 #[test]
-fn restriction1() {
+fn should_respect_regexp_restriction() {
+    let f = super::fixture().join("restrictions");
+
+    let re = Regex::new(r"\.(sass|scss|css)$").unwrap();
+    let resolver1 = Resolver::new(ResolveOptions {
+        extensions: vec![".js".into()],
+        restrictions: vec![Restriction::Fn(Arc::new(move |path| {
+            path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
+        }))],
+        ..ResolveOptions::default()
+    });
+
+    let resolution = resolver1.resolve(&f, "pck1").map(|r| r.full_path());
+    assert_eq!(resolution, Err(ResolveError::NotFound("pck1".to_string())));
+}
+
+#[test]
+fn should_try_to_find_alternative_1() {
+    let f = super::fixture().join("restrictions");
+
+    let re = Regex::new(r"\.(sass|scss|css)$").unwrap();
+    let resolver1 = Resolver::new(ResolveOptions {
+        extensions: vec![".js".into(), ".css".into()],
+        main_files: vec!["index".into()],
+        restrictions: vec![Restriction::Fn(Arc::new(move |path| {
+            path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
+        }))],
+        ..ResolveOptions::default()
+    });
+
+    let resolution = resolver1.resolve(&f, "pck1").map(|r| r.full_path());
+    assert_eq!(resolution, Ok(f.join("node_modules/pck1/index.css")));
+}
+
+#[test]
+fn should_respect_string_restriction() {
     let fixture = super::fixture();
     let f = fixture.join("restrictions");
 
@@ -21,5 +53,41 @@ fn restriction1() {
     });
 
     let resolution = resolver.resolve(&f, "pck2");
-    assert_eq!(resolution, Err(ResolveError::Restriction(fixture.join("c.js"), f)));
+    assert_eq!(resolution, Err(ResolveError::NotFound("pck2".to_string())));
+}
+
+#[test]
+fn should_try_to_find_alternative_2() {
+    let f = super::fixture().join("restrictions");
+
+    let re = Regex::new(r"\.(sass|scss|css)$").unwrap();
+    let resolver1 = Resolver::new(ResolveOptions {
+        extensions: vec![".js".into(), ".css".into()],
+        main_fields: vec!["main".into(), "style".into()],
+        restrictions: vec![Restriction::Fn(Arc::new(move |path| {
+            path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
+        }))],
+        ..ResolveOptions::default()
+    });
+
+    let resolution = resolver1.resolve(&f, "pck2").map(|r| r.full_path());
+    assert_eq!(resolution, Ok(f.join("node_modules/pck2/index.css")));
+}
+
+#[test]
+fn should_try_to_find_alternative_3() {
+    let f = super::fixture().join("restrictions");
+
+    let re = Regex::new(r"\.(sass|scss|css)$").unwrap();
+    let resolver1 = Resolver::new(ResolveOptions {
+        extensions: vec![".js".into()],
+        main_fields: vec!["main".into(), "module".into(), "style".into()],
+        restrictions: vec![Restriction::Fn(Arc::new(move |path| {
+            path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
+        }))],
+        ..ResolveOptions::default()
+    });
+
+    let resolution = resolver1.resolve(&f, "pck2").map(|r| r.full_path());
+    assert_eq!(resolution, Ok(f.join("node_modules/pck2/index.css")));
 }


### PR DESCRIPTION
Fix [#9838](https://github.com/web-infra-dev/rspack/issues/9838)

The restriction configuration option supports passing closure, allowing users to check paths through regular expressions.

The advantage of using closures is that they can be decoupled from regular implementations.