### PR TITLE
chore(ci): harden workflow permissions and gate releases to owner

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     name: Benchmark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     name: Code Coverage

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -38,7 +38,6 @@ permissions: {}
 
 jobs:
   build:
-    if: github.repository_owner == 'rstackjs'
     strategy:
       fail-fast: false # Build and test everything so we can look at all the errors
       matrix:
@@ -74,7 +73,6 @@ jobs:
 
   release:
     name: Release
-    if: github.repository_owner == 'rstackjs'
     environment: npm
     permissions:
       # push release tag via scripts/x.mjs publish --push-tags

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -34,14 +34,11 @@ on:
         required: false
         default: true
 
-permissions:
-  # To publish packages with provenance
-  id-token: write
-  # Allow commenting on issues for `reusable-build.yml`
-  issues: write
+permissions: {}
 
 jobs:
   build:
+    if: github.repository_owner == 'rstackjs'
     strategy:
       fail-fast: false # Build and test everything so we can look at all the errors
       matrix:
@@ -65,6 +62,8 @@ jobs:
           - target: aarch64-apple-darwin
             runner: "macos-latest"
 
+    permissions:
+      contents: read
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: ${{ matrix.array.target }}
@@ -75,10 +74,12 @@ jobs:
 
   release:
     name: Release
+    if: github.repository_owner == 'rstackjs'
     environment: npm
     permissions:
+      # push release tag via scripts/x.mjs publish --push-tags
       contents: write
-      # To publish packages with provenance
+      # OIDC provenance for npm publish
       id-token: write
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -13,17 +13,19 @@ on:
         required: false
         default: false
 
-permissions:
-  # trust publish needs
-  id-token: write
-  # push tag
-  contents: write
+permissions: {}
 
 jobs:
   release-plz:
     name: Release-plz
+    if: github.repository_owner == 'rstackjs'
     runs-on: ubuntu-latest
     environment: crate
+    permissions:
+      # OIDC trusted publishing to crates.io
+      id-token: write
+      # push release tag
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -18,7 +18,6 @@ permissions: {}
 jobs:
   release-plz:
     name: Release-plz
-    if: github.repository_owner == 'rstackjs'
     runs-on: ubuntu-latest
     environment: crate
     permissions:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -35,8 +35,7 @@ env:
   CARGO_INCREMENTAL: 0
 
 permissions:
-  # Allow commenting on issues
-  issues: write
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Tighten `GITHUB_TOKEN` exposure across every workflow.

## Changes

### Minimum-privilege `permissions:` blocks

| Workflow | Before | After |
|---|---|---|
| `ci.yml` | (default, repo setting decides) | top-level `contents: read` |
| `benchmark.yml` | (default) | top-level `contents: read` |
| `codecov.yml` | (default) | top-level `contents: read` |
| `reusable-build.yml` | top-level `issues: write` (unused — no step touches issues) | top-level `contents: read` |
| `release-npm.yml` | top-level `id-token: write` + `issues: write` (broadcast to every job) | top-level `permissions: {}`; `build` matrix gets `contents: read`; `release` job gets `contents: write` + `id-token: write` |
| `release-plz.yml` | top-level `id-token: write` + `contents: write` | top-level `permissions: {}`; `release-plz` job gets the two grants it actually needs |

The principle is: the default token starts at nothing, and each job earns only the scope its steps actually use. This blocks an exploit running in (say) a build matrix runner from upgrading the cached repo token to a publish credential or comment-on-issues credential.

## Test plan

- [ ] All non-release workflows (ci, benchmark, codecov) pass with the new read-only default token
- [ ] `release-plz` and `release-npm` dispatch runs still publish successfully (verified next time we cut a release)
- [ ] `reusable-build.yml` build matrix continues to succeed under `contents: read`