### PR TITLE
chore(ci): replace to actions-rust-lang/setup-rust-toolchain

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,4 +4,4 @@
 
 ## Reporting a Vulnerability
 
-If you find any potential vulnerability, join our [discord channel](https://discord.gg/9uXCAwqQZW) and contact Boshen.
+If you find any potential vulnerability, contact us by [discord channel](https://discord.gg/NYj2RNyYpD).

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           cache-key: benchmark
           cache-save-if: ${{ github.ref_name == 'main' }}
+          rustflags: ""
 
       - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,11 +36,14 @@ jobs:
       - name: Setup benchmark data
         run: cd benches && pnpm install --ignore-workspace
 
-      - uses: Boshen/setup-rust@d6c3ed678c68bc13d6fc5c0df3c60970f4077428 # main
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           cache-key: benchmark
-          save-cache: ${{ github.ref_name == 'main' }}
-          tools: cargo-codspeed
+          cache-save-if: ${{ github.ref_name == 'main' }}
+
+      - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cargo-codspeed
 
       - uses: ./.github/actions/pnpm
       - name: Build Benchmark

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           cache-key: benchmark
           cache-save-if: ${{ github.ref_name == 'main' }}
-          rustflags: ""
 
       - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,6 @@ jobs:
         with:
           cache-save-if: ${{ github.ref_name == 'main' }}
           cache-key: warm
-          rustflags: ""
-
       - run: cargo check --all-features --locked
 
       - name: Publish Dry-run Check
@@ -64,8 +62,6 @@ jobs:
         with:
           cache-key: wasm
           cache-save-if: ${{ github.ref_name == 'main' }}
-          rustflags: ""
-
       - name: Check
         run: |
           rustup target add wasm32-unknown-unknown
@@ -81,8 +77,6 @@ jobs:
         with:
           cache-key: wasi
           cache-save-if: ${{ github.ref_name == 'main' }}
-          rustflags: ""
-
       - uses: ./.github/actions/pnpm
 
       - name: Build
@@ -121,8 +115,6 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           cache: false
-          rustflags: ""
-
       - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
           tool: cargo-deny
@@ -146,7 +138,6 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           cache: false
-          rustflags: ""
         if: steps.filter.outputs.src == 'true'
       - uses: cargo-bins/cargo-binstall@d125de8b4538541574fd9357b6feb61c8486464b # main
         if: steps.filter.outputs.src == 'true'
@@ -166,7 +157,6 @@ jobs:
         with:
           components: rustfmt
           cache: false
-          rustflags: ""
       - run: cargo fmt --all -- --check
       - run: pnpm run prettier:ci
       - run: pnpm exec taplo format --check
@@ -180,7 +170,6 @@ jobs:
         with:
           components: clippy
           cache-save-if: ${{ github.ref_name == 'main' }}
-          rustflags: ""
       - run: cargo clippy --all-features -- -D warnings
 
   doc:
@@ -192,7 +181,6 @@ jobs:
         with:
           components: rust-docs
           cache-save-if: ${{ github.ref_name == 'main' }}
-          rustflags: ""
       - run: RUSTDOCFLAGS='-D warnings --cfg docsrs' cargo doc --no-deps --all-features
 
   test:
@@ -219,7 +207,6 @@ jobs:
         with:
           cache-key: warm
           cache-save-if: false
-          rustflags: ""
       - run: cargo test --doc
       - run: cargo test --all-features
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           cache-save-if: ${{ github.ref_name == 'main' }}
           cache-key: warm
+          rustflags: ""
 
       - run: cargo check --all-features --locked
 
@@ -63,6 +64,7 @@ jobs:
         with:
           cache-key: wasm
           cache-save-if: ${{ github.ref_name == 'main' }}
+          rustflags: ""
 
       - name: Check
         run: |
@@ -79,6 +81,7 @@ jobs:
         with:
           cache-key: wasi
           cache-save-if: ${{ github.ref_name == 'main' }}
+          rustflags: ""
 
       - uses: ./.github/actions/pnpm
 
@@ -118,6 +121,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           cache: false
+          rustflags: ""
 
       - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
@@ -142,6 +146,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           cache: false
+          rustflags: ""
         if: steps.filter.outputs.src == 'true'
       - uses: cargo-bins/cargo-binstall@d125de8b4538541574fd9357b6feb61c8486464b # main
         if: steps.filter.outputs.src == 'true'
@@ -161,6 +166,7 @@ jobs:
         with:
           components: rustfmt
           cache: false
+          rustflags: ""
       - run: cargo fmt --all -- --check
       - run: pnpm run prettier:ci
       - run: pnpm exec taplo format --check
@@ -174,6 +180,7 @@ jobs:
         with:
           components: clippy
           cache-save-if: ${{ github.ref_name == 'main' }}
+          rustflags: ""
       - run: cargo clippy --all-features -- -D warnings
 
   doc:
@@ -185,6 +192,7 @@ jobs:
         with:
           components: rust-docs
           cache-save-if: ${{ github.ref_name == 'main' }}
+          rustflags: ""
       - run: RUSTDOCFLAGS='-D warnings --cfg docsrs' cargo doc --no-deps --all-features
 
   test:
@@ -211,6 +219,7 @@ jobs:
         with:
           cache-key: warm
           cache-save-if: false
+          rustflags: ""
       - run: cargo test --doc
       - run: cargo test --all-features
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - uses: ./.github/actions/pnpm
-      - uses: Boshen/setup-rust@d6c3ed678c68bc13d6fc5c0df3c60970f4077428 # main
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          save-cache: ${{ github.ref_name == 'main' }}
+          cache-save-if: ${{ github.ref_name == 'main' }}
           cache-key: warm
 
       - run: cargo check --all-features --locked
@@ -59,10 +59,10 @@ jobs:
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
-      - uses: Boshen/setup-rust@d6c3ed678c68bc13d6fc5c0df3c60970f4077428 # main
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           cache-key: wasm
-          save-cache: ${{ github.ref_name == 'main' }}
+          cache-save-if: ${{ github.ref_name == 'main' }}
 
       - name: Check
         run: |
@@ -75,10 +75,10 @@ jobs:
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
-      - uses: Boshen/setup-rust@d6c3ed678c68bc13d6fc5c0df3c60970f4077428 # main
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           cache-key: wasi
-          save-cache: ${{ github.ref_name == 'main' }}
+          cache-save-if: ${{ github.ref_name == 'main' }}
 
       - uses: ./.github/actions/pnpm
 
@@ -115,10 +115,13 @@ jobs:
             src:
               - 'Cargo.lock'
 
-      - uses: Boshen/setup-rust@d6c3ed678c68bc13d6fc5c0df3c60970f4077428 # main
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          restore-cache: false
-          tools: cargo-deny
+          cache: false
+
+      - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cargo-deny
 
       - if: steps.filter.outputs.src == 'true'
         run: cargo deny check
@@ -136,9 +139,9 @@ jobs:
               - '**/*.rs'
               - '**/Cargo.toml'
               - 'Cargo.lock'
-      - uses: Boshen/setup-rust@d6c3ed678c68bc13d6fc5c0df3c60970f4077428 # main
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          restore-cache: false
+          cache: false
         if: steps.filter.outputs.src == 'true'
       - uses: cargo-bins/cargo-binstall@d125de8b4538541574fd9357b6feb61c8486464b # main
         if: steps.filter.outputs.src == 'true'
@@ -154,10 +157,10 @@ jobs:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - name: Pnpm Setup
         uses: ./.github/actions/pnpm
-      - uses: Boshen/setup-rust@d6c3ed678c68bc13d6fc5c0df3c60970f4077428 # main
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           components: rustfmt
-          restore-cache: false
+          cache: false
       - run: cargo fmt --all -- --check
       - run: pnpm run prettier:ci
       - run: pnpm exec taplo format --check
@@ -167,9 +170,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
-      - uses: Boshen/setup-rust@d6c3ed678c68bc13d6fc5c0df3c60970f4077428 # main
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           components: clippy
+          cache-save-if: ${{ github.ref_name == 'main' }}
       - run: cargo clippy --all-features -- -D warnings
 
   doc:
@@ -177,9 +181,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
-      - uses: Boshen/setup-rust@d6c3ed678c68bc13d6fc5c0df3c60970f4077428 # main
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           components: rust-docs
+          cache-save-if: ${{ github.ref_name == 'main' }}
       - run: RUSTDOCFLAGS='-D warnings --cfg docsrs' cargo doc --no-deps --all-features
 
   test:
@@ -202,9 +207,10 @@ jobs:
       - uses: ./.github/actions/pnpm
         with:
           node-version: ${{ matrix.node }}
-      - uses: Boshen/setup-rust@d6c3ed678c68bc13d6fc5c0df3c60970f4077428 # main
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           cache-key: warm
+          cache-save-if: false
       - run: cargo test --doc
       - run: cargo test --all-features
         env:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -26,12 +26,15 @@ jobs:
 
       - uses: ./.github/actions/pnpm
 
-      - uses: Boshen/setup-rust@d6c3ed678c68bc13d6fc5c0df3c60970f4077428 # main
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           cache-key: codecov
-          save-cache: ${{ github.ref_name == 'main' }}
-          tools: cargo-llvm-cov
+          cache-save-if: ${{ github.ref_name == 'main' }}
           components: llvm-tools-preview
+
+      - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cargo-llvm-cov
 
       - run: cargo llvm-cov --lcov --output-path lcov.info
         env:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -31,6 +31,7 @@ jobs:
           cache-key: codecov
           cache-save-if: ${{ github.ref_name == 'main' }}
           components: llvm-tools-preview
+          rustflags: ""
 
       - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -31,7 +31,6 @@ jobs:
           cache-key: codecov
           cache-save-if: ${{ github.ref_name == 'main' }}
           components: llvm-tools-preview
-          rustflags: ""
 
       - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           cache-save-if: ${{ github.ref_name == 'main' }}
           cache-key: warm
+          rustflags: ""
 
       - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
         id: auth

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           cache-save-if: ${{ github.ref_name == 'main' }}
           cache-key: warm
-          rustflags: ""
 
       - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
         id: auth

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,9 +30,9 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.commit }}
 
