### PR TITLE
perf: compare cached path hash before path

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -390,7 +390,9 @@ impl Hash for dyn CacheKey + '_ {
 
 impl PartialEq for dyn CacheKey + '_ {
   fn eq(&self, other: &Self) -> bool {
-    self.tuple().1 == other.tuple().1
+    let (self_hash, self_path) = self.tuple();
+    let (other_hash, other_path) = other.tuple();
+    self_hash == other_hash && self_path == other_path
   }
 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -117,7 +117,7 @@ impl Hash for CachedPath {
 
 impl PartialEq for CachedPath {
   fn eq(&self, other: &Self) -> bool {
-    self.0.path == other.0.path
+    self.0.hash == other.0.hash && self.0.path == other.0.path
   }
 }
 impl Eq for CachedPath {}


### PR DESCRIPTION
## Summary

- Compare `CachedPath` memoized hashes before falling back to path equality.
- Compare `dyn CacheKey` memoized hashes before falling back to path equality, covering borrowed cache lookup paths like `DashSet::get((hash, path).borrow())`.
- Keep path comparison as the collision guard.

## Test

- `rustfmt --edition 2021 src/cache.rs`
- `cargo test --no-run` using installed `nightly-aarch64-apple-darwin` because local pinned `nightly-2025-11-10` is incomplete
- `cargo test tests::simple::simple`
- Full `cargo test` was not rerun for this follow-up; previous full run failed in existing PnP fixture resolution cases with `NotFound(...)` errors