### PR TITLE
feat: add clear_cache_without_tsconfig for HMR optimization

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -42,6 +42,14 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
     self.tsconfigs.clear();
   }
 
+  /// Clear the path cache without clearing the tsconfig cache.
+  ///
+  /// This is useful for HMR (Hot Module Replacement) scenarios where tsconfig.json
+  /// doesn't change during development, but file system state may change.
+  pub fn clear_without_tsconfig(&self) {
+    self.paths.clear();
+  }
+
   pub fn value(&self, path: &Path) -> CachedPath {
     let hash = {
       let mut hasher = FxHasher::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,21 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     }
   }
 
+  /// Clear the underlying cache without clearing tsconfig cache.
+  ///
+  /// This is useful for HMR (Hot Module Replacement) scenarios where tsconfig.json
+  /// doesn't change during development, but file system state may change.
+  /// Preserving the tsconfig cache avoids re-parsing tsconfig.json on every HMR update,
+  /// which can cause intermittent module resolution failures with tsconfig path aliases.
+  pub fn clear_cache_without_tsconfig(&self) {
+    self.cache.clear_without_tsconfig();
+    #[cfg(feature = "yarn_pnp")]
+    {
+      self.pnp_manifest_content_cache.clear();
+      self.pnp_manifest_path_cache.clear();
+    }
+  }
+
   /// Resolve `specifier` at an absolute path to a `directory`.
   ///
   /// A specifier is the string passed to require or import, i.e. `require("specifier")` or `import "specifier"`.


### PR DESCRIPTION
## Summary
- Add `clear_cache_without_tsconfig()` method that clears path cache while preserving tsconfig cache
- Useful for HMR scenarios where tsconfig.json doesn't change during development

## Problem
When using tsconfig path aliases (especially wildcard patterns like `"*": ["./src/*"]`), HMR intermittently fails with "Module not found" errors. This happens because:

1. During HMR, rspack calls `clear_cache()` which clears both the path cache AND tsconfig cache
2. Re-parsing `tsconfig.json` on every HMR update is wasteful
3. Race conditions during re-parsing can cause intermittent module resolution failures

Related issue: https://github.com/web-infra-dev/rspack/issues/12753

## Solution
Add two new methods:
- `Cache::clear_without_tsconfig()` - clears only the path cache
- `ResolverGeneric::clear_cache_without_tsconfig()` - public API that clears path cache but preserves tsconfig cache

This allows rspack to preserve tsconfig state during HMR while still invalidating file system caches.

## Test plan
- [x] All existing tests pass (114 unit tests + 9 integration tests)
- [x] Build compiles successfully

## Next steps

  Once this PR is merged, a second PR is needed in `rspack` to use the new method during HMR:
  - Update `crates/rspack_core/src/compiler/rebuild.rs:58` to call `clear_cache_without_tsconfig()` instead of `clear_cache()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)