### PR TITLE
refactor: release by explicit commit not by workflow ref

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -3,6 +3,10 @@ name: Release Full
 on:
   workflow_dispatch:
     inputs:
+      commit:
+        required: true
+        type: string
+        description: "Full Commit SHA to release"
       tag:
         type: choice
         description: "Release Npm Tag"
@@ -67,6 +71,7 @@ jobs:
       runner: ${{ matrix.array.runner }}
       test: false
       profile: "release"
+      ref: ${{ inputs.commit }}
 
   release:
     name: Release
@@ -84,6 +89,7 @@ jobs:
         with:
           # This makes Actions fetch only one branch to release
           fetch-depth: 1
+          ref: ${{ inputs.commit }}
 
       - name: Pnpm Setup
         uses: ./.github/actions/pnpm

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.commit }}
 
       - uses: Boshen/setup-rust@main
         with:


### PR DESCRIPTION
Before we use workflow ref to appointing which commit to release, it works.
But it's not so explicit to know which commit will be published, so We use `commit` input to appoint.
