### PR TITLE
feat: track tsconfig files as dependencies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,7 +322,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   ) -> Result<CachedPath, ResolveError> {
     // tsconfig-paths
     if let Some(path) = self
-      .load_tsconfig_paths(cached_path, specifier, &mut Ctx::default())
+      .load_tsconfig_paths(cached_path, specifier, ctx)
       .await?
     {
       return Ok(path);
@@ -1447,6 +1447,9 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
         &tsconfig_options.references,
       )
       .await?;
+    for dependency in &tsconfig.file_dependencies {
+      ctx.add_file_dependency(dependency);
+    }
     let paths = tsconfig.resolve(cached_path.path(), specifier);
     for path in paths {
       let cached_path = self.cache.value(&path);
@@ -1522,7 +1525,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
             let directory = tsconfig.directory().to_path_buf();
             for reference in &mut tsconfig.references {
               let reference_tsconfig_path = directory.normalize_with(&reference.path);
-              let tsconfig = self
+              let reference_tsconfig = self
                 .cache
                 .tsconfig(
                   /* root */ true,
@@ -1537,7 +1540,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
                   },
                 )
                 .await?;
-              reference.tsconfig.replace(tsconfig);
+              tsconfig
+                .file_dependencies
+                .extend(reference_tsconfig.file_dependencies.iter().cloned());
+              reference.tsconfig.replace(reference_tsconfig);
             }
           }
 

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -1,6 +1,8 @@
 //! Tests for tsconfig project references
 
-use crate::{ResolveError, ResolveOptions, Resolver, TsconfigOptions, TsconfigReferences};
+use crate::{
+  ResolveContext, ResolveError, ResolveOptions, Resolver, TsconfigOptions, TsconfigReferences,
+};
 
 #[tokio::test]
 async fn auto() {
@@ -38,6 +40,44 @@ async fn auto() {
       .await
       .map(|f| f.full_path());
     assert_eq!(resolved_path, Ok(expected), "{request} {path:?}");
+  }
+}
+
+#[tokio::test]
+async fn tscconfig_file_as_file_dependencies() {
+  let f = super::fixture_root().join("tsconfig/cases/project_references");
+
+  let resolver = Resolver::new(ResolveOptions {
+    tsconfig: Some(TsconfigOptions {
+      config_file: f.join("app"),
+      references: TsconfigReferences::Auto,
+    }),
+    ..ResolveOptions::default()
+  });
+  let mut ctx = ResolveContext::default();
+
+  let resolved_path = resolver
+    .resolve_with_context(&f.join("project_b/src"), "@/index.ts", &mut ctx)
+    .await
+    .map(|f| f.full_path());
+  assert_eq!(resolved_path, Ok(f.join("project_b/src/aliased/index.ts")));
+
+  let expected_dependencies = [
+    f.join("app/tsconfig.json"),
+    f.join("tsconfig.base.json"),
+    f.join("project_a/conf.json"),
+    f.join("project_b/tsconfig.json"),
+    f.join("project_c/tsconfig.json"),
+    f.parent()
+      .unwrap()
+      .join("paths_template_variable/tsconfig2.json"),
+  ];
+  for dependency in expected_dependencies {
+    assert!(
+      ctx.file_dependencies.contains(&dependency),
+      "missing tsconfig file dependency {dependency:?}: {:?}",
+      ctx.file_dependencies
+    );
   }
 }
 

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -44,7 +44,7 @@ async fn auto() {
 }
 
 #[tokio::test]
-async fn tscconfig_file_as_file_dependencies() {
+async fn tsconfig_file_as_file_dependencies() {
   let f = super::fixture_root().join("tsconfig/cases/project_references");
 
   let resolver = Resolver::new(ResolveOptions {

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -33,6 +33,9 @@ pub struct TsConfig {
   #[serde(skip)]
   pub(crate) path: PathBuf,
 
+  #[serde(skip)]
+  pub(crate) file_dependencies: Vec<PathBuf>,
+
   #[serde(default)]
   pub extends: Option<ExtendsField>,
 
@@ -82,11 +85,13 @@ impl TsConfig {
       let mut tsconfig: Self = serde_json::from_str("{}")?;
       tsconfig.root = root;
       tsconfig.path = path.to_path_buf();
+      tsconfig.file_dependencies.push(path.to_path_buf());
       return Ok(tsconfig);
     }
     let mut tsconfig: Self = serde_json::from_str(json)?;
     tsconfig.root = root;
     tsconfig.path = path.to_path_buf();
+    tsconfig.file_dependencies.push(path.to_path_buf());
     let directory = tsconfig.directory().to_path_buf();
     if let Some(base_url) = &tsconfig.compiler_options.base_url {
       // keep the `${configDir}` template variable in the baseUrl
@@ -159,6 +164,9 @@ impl TsConfig {
         .base_url
         .clone_from(&other_config.compiler_options.base_url);
     }
+    self
+      .file_dependencies
+      .extend(other_config.file_dependencies.iter().cloned());
   }
 
   pub fn resolve(&self, path: &Path, specifier: &str) -> Vec<PathBuf> {


### PR DESCRIPTION
## Summary

- Track tsconfig files loaded for paths resolution as file dependencies.
- Propagate config file dependencies through extended tsconfigs and project references.
- Add a regression test covering tsconfig, extends, and referenced config files in `ResolveContext.file_dependencies`.

## Why

When tsconfig paths resolution was enabled, the resolver loaded `tsconfig.json` files through a separate context, so those config files were not reported as file dependencies. This diverged from enhanced-resolve and could miss invalidation when tsconfig files changed.

## Validation

- `cargo fmt --check`
- `cargo test tsconfig --lib`
- `cargo test --lib -- --skip tests::pnp`

Note: full `cargo test --lib` still fails in this checkout because PnP fixtures do not include `.pnp.*` files; non-PnP lib tests pass.