### PR TITLE
perf: micro-optimize resolver normal path

### DIFF
--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -1,10 +1,11 @@
+#![allow(clippy::significant_drop_tightening)]
+
 #[cfg(target_family = "wasm")]
 use std::alloc::System;
 use std::{
   alloc::{GlobalAlloc, Layout},
   env, fs,
   fs::read_to_string,
-  future::Future,
   io::{self, Write},
   path::{Path, PathBuf},
   sync::Arc,
@@ -42,7 +43,7 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for NeverGrowInPlaceAllocator<A> {
   }
 
   unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-    self.allocator.dealloc(ptr, layout)
+    self.allocator.dealloc(ptr, layout);
   }
 }
 
@@ -170,14 +171,12 @@ fn resolver_with_many_extensions() -> rspack_resolver::Resolver {
   })
 }
 
-fn create_async_resolve_task(
+async fn create_async_resolve_task(
   rspack_resolver: Arc<rspack_resolver::Resolver>,
   path: PathBuf,
   request: String,
-) -> impl Future<Output = ()> {
-  async move {
-    let _ = rspack_resolver.resolve(path, &request).await;
-  }
+) {
+  let _ = rspack_resolver.resolve(path, &request).await;
 }
 
 fn bench_resolver(c: &mut Criterion) {
@@ -197,9 +196,11 @@ fn bench_resolver(c: &mut Criterion) {
   runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
         for (path, request) in &data {
             let r = rspack_resolver(false).resolve(path, request).await;
-            if !r.is_ok() {
-                panic!("resolve failed {path:?} {request},\n\nplease run `pnpm install --ignore-workspace` in `/benches` before running the benchmarks");
-            }
+            assert!(
+                r.is_ok(),
+                "resolve failed {} {request},\n\nplease run `pnpm install --ignore-workspace` in `/benches` before running the benchmarks",
+                path.display(),
+            );
         }
     });
 
@@ -255,7 +256,7 @@ fn bench_resolver(c: &mut Criterion) {
         || {
           rspack_resolver.clear_cache();
         },
-        |_| async {
+        |()| async {
           for (path, request) in data {
             _ = rspack_resolver.resolve(path, request).await;
           }
@@ -278,10 +279,10 @@ fn bench_resolver(c: &mut Criterion) {
         || {
           rspack_resolver.clear_cache();
         },
-        |_| async {
+        |()| async {
           for (path, request) in data {
             _ = rspack_resolver
-              .resolve(path, &format!("{}/bad", request))
+              .resolve(path, &format!("{request}/bad"))
               .await;
           }
         },
@@ -300,16 +301,16 @@ fn bench_resolver(c: &mut Criterion) {
         || {
           rspack_resolver.clear_cache();
         },
-        |_| {
+        |()| {
           runner.block_on(async {
             let mut join_set = JoinSet::new();
-            data.iter().for_each(|(path, request)| {
+            for (path, request) in data {
               join_set.spawn(create_async_resolve_task(
-                rspack_resolver.clone(),
-                path.to_path_buf(),
-                request.to_string(),
+                Arc::clone(&rspack_resolver),
+                (*path).clone(),
+                (*request).clone(),
               ));
-            });
+            }
             let _ = join_set.join_all().await;
           });
         },
@@ -328,7 +329,7 @@ fn bench_resolver(c: &mut Criterion) {
         || {
           rspack_resolver.clear_cache();
         },
-        |_| async {
+        |()| async {
           for i in data.clone() {
             assert!(
               rspack_resolver
@@ -357,9 +358,9 @@ fn bench_resolver(c: &mut Criterion) {
 
         data.clone().for_each(|i| {
           join_set.spawn(create_async_resolve_task(
-            rspack_resolver.clone(),
+            Arc::clone(&rspack_resolver),
             symlink_test_dir.clone(),
-            format!("./file{i}").to_string(),
+            format!("./file{i}"),
           ));
         });
         join_set.join_all().await;
@@ -381,7 +382,7 @@ fn bench_resolver(c: &mut Criterion) {
         || {
           rspack_resolver.clear_cache();
         },
-        |_| async {
+        |()| async {
           for i in data.clone() {
             let _ = rspack_resolver
               .resolve(pnp_workspace.join(format!("{i}")), "preact")

--- a/examples/resolver.rs
+++ b/examples/resolver.rs
@@ -1,7 +1,7 @@
-///! See documentation at <https://docs.rs/rspack_resolver>
+//! See documentation at <https://docs.rs/rspack_resolver>
 use std::{env, path::PathBuf};
 
-use rspack_resolver::{AliasValue, ResolveOptions, Resolver};
+use rspack_resolver::{AliasValue, ResolveContext, ResolveOptions, Resolver};
 
 #[tokio::main]
 async fn main() {
@@ -9,13 +9,18 @@ async fn main() {
 
   assert!(
     path.is_dir(),
-    "{path:?} must be a directory that will be resolved against."
+    "{} must be a directory that will be resolved against.",
+    path.display()
   );
-  assert!(path.is_absolute(), "{path:?} must be an absolute path.",);
+  assert!(
+    path.is_absolute(),
+    "{} must be an absolute path.",
+    path.display()
+  );
 
   let specifier = env::args().nth(2).expect("specifier");
 
-  println!("path: {path:?}");
+  println!("path: {}", path.display());
   println!("specifier: {specifier}");
 
   let options = ResolveOptions {
@@ -29,21 +34,21 @@ async fn main() {
     // condition_names: vec!["node".into(), "require".into()],
     ..ResolveOptions::default()
   };
-  let mut ctx = Default::default();
+  let mut ctx = ResolveContext::default();
 
   match Resolver::new(options)
     .resolve_with_context(path, &specifier, &mut ctx)
     .await
   {
     Err(error) => println!("Error: {error}"),
-    Ok(resolution) => println!("Resolved: {:?}", resolution.full_path()),
-  };
+    Ok(resolution) => println!("Resolved: {}", resolution.full_path().display()),
+  }
 
   let mut sorted_file_deps = ctx.file_dependencies.iter().collect::<Vec<_>>();
   sorted_file_deps.sort();
-  println!("file_deps: {:#?}", sorted_file_deps);
+  println!("file_deps: {sorted_file_deps:#?}");
 
   let mut sorted_missing = ctx.missing_dependencies.iter().collect::<Vec<_>>();
   sorted_missing.sort();
-  println!("missing_deps: {:#?}", sorted_missing);
+  println!("missing_deps: {sorted_missing:#?}");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1276,7 +1276,12 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     aliases: &Alias,
     ctx: &mut Ctx,
   ) -> ResolveResult {
+    let specifier_is_absolute = Path::new(specifier).is_absolute();
     for (alias_key_raw, specifiers) in aliases {
+      let alias_key_without_exact = alias_key_raw.strip_suffix('$').unwrap_or(alias_key_raw);
+      if specifier_is_absolute && !Path::new(alias_key_without_exact).is_absolute() {
+        continue;
+      }
       let alias_key = if let Some(alias_key) = alias_key_raw.strip_suffix('$') {
         if alias_key != specifier {
           continue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,22 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     }
   }
 
+  fn path_alias_may_match(path: &Path, aliases: &Alias) -> bool {
+    if aliases.is_empty() {
+      return false;
+    }
+    let Some(path) = path.to_str() else {
+      return true;
+    };
+    aliases.iter().any(|(alias_key_raw, _)| {
+      if let Some(alias_key) = alias_key_raw.strip_suffix('$') {
+        alias_key == path
+      } else {
+        Self::strip_package_name(path, alias_key_raw).is_some()
+      }
+    })
+  }
+
   pub fn new_with_file_system(file_system: Fs, options: ResolveOptions) -> Self {
     let options = options.sanitize();
     let (absolute_alias, relative_alias) = Self::partition_alias(&options.alias);
@@ -885,17 +901,20 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       }
     }
     // enhanced-resolve: try file as alias
-    let alias_specifier = cached_path.path().to_string_lossy();
-    if let Some(path) = self
-      .load_alias(
-        cached_path,
-        &alias_specifier,
-        Self::aliases_for(&alias_specifier, &self.absolute_alias, &self.relative_alias),
-        ctx,
-      )
-      .await?
-    {
-      return Ok(Some(path));
+    let path = cached_path.path();
+    let aliases = if path.is_absolute() {
+      &self.absolute_alias
+    } else {
+      &self.relative_alias
+    };
+    if Self::path_alias_may_match(path, aliases) {
+      let alias_specifier = path.to_string_lossy();
+      if let Some(path) = self
+        .load_alias(cached_path, &alias_specifier, aliases, ctx)
+        .await?
+      {
+        return Ok(Some(path));
+      }
     }
     if cached_path.is_file(&self.cache.fs, ctx).await && self.check_restrictions(cached_path.path())
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,8 @@ mod tsconfig;
 #[cfg(test)]
 mod tests;
 
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
 use std::{
   borrow::Cow,
   cmp::Ordering,
@@ -692,20 +694,44 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       return Ok(None);
     }
     let path = path.path().as_os_str();
-    // 8 is wild guess for max extension length
-    let mut path_with_extension_buffer = String::with_capacity(path.len() + 8);
-    path_with_extension_buffer.push_str(&path.to_string_lossy());
-    let base_len = path_with_extension_buffer.len();
 
-    for extension in extensions {
-      path_with_extension_buffer.truncate(base_len);
-      path_with_extension_buffer.push_str(extension);
-      let cached_path = self.cache.value(Path::new(&path_with_extension_buffer));
-      if let Some(path) = self.load_alias_or_file(&cached_path, ctx).await? {
-        return Ok(Some(path));
+    #[cfg(unix)]
+    {
+      let path = path.as_bytes();
+      let mut path_with_extension_buffer = Vec::with_capacity(path.len() + 8);
+      path_with_extension_buffer.extend_from_slice(path);
+      let base_len = path_with_extension_buffer.len();
+
+      for extension in extensions {
+        path_with_extension_buffer.truncate(base_len);
+        path_with_extension_buffer.extend_from_slice(extension.as_bytes());
+        let cached_path = self
+          .cache
+          .value(Path::new(OsStr::from_bytes(&path_with_extension_buffer)));
+        if let Some(path) = self.load_alias_or_file(&cached_path, ctx).await? {
+          return Ok(Some(path));
+        }
       }
+      return Ok(None);
     }
-    Ok(None)
+
+    #[cfg(not(unix))]
+    {
+      // 8 is wild guess for max extension length
+      let mut path_with_extension_buffer = String::with_capacity(path.len() + 8);
+      path_with_extension_buffer.push_str(&path.to_string_lossy());
+      let base_len = path_with_extension_buffer.len();
+
+      for extension in extensions {
+        path_with_extension_buffer.truncate(base_len);
+        path_with_extension_buffer.push_str(extension);
+        let cached_path = self.cache.value(Path::new(&path_with_extension_buffer));
+        if let Some(path) = self.load_alias_or_file(&cached_path, ctx).await? {
+          return Ok(Some(path));
+        }
+      }
+      Ok(None)
+    }
   }
 
   #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %cached_path.path().to_string_lossy())))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,11 +197,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       return true;
     };
     aliases.iter().any(|(alias_key_raw, _)| {
-      if let Some(alias_key) = alias_key_raw.strip_suffix('$') {
-        alias_key == path
-      } else {
-        Self::strip_package_name(path, alias_key_raw).is_some()
-      }
+      alias_key_raw.strip_suffix('$').map_or_else(
+        || Self::strip_package_name(path, alias_key_raw).is_some(),
+        |alias_key| alias_key == path,
+      )
     })
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,10 @@ pub type Resolver = ResolverGeneric<FileSystemOs>;
 /// Generic implementation of the resolver, can be configured by the [FileSystem] trait
 pub struct ResolverGeneric<Fs> {
   options: ResolveOptions,
+  absolute_alias: Alias,
+  relative_alias: Alias,
+  absolute_fallback: Alias,
+  relative_fallback: Alias,
   cache: Arc<Cache<Fs>>,
   #[cfg(feature = "yarn_pnp")]
   pnp_manifest: Arc<arc_swap::ArcSwapOption<(PathBuf, pnp::Manifest)>>,
@@ -139,8 +143,15 @@ impl<Fs: Send + Sync + FileSystem + Default> Default for ResolverGeneric<Fs> {
 
 impl<Fs: Send + Sync + FileSystem + Default> ResolverGeneric<Fs> {
   pub fn new(options: ResolveOptions) -> Self {
+    let options = options.sanitize();
+    let (absolute_alias, relative_alias) = Self::partition_alias(&options.alias);
+    let (absolute_fallback, relative_fallback) = Self::partition_alias(&options.fallback);
     Self {
-      options: options.sanitize(),
+      options,
+      absolute_alias,
+      relative_alias,
+      absolute_fallback,
+      relative_fallback,
       cache: Arc::new(Cache::new(Fs::default())),
       #[cfg(feature = "yarn_pnp")]
       pnp_manifest: Arc::new(arc_swap::ArcSwapOption::empty()),
@@ -152,9 +163,42 @@ impl<Fs: Send + Sync + FileSystem + Default> ResolverGeneric<Fs> {
 }
 
 impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
+  fn partition_alias(aliases: &Alias) -> (Alias, Alias) {
+    let mut absolute_alias = Vec::new();
+    let mut relative_alias = Vec::new();
+    for (key, values) in aliases {
+      let key_without_exact = key.strip_suffix('$').unwrap_or(key);
+      if Path::new(key_without_exact).is_absolute() {
+        absolute_alias.push((key.clone(), values.clone()));
+      } else {
+        relative_alias.push((key.clone(), values.clone()));
+      }
+    }
+    (absolute_alias, relative_alias)
+  }
+
+  fn aliases_for<'a>(
+    specifier: &str,
+    absolute_aliases: &'a Alias,
+    relative_aliases: &'a Alias,
+  ) -> &'a Alias {
+    if Path::new(specifier).is_absolute() {
+      absolute_aliases
+    } else {
+      relative_aliases
+    }
+  }
+
   pub fn new_with_file_system(file_system: Fs, options: ResolveOptions) -> Self {
+    let options = options.sanitize();
+    let (absolute_alias, relative_alias) = Self::partition_alias(&options.alias);
+    let (absolute_fallback, relative_fallback) = Self::partition_alias(&options.fallback);
     Self {
-      options: options.sanitize(),
+      options,
+      absolute_alias,
+      relative_alias,
+      absolute_fallback,
+      relative_fallback,
       cache: Arc::new(Cache::new(file_system)),
       #[cfg(feature = "yarn_pnp")]
       pnp_manifest: Arc::new(arc_swap::ArcSwapOption::empty()),
@@ -167,8 +211,15 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   /// Clone the resolver using the same underlying cache.
   #[must_use]
   pub fn clone_with_options(&self, options: ResolveOptions) -> Self {
+    let options = options.sanitize();
+    let (absolute_alias, relative_alias) = Self::partition_alias(&options.alias);
+    let (absolute_fallback, relative_fallback) = Self::partition_alias(&options.fallback);
     Self {
-      options: options.sanitize(),
+      options,
+      absolute_alias,
+      relative_alias,
+      absolute_fallback,
+      relative_fallback,
       cache: Arc::clone(&self.cache),
       #[cfg(feature = "yarn_pnp")]
       pnp_manifest: Arc::clone(&self.pnp_manifest),
@@ -332,7 +383,12 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
     // enhanced-resolve: try alias
     if let Some(path) = self
-      .load_alias(cached_path, specifier, &self.options.alias, ctx)
+      .load_alias(
+        cached_path,
+        specifier,
+        Self::aliases_for(specifier, &self.absolute_alias, &self.relative_alias),
+        ctx,
+      )
       .await?
     {
       return Ok(path);
@@ -372,7 +428,12 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
         }
         // enhanced-resolve: try fallback
         self
-          .load_alias(cached_path, specifier, &self.options.fallback, ctx)
+          .load_alias(
+            cached_path,
+            specifier,
+            Self::aliases_for(specifier, &self.absolute_fallback, &self.relative_fallback),
+            ctx,
+          )
           .await
           .and_then(|value| value.ok_or(err))
       }
@@ -826,7 +887,12 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     // enhanced-resolve: try file as alias
     let alias_specifier = cached_path.path().to_string_lossy();
     if let Some(path) = self
-      .load_alias(cached_path, &alias_specifier, &self.options.alias, ctx)
+      .load_alias(
+        cached_path,
+        &alias_specifier,
+        Self::aliases_for(&alias_specifier, &self.absolute_alias, &self.relative_alias),
+        ctx,
+      )
       .await?
     {
       return Ok(Some(path));
@@ -1276,12 +1342,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     aliases: &Alias,
     ctx: &mut Ctx,
   ) -> ResolveResult {
-    let specifier_is_absolute = Path::new(specifier).is_absolute();
     for (alias_key_raw, specifiers) in aliases {
-      let alias_key_without_exact = alias_key_raw.strip_suffix('$').unwrap_or(alias_key_raw);
-      if specifier_is_absolute && !Path::new(alias_key_without_exact).is_absolute() {
-        continue;
-      }
       let alias_key = if let Some(alias_key) = alias_key_raw.strip_suffix('$') {
         if alias_key != specifier {
           continue;

--- a/src/tests/dependencies.rs
+++ b/src/tests/dependencies.rs
@@ -99,14 +99,19 @@ mod windows {
     for (name, context, request, result, file_dependencies, missing_dependencies) in data {
       let mut ctx = ResolveContext::default();
       let path = PathBuf::from(context);
-      let resolved = resolver
+      let resolution = resolver
         .resolve_with_context(path, request, &mut ctx)
         .await
         .map(|r| r.full_path());
-      assert_eq!(resolved, Ok(PathBuf::from(result)));
-      let file_dependencies = FxHashSet::from_iter(file_dependencies.iter().map(PathBuf::from));
-      let missing_dependencies =
-        FxHashSet::from_iter(missing_dependencies.iter().map(PathBuf::from));
+      assert_eq!(resolution, Ok(PathBuf::from(result)));
+      let file_dependencies = file_dependencies
+        .iter()
+        .map(PathBuf::from)
+        .collect::<FxHashSet<_>>();
+      let missing_dependencies = missing_dependencies
+        .iter()
+        .map(PathBuf::from)
+        .collect::<FxHashSet<_>>();
       assert_eq!(ctx.file_dependencies, file_dependencies, "{name}");
       assert_eq!(ctx.missing_dependencies, missing_dependencies, "{name}");
     }

--- a/src/tests/exports_field.rs
+++ b/src/tests/exports_field.rs
@@ -393,7 +393,7 @@ fn exports_field(value: simd_json::value::OwnedValue) -> package_json::JSONValue
 
 #[tokio::test]
 async fn test_cases() {
-  let test_cases = [
+  let test_cases = vec![
     TestCase {
       name: "sample #1",
       expect: Some(vec!["./dist/test/file.js"]),

--- a/src/tests/incorrect_description_file.rs
+++ b/src/tests/incorrect_description_file.rs
@@ -38,7 +38,7 @@ async fn incorrect_description_file_2() {
     message: String::from("EOF while parsing a value at line 1 column 0"),
     line: 1,
     column: 0,
-    content: Some("".to_string()),
+    content: Some(String::new()),
   });
   assert!(matches!(resolution, Err(ResolveError::JSON(_))));
 }

--- a/src/tests/missing.rs
+++ b/src/tests/missing.rs
@@ -98,8 +98,8 @@ async fn alias_and_extensions() {
   });
 
   let mut ctx = ResolveContext::default();
-  let _ = resolver.resolve_with_context(&f, "@scope-js/package-name/dir/router", &mut ctx);
-  let _ = resolver.resolve_with_context(&f, "react-dom/client", &mut ctx);
+  std::mem::drop(resolver.resolve_with_context(&f, "@scope-js/package-name/dir/router", &mut ctx));
+  std::mem::drop(resolver.resolve_with_context(&f, "react-dom/client", &mut ctx));
 
   for path in ctx.file_dependencies {
     assert_eq!(path, path.normalize(), "{path:?}");

--- a/src/tests/package_json.rs
+++ b/src/tests/package_json.rs
@@ -9,7 +9,7 @@ mod tests {
     let mock_path = PathBuf::from("package.json");
     let json_with_bom = b"\xEF\xBB\xBF{\"name\": \"example-package\"}".to_vec();
 
-    let result = PackageJson::parse(mock_path.clone(), mock_path.clone(), json_with_bom).err();
+    let result = PackageJson::parse(mock_path.clone(), mock_path, json_with_bom).err();
 
     assert_eq!(
       result,
@@ -23,9 +23,9 @@ mod tests {
   #[tokio::test]
   async fn test_normal_json() {
     let mock_path = PathBuf::from("package.json");
-    let json_with_bom = r##"{"name": "example-package"}"##.as_bytes().to_vec();
+    let json_with_bom = br#"{"name": "example-package"}"#.to_vec();
 
-    let parsed = PackageJson::parse(mock_path.clone(), mock_path.clone(), json_with_bom).unwrap();
+    let parsed = PackageJson::parse(mock_path.clone(), mock_path, json_with_bom).unwrap();
 
     assert_eq!(parsed.name.unwrap(), "example-package");
   }
@@ -33,9 +33,9 @@ mod tests {
   #[tokio::test]
   async fn test_broken_json() {
     let mock_path = PathBuf::from("package.json");
-    let json_with_bom = r##"{"broken":"string"##.as_bytes().to_vec();
+    let json_with_bom = br#"{"broken":"string"#.to_vec();
 
-    let parsed_err = PackageJson::parse(mock_path.clone(), mock_path.clone(), json_with_bom).err();
+    let parsed_err = PackageJson::parse(mock_path.clone(), mock_path, json_with_bom).err();
 
     assert_eq!(
       parsed_err,
@@ -50,9 +50,9 @@ mod tests {
   #[tokio::test]
   async fn test_empty_string() {
     let mock_path = PathBuf::from("package.json");
-    let json_with_bom = "    ".as_bytes().to_vec();
+    let json_with_bom = b"    ".to_vec();
 
-    let parse_error = PackageJson::parse(mock_path.clone(), mock_path.clone(), json_with_bom)
+    let parse_error = PackageJson::parse(mock_path.clone(), mock_path, json_with_bom)
       .err()
       .unwrap();
 

--- a/src/tests/pnp.rs
+++ b/src/tests/pnp.rs
@@ -201,13 +201,13 @@ async fn resolve_pnp_with_global_cache_enabled_windows() {
     ..ResolveOptions::default()
   });
 
-  let resolved = resolver
+  let resolution = resolver
     .resolve(&fixture, "path-to-regexp")
     .await
     .map(|r| r.full_path())
     .unwrap();
 
-  let module_root = resolved.parent().unwrap();
+  let module_root = resolution.parent().unwrap();
   let module_root_str = module_root.to_string_lossy().replace('\\', "/");
   assert!(
     module_root_str.contains("/Yarn/Berry/cache/path-to-regexp"),
@@ -241,13 +241,13 @@ async fn resolve_pnp_with_global_cache_enabled_unix() {
     ..ResolveOptions::default()
   });
 
-  let resolved = resolver
+  let resolution = resolver
     .resolve(&fixture, "path-to-regexp")
     .await
     .map(|r| r.full_path())
     .unwrap();
 
-  let module_root = resolved.parent().unwrap();
+  let module_root = resolution.parent().unwrap();
   let module_root_str = module_root.to_string_lossy();
   assert!(
     module_root_str.contains("/.yarn/berry/cache/path-to-regexp"),
@@ -292,7 +292,6 @@ async fn resolve_pnp_transitive_dep_from_global_cache() {
         .to_string_lossy()
         .replace('\\', "/")
         .to_lowercase()
-        .to_string()
     })
     .unwrap();
 

--- a/src/tests/restrictions.rs
+++ b/src/tests/restrictions.rs
@@ -14,7 +14,7 @@ async fn should_respect_regexp_restriction() {
   let resolver1 = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
     restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-      path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
+      path.as_os_str().to_str().is_some_and(|s| re.is_match(s))
     }))],
     ..ResolveOptions::default()
   });
@@ -32,7 +32,7 @@ async fn should_try_to_find_alternative_1() {
     extensions: vec![".js".into(), ".css".into()],
     main_files: vec!["index".into()],
     restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-      path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
+      path.as_os_str().to_str().is_some_and(|s| re.is_match(s))
     }))],
     ..ResolveOptions::default()
   });
@@ -65,7 +65,7 @@ async fn should_try_to_find_alternative_2() {
     extensions: vec![".js".into(), ".css".into()],
     main_fields: vec!["main".into(), "style".into()],
     restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-      path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
+      path.as_os_str().to_str().is_some_and(|s| re.is_match(s))
     }))],
     ..ResolveOptions::default()
   });
@@ -83,7 +83,7 @@ async fn should_try_to_find_alternative_3() {
     extensions: vec![".js".into()],
     main_fields: vec!["main".into(), "module".into(), "style".into()],
     restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-      path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
+      path.as_os_str().to_str().is_some_and(|s| re.is_match(s))
     }))],
     ..ResolveOptions::default()
   });
@@ -102,7 +102,7 @@ async fn should_try_to_find_alternative_4() {
     main_fields: vec!["main".into()],
     extension_alias: vec![(".js".into(), vec![".js".into(), ".jsx".into()])],
     restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-      path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
+      path.as_os_str().to_str().is_some_and(|s| re.is_match(s))
     }))],
     ..ResolveOptions::default()
   });

--- a/src/tests/symlink.rs
+++ b/src/tests/symlink.rs
@@ -1,6 +1,6 @@
 use std::{fs, io, path::Path};
 
-use crate::{ResolveOptions, Resolver};
+use crate::{ResolveContext, ResolveOptions, Resolver};
 
 #[derive(Debug, Clone, Copy)]
 enum FileType {
@@ -141,7 +141,7 @@ async fn test() -> io::Result<()> {
       .map(|r| r.full_path());
     assert_eq!(filename, Ok(root.join("lib/index.js")), "{comment:?}");
 
-    let mut ctx = &mut Default::default();
+    let mut ctx = ResolveContext::default();
     let resolved_path = resolver_without_symlinks
       .resolve_with_context(&path, request, &mut ctx)
       .await

--- a/src/tests/tsconfig_paths.rs
+++ b/src/tests/tsconfig_paths.rs
@@ -35,7 +35,7 @@ async fn tsconfig() {
       }),
       ..ResolveOptions::default()
     });
-    let path = subdir.map_or(dir.clone(), |subdir| dir.join(subdir));
+    let path = subdir.map_or_else(|| dir.clone(), |subdir| dir.join(subdir));
     let resolved_path = resolver
       .resolve(&path, request)
       .await

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -43,7 +43,7 @@ async fn package_json() {
   let package_json = resolution.package_json().unwrap();
   assert_eq!(package_json.name.as_ref().unwrap(), "name");
   assert_eq!(package_json.r#type, Some(ModuleType::Module));
-  assert!(matches!(package_json.side_effects, Some(_)));
+  assert!(package_json.side_effects.is_some());
 }
 
 #[cfg(feature = "package_json_raw_json_api")]


### PR DESCRIPTION
## Goal

Micro-optimize the resolver normal path by at least 5% using exact Callgrind instruction references as the primary metric.

## Benchmark

Target benchmark:

```bash
RUSTFLAGS="-C debuginfo=1 -C strip=none -g" cargo codspeed build
CODSPEED_CARGO_WORKSPACE_ROOT=$PWD valgrind --tool=callgrind --callgrind-out-file="$out_dir/callgrind.out.%p" "$bench_bin" "benches/resolver.rs::resolver::bench_resolver::resolver[single-thread]" --exact
```

Metric: Callgrind `Ir` from CodSpeed Valgrind.

Baseline: `116,917,041` Ir.
5% target threshold: `111,071,189` Ir.
Final: `109,733,110` Ir (`-7,183,931`, `-6.15%`).

## Changes and Measurements

| Commit | Ir | Delta vs baseline | Check | Notes |
| --- | ---: | ---: | --- | --- |
| `05be16b` | `116,554,214` | `-362,827` (`-0.31%`) | `cargo test --lib -- --skip tests::pnp` | Avoid UTF-8 conversion while appending extensions on Unix. |
| `16c1795` | `114,956,513` | `-1,960,528` (`-1.68%`) | `cargo test --lib -- --skip tests::pnp` | Skip impossible bare alias checks for absolute requests. |
| `278d640` | `112,025,825` | `-4,891,216` (`-4.18%`) | `cargo test --lib -- --skip tests::pnp` | Partition aliases and fallback aliases by absolute vs relative request kind. |
| `e6517c6` | `109,733,110` | `-7,183,931` (`-6.15%`) | `cargo test --lib -- --skip tests::pnp` | Precheck path aliases before path-to-string conversion. |

## Artifacts

- Baseline: `optimization-artifacts/valgrind/callgrind/20260517T043326Z-single-thread-baseline/`
- Unix extension buffer: `optimization-artifacts/valgrind/callgrind/20260517T043726Z-single-thread-unix-extension-buffer/`
- Absolute alias filter: `optimization-artifacts/valgrind/callgrind/20260517T044703Z-single-thread-absolute-alias-filter/`
- Partition aliases: `optimization-artifacts/valgrind/callgrind/20260517T045216Z-single-thread-partition-aliases/`
- Path alias precheck: `optimization-artifacts/valgrind/callgrind/20260517T045641Z-single-thread-path-alias-precheck/`
- Final clean measurement: `optimization-artifacts/valgrind/callgrind/20260517T045822Z-single-thread-final/`

## Test Status

`cargo test --lib -- --skip tests::pnp` passes (`123 passed`).

A full `cargo test --lib` still fails the existing PnP fixture cases (`125 passed; 6 failed`) with `NotFound` fixture paths. Those failures were observed before these perf changes and are tracked here as a residual environment/fixture gap, not as a new regression from this branch.

## Status

Target achieved for exact `resolver[single-thread]`: `109,733,110` Ir is `6.15%` below the clean baseline.