### PR TITLE
chore: remove cargo bench in CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Setup benchmark data
         run: cd benches && pnpm install --ignore-workspace
 
-      - name: Cargo Bench
-        run:  cargo bench
-
       - uses: Boshen/setup-rust@main
         with:
           cache-key: benchmark


### PR DESCRIPTION
Since codspeed is totally supported, `cargo bench` is unnecessary now.