### PR TITLE
test: sync enhanced-resolve#579 tsconfig paths fall-through

### DIFF
--- a/fixtures/tsconfig/cases/scoped-pkg-fallthrough/node_modules/@sentry/react/index.js
+++ b/fixtures/tsconfig/cases/scoped-pkg-fallthrough/node_modules/@sentry/react/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/fixtures/tsconfig/cases/scoped-pkg-fallthrough/node_modules/@sentry/react/package.json
+++ b/fixtures/tsconfig/cases/scoped-pkg-fallthrough/node_modules/@sentry/react/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@sentry/react",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/fixtures/tsconfig/cases/scoped-pkg-fallthrough/src/helper/index.ts
+++ b/fixtures/tsconfig/cases/scoped-pkg-fallthrough/src/helper/index.ts
@@ -1,0 +1,4 @@
+import * as sentry from "@sentry/react";
+
+export const helper = true;
+export { sentry };

--- a/fixtures/tsconfig/cases/scoped-pkg-fallthrough/tsconfig.json
+++ b/fixtures/tsconfig/cases/scoped-pkg-fallthrough/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@*": ["./src/*"]
+    }
+  }
+}

--- a/src/tests/tsconfig_paths.rs
+++ b/src/tests/tsconfig_paths.rs
@@ -269,6 +269,42 @@ async fn test_template_variable() {
   }
 }
 
+// https://github.com/webpack/enhanced-resolve/pull/579
+// https://github.com/webpack/webpack/issues/20944
+// When a tsconfig `paths` pattern (e.g. "@*") matches a request but the
+// mapped target does not exist, resolution should fall through to normal
+// module resolution (node_modules), matching TypeScript's native behavior.
+#[tokio::test]
+async fn tsconfig_paths_scoped_pkg_fallthrough() {
+  let f = super::fixture_root().join("tsconfig/cases/scoped-pkg-fallthrough");
+
+  let resolver = Resolver::new(ResolveOptions {
+    extensions: vec![".ts".into(), ".tsx".into(), ".js".into()],
+    main_fields: vec!["main".into()],
+    main_files: vec!["index".into()],
+    tsconfig: Some(TsconfigOptions {
+      config_file: f.join("tsconfig.json"),
+      references: TsconfigReferences::Auto,
+    }),
+    ..ResolveOptions::default()
+  });
+
+  // "@helper" resolves via the "@*" mapping when the mapped path exists
+  let resolved_path = resolver.resolve(&f, "@helper").await.map(|p| p.full_path());
+  assert_eq!(resolved_path, Ok(f.join("src/helper/index.ts")));
+
+  // "@sentry/react" falls through to node_modules when "@*" mapping does
+  // not resolve to an existing file.
+  let resolved_path = resolver
+    .resolve(&f, "@sentry/react")
+    .await
+    .map(|p| p.full_path());
+  assert_eq!(
+    resolved_path,
+    Ok(f.join("node_modules/@sentry/react/index.js"))
+  );
+}
+
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 mod windows_test {
   use std::path::{Path, PathBuf};


### PR DESCRIPTION
## Summary
Sync the regression test from [webpack/enhanced-resolve#579](https://github.com/webpack/enhanced-resolve/pull/579) (fixes [webpack/webpack#20944](https://github.com/webpack/webpack/issues/20944)).

When a tsconfig `paths` pattern matches a request but the mapped target does not exist on disk, resolution should fall through to normal `node_modules` lookup — matching TypeScript's native behavior.

## Investigation
rspack-resolver is **not affected** by this bug. The architecture in `load_tsconfig_paths` (`src/lib.rs`) iterates every candidate path and returns `Ok(None)` if none resolve, letting the outer pipeline continue with `load_alias` → `require_bare` → `node_modules` resolution.

This PR adds the regression test only (no source changes).

## Test plan
- [x] `cargo test --all-features tsconfig_paths_scoped_pkg_fallthrough` passes
- [x] All existing tsconfig tests still pass