### PR TITLE
chore: use mimalloc for codspeed benchmark allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -673,6 +673,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +722,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -828,7 +847,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1029,6 +1048,7 @@ dependencies = [
  "futures",
  "indexmap",
  "json-strip-comments",
+ "mimalloc",
  "normalize-path",
  "pnp",
  "rayon",
@@ -1358,7 +1378,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,16 @@ rayon          = { version = "1.11.0" }
 regex          = "1.12.2"
 vfs            = "0.13.0"               # for testing with in memory file system
 
+# Benchmark allocator features kept aligned with rspack's `xtask/benchmark`.
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+mimalloc = { version = "0.1.48", features = ["local_dynamic_tls", "v3"] }
+
+[target.'cfg(target_os = "macos")'.dev-dependencies]
+mimalloc = { version = "0.1.48", features = ["v3"] }
+
+[target.'cfg(all(not(target_os = "linux"), not(target_os = "macos"), not(target_family = "wasm")))'.dev-dependencies]
+mimalloc = { version = "0.1.48", features = ["v3"] }
+
 [features]
 default = ["yarn_pnp"]
 ## Enables the [PackageJson::raw_json] API,

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -36,14 +36,13 @@ impl<A> NeverGrowInPlaceAllocator<A> {
 }
 
 // SAFETY: Methods simply delegate to the wrapped allocator.
-#[expect(unsafe_code, clippy::undocumented_unsafe_blocks)]
 unsafe impl<A: GlobalAlloc> GlobalAlloc for NeverGrowInPlaceAllocator<A> {
   unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-    unsafe { self.allocator.alloc(layout) }
+    self.allocator.alloc(layout)
   }
 
   unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-    unsafe { self.allocator.dealloc(ptr, layout) }
+    self.allocator.dealloc(ptr, layout)
   }
 }
 

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -1,5 +1,7 @@
+#[cfg(target_family = "wasm")]
+use std::alloc::System;
 use std::{
-  alloc::{GlobalAlloc, Layout, System},
+  alloc::{GlobalAlloc, Layout},
   env, fs,
   fs::read_to_string,
   future::Future,
@@ -9,20 +11,39 @@ use std::{
 };
 
 #[global_allocator]
-static GLOBAL: NeverGrowInPlaceAllocator = NeverGrowInPlaceAllocator;
+#[cfg(not(target_family = "wasm"))]
+static GLOBAL: NeverGrowInPlaceAllocator<mimalloc::MiMalloc> =
+  NeverGrowInPlaceAllocator::new(mimalloc::MiMalloc);
 
-/// Delegates `alloc`/`dealloc` to [`System`] but omits [`GlobalAlloc::realloc`],
-/// forcing the default "alloc-new + copy + dealloc-old" path so that benchmarks
-/// never benefit from non-deterministic in-place growth provided by `libc::realloc`.
-struct NeverGrowInPlaceAllocator;
+#[global_allocator]
+#[cfg(target_family = "wasm")]
+static GLOBAL: NeverGrowInPlaceAllocator<System> = NeverGrowInPlaceAllocator::new(System);
 
-unsafe impl GlobalAlloc for NeverGrowInPlaceAllocator {
+/// Delegates `alloc`/`dealloc` to the wrapped allocator but omits
+/// [`GlobalAlloc::realloc`], forcing the default "alloc-new + copy + dealloc-old"
+/// path so that benchmarks never benefit from non-deterministic in-place growth
+/// provided by the underlying allocator's `realloc`. Wrapping `mimalloc::MiMalloc`
+/// (instead of using it directly) also keeps `alloc` / `dealloc` visible to
+/// CodSpeed's mimalloc white-box allocator tracking.
+struct NeverGrowInPlaceAllocator<A> {
+  allocator: A,
+}
+
+impl<A> NeverGrowInPlaceAllocator<A> {
+  const fn new(allocator: A) -> Self {
+    Self { allocator }
+  }
+}
+
+// SAFETY: Methods simply delegate to the wrapped allocator.
+#[expect(unsafe_code, clippy::undocumented_unsafe_blocks)]
+unsafe impl<A: GlobalAlloc> GlobalAlloc for NeverGrowInPlaceAllocator<A> {
   unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-    unsafe { System.alloc(layout) }
+    unsafe { self.allocator.alloc(layout) }
   }
 
   unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-    unsafe { System.dealloc(ptr, layout) }
+    unsafe { self.allocator.dealloc(ptr, layout) }
   }
 }
 


### PR DESCRIPTION
## Summary

Port of [web-infra-dev/rspack#13966](https://github.com/web-infra-dev/rspack/pull/13966) to this repo's benchmark harness.

- Route `NeverGrowInPlaceAllocator` `alloc`/`dealloc` through `mimalloc::MiMalloc` on non-wasm targets so CodSpeed can white-box allocator activity.
- Keep the wrapper without a `realloc` override to preserve never-grow-in-place benchmark behavior — `realloc` falls through to the default `GlobalAlloc::realloc` (alloc-new + copy + dealloc-old), which is what stabilizes results.
- Keep wasm on `System` and align `mimalloc` feature flags (`local_dynamic_tls` on Linux, `v3` everywhere) with `rspack_allocator`.

## Verification

- \`cargo check --benches --all-features\`
- \`cargo clippy --bench resolver --all-features\` — no new warnings in the modified region
- \`cargo fmt --check\`
- pre-commit hooks (fmt + taplo + clippy with \`-D warnings\`) green