### PR TITLE
chore: exclude benches pnpm lock file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/web-infra-dev/rspack-resolver"
 rust-version = "1.70"
-include      = ["/src", "/examples", "/benches"]
+include      = ["/src", "/examples", "/benches", "!/benches/pnpm-lock.yaml"]
 
 [lib]
 doctest = false


### PR DESCRIPTION
reduce crate's size

```text
// before
Packaged 45 files,   1.2MiB (319.9KiB compressed)
// after
Packaged 44 files, 491.3KiB (85.4KiB compressed)
```

because the benches's pnpm lock file is huge (766K).