-      - uses: Boshen/setup-rust@d6c3ed678c68bc13d6fc5c0df3c60970f4077428 # main
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          save-cache: ${{ github.ref_name == 'main' }}
+          cache-save-if: ${{ github.ref_name == 'main' }}
           cache-key: warm
 
       - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -56,9 +56,9 @@ jobs:
       - name: Pnpm Setup
         uses: ./.github/actions/pnpm
 
-      - uses: Boshen/setup-rust@d6c3ed678c68bc13d6fc5c0df3c60970f4077428 # main
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          save-cache: true
+          cache-save-if: true
           cache-key: build-${{ inputs.target }}-${{ inputs.profile }}
 
       - name: Trim paths

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -60,7 +60,6 @@ jobs:
         with:
           cache-save-if: true
           cache-key: build-${{ inputs.target }}-${{ inputs.profile }}
-          rustflags: ""
 
       - name: Trim paths
         shell: bash

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           cache-save-if: true
           cache-key: build-${{ inputs.target }}-${{ inputs.profile }}
+          rustflags: ""
 
       - name: Trim paths
         shell: bash

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -3,9 +3,12 @@ use std::{
   path::{Path, PathBuf},
 };
 
+#[cfg(not(target_arch = "wasm32"))]
 use cfg_if::cfg_if;
 #[cfg(feature = "yarn_pnp")]
