### PR TITLE
fix!: paths match align with tsconfig-paths-webpack-plugin

### DIFF
--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -56,8 +56,8 @@ async fn disabled() {
         (f.join("app"), "@/index.ts", Ok(f.join("app/aliased/index.ts"))),
         (f.join("app"), "@/../index.ts", Ok(f.join("app/index.ts"))),
         // Test project reference
-        (f.join("project_a"), "@/index.ts", Err(ResolveError::NotFound("@/index.ts".into()))),
-        (f.join("project_b/src"), "@/index.ts", Err(ResolveError::NotFound("@/index.ts".into()))),
+        (f.join("project_a"), "@/index.ts", Ok(f.join("app/aliased/index.ts"))),
+        (f.join("project_b/src"), "@/index.ts", Ok(f.join("app/aliased/index.ts"))),
         // Does not have paths alias
         (f.join("project_a"), "./index.ts", Ok(f.join("project_a/index.ts"))),
         (f.join("project_c"), "./index.ts", Ok(f.join("project_c/index.ts"))),
@@ -88,7 +88,7 @@ async fn manual() {
         (f.join("app"), "@/../index.ts", Ok(f.join("app/index.ts"))),
         // Test project reference
         (f.join("project_a"), "@/index.ts", Ok(f.join("project_a/aliased/index.ts"))),
-        (f.join("project_b/src"), "@/index.ts", Err(ResolveError::NotFound("@/index.ts".into()))),
+        (f.join("project_b/src"), "@/index.ts", Ok(f.join("app/aliased/index.ts"))),
         // Does not have paths alias
         (f.join("project_a"), "./index.ts", Ok(f.join("project_a/index.ts"))),
         (f.join("project_c"), "./index.ts", Ok(f.join("project_c/index.ts"))),


### PR DESCRIPTION
> ⚠️ Note
> This PR will introduce Breaking Change‼️

When there is no `references` configed, take the [demo](https://github.com/stormslowly/tsconfig-paths-demo) repo struct as an example.
`app` uses codes from `project-a`, they both config paths as `` "foo": ["./mock_foo"] `` in tsconfig.json

```txt
├── app
│   ├── mock_foo
│   │   └── index.js
│   ├── src
│   │   └── index.ts
│   ├── tsconfig.json
│   └── webpack.config.js
└── project-a
    ├── index.js
    ├── mock_foo
    │   └── index.js
    ├── src
    │   └── index.ts
    └── tsconfig.json
````
### before
paths alias takes effect on files under project folder only.
for example 
in `app/src/index.ts`,       resolve `"foo"` will return `app/mock_foo/index.js`
in `project-a/src/index.ts`, resolve `"foo"` will return NotFound Error
see the example in `spack_resolver_demo.js` in demo repo

### after
paths alias takes effect on all files. (tsconfig-paths-webpack-plugin dose so)
take previous exmaple, resolving `"foo"` in `project-a/src/index.ts` will return `app/mock_foo/index.ts`.





close: https://github.com/web-infra-dev/rspack-resolver/pull/74
