### PR TITLE
fix(pnp): align exports resolution with enhanced-resolve

### DIFF
--- a/fixtures/pnp/package.json
+++ b/fixtures/pnp/package.json
@@ -2,6 +2,7 @@
   "name": "pnp",
   "packageManager": "yarn@4.3.1",
   "dependencies": {
+    "@user/m1": "link:./shared-name-mismatch",
     "extend": "3.0.2",
     "is-even": "^1.0.0",
     "is-odd": "^3.0.1",

--- a/fixtures/pnp/shared-name-mismatch/dist/a.js
+++ b/fixtures/pnp/shared-name-mismatch/dist/a.js
@@ -1,0 +1,1 @@
+module.exports = "feature";

--- a/fixtures/pnp/shared-name-mismatch/package.json
+++ b/fixtures/pnp/shared-name-mismatch/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "shared-package",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./dist/a.js",
+    "./x": "./dist/a.js"
+  }
+}

--- a/fixtures/pnp/yarn.lock
+++ b/fixtures/pnp/yarn.lock
@@ -5,6 +5,12 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@user/m1@link:./shared-name-mismatch::locator=pnp%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@user/m1@link:./shared-name-mismatch::locator=pnp%40workspace%3A."
+  languageName: node
+  linkType: soft
+
 "extend@npm:3.0.2":
   version: 3.0.2
   resolution: "extend@npm:3.0.2"
@@ -88,6 +94,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "pnp@workspace:."
   dependencies:
+    "@user/m1": "link:./shared-name-mismatch"
     extend: "npm:3.0.2"
     is-even: "npm:^1.0.0"
     is-odd: "npm:^3.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1022,21 +1022,26 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     match resolution {
       Ok(pnp::Resolution::Resolved(path, subpath)) => {
         let cached_path = self.cache.value(&path);
+        let normalized_subpath = subpath
+          .as_deref()
+          .map(|subpath| subpath.trim_start_matches('/'))
+          .filter(|subpath| !subpath.is_empty());
 
-        let export_resolution = self.load_package_self(&cached_path, specifier, ctx).await?;
-        // can be found in pnp cached folder
+        // Mirror enhanced-resolve's PnP pipeline by resolving exports from the
+        // request-derived subpath instead of PACKAGE_SELF name matching.
+        let exports_subpath =
+          normalized_subpath.map_or_else(String::new, |subpath| format!("/{subpath}"));
+        let export_resolution = self
+          .load_package_exports(specifier, &exports_subpath, &cached_path, ctx)
+          .await?;
         if export_resolution.is_some() {
           return Ok(export_resolution);
         }
-        let is_bare = subpath.is_none();
 
-        let inner_request = subpath.map_or_else(
-          || ".".to_string(),
-          |mut p| {
-            p.insert_str(0, "./");
-            p
-          },
-        );
+        let is_bare = normalized_subpath.is_none();
+
+        let inner_request = normalized_subpath
+          .map_or_else(|| ".".to_string(), |subpath| format!("./{subpath}"));
 
         let mut inner_options = self.options().clone();
         if is_bare {

--- a/src/tests/pnp.rs
+++ b/src/tests/pnp.rs
@@ -303,3 +303,43 @@ async fn resolve_pnp_transitive_dep_from_global_cache() {
     "Expected isarray in global cache, got: {isarray}"
   );
 }
+
+#[tokio::test]
+async fn resolve_pnp_should_handle_exports_field_when_using_pnp() {
+  // Mimics enhanced-resolve: "should handle the exports field when using PnP"
+  let fixture = super::fixture_root().join("pnp");
+
+  let resolver = Resolver::new(ResolveOptions {
+    extensions: vec![".js".into()],
+    condition_names: vec!["import".into()],
+    ..ResolveOptions::default()
+  });
+
+  assert_eq!(
+    resolver
+      .resolve(&fixture, "@user/m1")
+      .await
+      .map(|r| r.full_path()),
+    Ok(fixture.join("shared-name-mismatch/dist/a.js"))
+  );
+}
+
+#[tokio::test]
+async fn resolve_pnp_should_handle_exports_field_when_using_pnp_with_sub_path() {
+  // Mimics enhanced-resolve: "should handle the exports field when using PnP (with sub path)"
+  let fixture = super::fixture_root().join("pnp");
+
+  let resolver = Resolver::new(ResolveOptions {
+    extensions: vec![".js".into()],
+    condition_names: vec!["import".into()],
+    ..ResolveOptions::default()
+  });
+
+  assert_eq!(
+    resolver
+      .resolve(&fixture, "@user/m1/x")
+      .await
+      .map(|r| r.full_path()),
+    Ok(fixture.join("shared-name-mismatch/dist/a.js"))
+  );
+}


### PR DESCRIPTION
### Background
`rspack-resolver`’s PnP path previously called `load_package_self(&cached_path, specifier, ...)` before resolving exports.  
That flow depends on `package_json.name` matching the request package prefix, which is valid for Node self-reference, but can be wrong for PnP edge cases (aliases, virtualized layouts, or name-mismatch paths).

`enhanced-resolve` does not rely on that check in its PnP path. It derives the subpath from the request and resolves exports from that subpath directly.

### Original fallback behavior (and why it was problematic)
In the old `load_pnp` flow:

1. Try `load_package_self(&cached_path, specifier, ...)`.
2. If it returns `None`, fall back to `inner_request` and call the inner resolver from the PnP-resolved package path.
3. For bare requests, fallback often became `resolve(path, ".")`, which can proceed via directory/main/index resolution.

Problem in mismatch cases:
- When PnP resolves to a package root whose `package.json.name` differs from the requested specifier, `load_package_self` fails early due to name check.
- This skips the intended exports resolution path even though the PnP resolution already identified the correct package location/subpath context.
- The fallback (`"."` / filesystem-style main/index pathing) is not equivalent to exports-field resolution and can produce incorrect results or `NotFound` for requests that should be resolved by `exports`.

### What changed
- In the PnP branch, derive and use the PnP subpath directly for:
  - exports subpath resolution
  - inner request fallback construction
- Avoid relying on `load_package_self` package-name matching in the PnP-specific flow.
- Keep non-PnP behavior unchanged, including normal self-reference checks outside PnP.

### Why
This aligns `rspack-resolver` with `enhanced-resolve` behavior in PnP mode and ensures deterministic exports resolution based on the PnP-resolved package/subpath, not on `package.json.name` string matching.

### Tests
Added/updated tests (modeled after enhanced-resolve scenarios) covering:
- bare package request in PnP
- subpath request in PnP
- name-mismatch case where exports must still resolve

### Result
- Before fix: PnP name-mismatch cases could bypass exports and fail via fallback behavior.
- After fix: exports resolution succeeds from PnP-derived subpath; non-PnP semantics remain intact.