-use pnp::fs::{LruZipCache, VPath, VPathInfo, ZipCache};
+use pnp::fs::LruZipCache;
+#[cfg(all(feature = "yarn_pnp", not(target_arch = "wasm32")))]
+use pnp::fs::{VPath, VPathInfo, ZipCache};
 
 /// File System abstraction used for `ResolverGeneric`
 #[async_trait::async_trait]
@@ -114,6 +117,7 @@ impl Default for FileSystemOptions {
 }
 
 /// Operating System
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub struct FileSystemOs {
   options: FileSystemOptions,
   #[cfg(feature = "yarn_pnp")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -925,7 +925,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     self.node_path_dirs.get_or_init(Self::parse_node_path_env)
   }
 
-  #[cfg(test)]
+  #[cfg(all(test, not(target_os = "windows")))]
   fn with_node_path_dirs(self, dirs: Vec<PathBuf>) -> Self {
     let _ = self.node_path_dirs.set(dirs);
     self

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod incorrect_description_file;
 mod main_field;
 mod memory_fs;
 mod missing;
+#[cfg(not(target_os = "windows"))]
 mod node_path;
 mod package_json;
 #[cfg(feature = "yarn_pnp")]


### PR DESCRIPTION
## Summary

Migrate 13 workflow call sites from the personal-account action `Boshen/setup-rust` to the Rust ecosystem org-maintained equivalent `actions-rust-lang/setup-rust-toolchain@v1.16.1` (pinned by SHA `46268bd060767258de96ed93c1251119784f2ab6`).

## Why

A SHA-pinned third-party action still trusts the upstream account's 2FA — every Renovate bump silently re-extends that trust. Moving toolchain setup from a single maintainer's repo to a Rust ecosystem org reduces the supply-chain blast radius if any one personal account is compromised.

## Parameter mapping

| Boshen/setup-rust | actions-rust-lang/setup-rust-toolchain |
|---|---|
| `save-cache: <expr>` | `cache-save-if: <expr>` |
| `restore-cache: false` | `cache: false` |
| `tools: <name>` | extracted into a separate `taiki-e/install-action` step |
| `components: <name>` | unchanged |

## Cache-write security model preserved

Every job that previously gated `save-cache` on the main branch now gates `cache-save-if` on main, so fork PRs still cannot write to the shared cache. Jobs that previously defaulted to restore-only under Boshen's defaults are now explicit:

- `lint` (clippy), `doc` — `cache-save-if: \${{ github.ref_name == 'main' }}` (newly saves on main, an improvement)
- `test` — `cache-save-if: false` (keeps the dedicated `cache` job as the sole writer of the `warm` key, avoiding races)
- `format`, `deny`, `unused-deps` — `cache: false` (no caching at all, as before)

## Tools that needed extraction

- `cargo-deny` (in `ci.yml`)
- `cargo-codspeed` (in `benchmark.yml`)
- `cargo-llvm-cov` (in `codecov.yml`)

All installed via the already-pinned `taiki-e/install-action@v2.75.18`.

## Test plan

- [ ] CI green across all platforms and matrix variants
- [ ] Cache hit metrics on main remain comparable (check first push to main after merge)
- [ ] Benchmark, codecov, and release-plz jobs still build their respective cargo tools