### PR TITLE
refactor: refactor utf8 path conversions

### DIFF
--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -26,7 +26,13 @@ pub struct ResolveResult {
 async fn resolve(resolver: &Resolver, path: &Path, request: &str) -> ResolveResult {
   match resolver.resolve(path, request).await {
     Ok(resolution) => ResolveResult {
-      path: Some(resolution.full_path().to_string_lossy().to_string()),
+      path: Some(
+        resolution
+          .full_path()
+          .to_str()
+          .expect("path should be UTF-8")
+          .to_string(),
+      ),
       error: None,
       module_type: resolution
         .package_json()

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -263,7 +263,12 @@ impl FileSystem for FileSystemOs {
           path_buf.pop();
         }
         Component::Normal(seg) => {
-          path_buf.push(seg.to_string_lossy().trim_end_matches('\0'));
+          path_buf.push(
+            seg
+              .to_str()
+              .expect("path should be UTF-8")
+              .trim_end_matches('\0'),
+          );
         }
         Component::RootDir => {
           path_buf = PathBuf::from("/");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ use crate::{
   cache::{Cache, CachedPath},
   context::ResolveContext as Ctx,
   package_json::JSONMap,
-  path::{PathUtil, SLASH_START},
+  path::{path_to_str, PathUtil, SLASH_START},
   specifier::Specifier,
   tsconfig::{ExtendsField, ProjectReference, TsConfig},
 };
@@ -239,7 +239,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   }
 
   /// Wrap `resolve_impl` with `tracing` information
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %directory.to_string_lossy(), specifier = specifier)))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(directory), specifier = specifier)))]
   async fn resolve_tracing(
     &self,
     directory: &Path,
@@ -436,7 +436,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   }
 
   // 3. If X begins with './' or '/' or '../'
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = %cached_path.path().to_string_lossy())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
   async fn require_relative(
     &self,
     cached_path: &CachedPath,
@@ -536,7 +536,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     Ok((parsed, None))
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = %cached_path.path().to_string_lossy())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
   async fn load_package_self_or_node_modules(
     &self,
     cached_path: &CachedPath,
@@ -590,7 +590,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     Ok(None)
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %cached_path.path().to_string_lossy())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(cached_path.path()))))]
   async fn load_as_file(&self, cached_path: &CachedPath, ctx: &mut Ctx) -> ResolveResult {
     // enhanced-resolve feature: extension_alias
     if let Some(path) = self.load_extension_alias(cached_path, ctx).await? {
@@ -653,7 +653,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     self.load_index(cached_path, ctx).await
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = %cached_path.path().to_string_lossy())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
   async fn load_as_file_or_directory(
     &self,
     cached_path: &CachedPath,
@@ -681,7 +681,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     Ok(None)
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %path.path().to_string_lossy())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(path.path()))))]
   async fn load_extensions(
     &self,
     path: &CachedPath,
@@ -691,10 +691,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     if ctx.fully_specified {
       return Ok(None);
     }
-    let path = path.path().as_os_str();
+    let path = path_to_str(path.path());
     // 8 is wild guess for max extension length
     let mut path_with_extension_buffer = String::with_capacity(path.len() + 8);
-    path_with_extension_buffer.push_str(&path.to_string_lossy());
+    path_with_extension_buffer.push_str(path);
     let base_len = path_with_extension_buffer.len();
 
     for extension in extensions {
@@ -708,7 +708,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     Ok(None)
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %cached_path.path().to_string_lossy())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(cached_path.path()))))]
   async fn load_realpath(
     &self,
     cached_path: &CachedPath,
@@ -758,7 +758,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     true
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %cached_path.path().to_string_lossy())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(cached_path.path()))))]
   async fn load_index(&self, cached_path: &CachedPath, ctx: &mut Ctx) -> ResolveResult {
     for main_file in &self.options.main_files {
       let main_path = cached_path.path().normalize_with(main_file);
@@ -798,7 +798,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       }
     }
     // enhanced-resolve: try file as alias
-    let alias_specifier = cached_path.path().to_string_lossy();
+    let alias_specifier = path_to_str(cached_path.path());
     if let Some(path) = self
       .load_alias(cached_path, &alias_specifier, &self.options.alias, ctx)
       .await?
@@ -812,7 +812,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     Ok(None)
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = %cached_path.path().to_string_lossy())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
   async fn load_node_modules(
     &self,
     cached_path: &CachedPath,
@@ -956,7 +956,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   }
 
   #[cfg(feature = "yarn_pnp")]
-  #[cfg_attr(feature = "enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %cached_path.path().to_string_lossy())))]
+  #[cfg_attr(feature = "enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(cached_path.path()))))]
   fn find_pnp_manifest(&self, cached_path: &CachedPath) -> Option<Arc<(PathBuf, pnp::Manifest)>> {
     // 1. Already have a manifest → return it (covers global cache paths too)
     if let Some(manifest) = self.pnp_manifest.load_full() {
@@ -1000,7 +1000,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   }
 
   #[cfg(feature = "yarn_pnp")]
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = %cached_path.path().to_string_lossy())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
   async fn load_pnp(
     &self,
     cached_path: &CachedPath,
@@ -1108,7 +1108,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     Ok(None)
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = %cached_path.path().to_string_lossy())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
   async fn load_package_self(
     &self,
     cached_path: &CachedPath,
@@ -1152,7 +1152,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   }
 
   /// RESOLVE_ESM_MATCH(MATCH)
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = %cached_path.path().to_string_lossy())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
   async fn resolve_esm_match(
     &self,
     specifier: &str,
@@ -1192,7 +1192,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   }
 
   /// enhanced-resolve: AliasFieldPlugin for [ResolveOptions::alias_fields]
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = module_specifier, path = %cached_path.path().to_string_lossy())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = module_specifier, path = path_to_str(cached_path.path()))))]
   async fn load_browser_field(
     &self,
     cached_path: &CachedPath,
@@ -1332,7 +1332,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
           Cow::Borrowed(alias_value)
         } else {
           let normalized = alias_path.normalize_with(tail);
-          Cow::Owned(normalized.to_string_lossy().to_string())
+          Cow::Owned(path_to_str(&normalized).to_string())
         }
       };
 
@@ -1397,14 +1397,14 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     // Create a meaningful error message.
     let dir = path.parent().unwrap().to_path_buf();
     let filename_without_extension = Path::new(filename).with_extension("");
-    let filename_without_extension = filename_without_extension.to_string_lossy();
+    let filename_without_extension = path_to_str(&filename_without_extension);
     let files = extensions
       .iter()
       .map(|ext| format!("{filename_without_extension}{ext}"))
       .collect::<Vec<_>>()
       .join(",");
     Err(ResolveError::ExtensionAlias(
-      filename.to_string_lossy().to_string(),
+      filename.to_str().expect("path should be UTF-8").to_string(),
       files,
       dir,
     ))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -800,7 +800,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     // enhanced-resolve: try file as alias
     let alias_specifier = path_to_str(cached_path.path());
     if let Some(path) = self
-      .load_alias(cached_path, &alias_specifier, &self.options.alias, ctx)
+      .load_alias(cached_path, alias_specifier, &self.options.alias, ctx)
       .await?
     {
       return Ok(Some(path));

--- a/src/path.rs
+++ b/src/path.rs
@@ -7,6 +7,10 @@ use std::path::{Component, Path, PathBuf};
 
 pub const SLASH_START: &[char; 2] = &['/', '\\'];
 
+pub(crate) fn path_to_str(path: &Path) -> &str {
+  path.to_str().expect("path should be UTF-8")
+}
+
 /// Extension trait to add path normalization to std's [`Path`].
 pub trait PathUtil {
   /// Normalize this path without performing I/O.

--- a/src/path.rs
+++ b/src/path.rs
@@ -7,7 +7,7 @@ use std::path::{Component, Path, PathBuf};
 
 pub const SLASH_START: &[char; 2] = &['/', '\\'];
 
-pub(crate) fn path_to_str(path: &Path) -> &str {
+pub fn path_to_str(path: &Path) -> &str {
   path.to_str().expect("path should be UTF-8")
 }
 

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -152,7 +152,7 @@ async fn infinite_recursion() {
 }
 
 fn check_slash(path: &Path) {
-  let s = path.to_string_lossy().to_string();
+  let s = path.to_str().expect("path should be UTF-8").to_string();
   #[cfg(target_os = "windows")]
   {
     assert!(!s.contains('/'), "{s}");
@@ -186,7 +186,9 @@ async fn system_path() {
   let resolver = Resolver::new(ResolveOptions {
     alias: vec![(
       "@app".into(),
-      vec![AliasValue::from(f.join("alias").to_string_lossy())],
+      vec![AliasValue::from(
+        f.join("alias").to_str().expect("path should be UTF-8"),
+      )],
     )],
     ..ResolveOptions::default()
   });
@@ -208,7 +210,7 @@ async fn system_path() {
 async fn alias_is_full_path() {
   let f = super::fixture();
   let dir = f.join("foo");
-  let dir_str = dir.to_string_lossy().to_string();
+  let dir_str = dir.to_str().expect("path should be UTF-8").to_string();
 
   let resolver = Resolver::new(ResolveOptions {
     alias: vec![("@".into(), vec![AliasValue::Path(dir_str.clone())])],
@@ -258,7 +260,8 @@ async fn all_alias_values_are_not_found() {
       vec![AliasValue::Path(
         f.join("node_modules")
           .join("m2")
-          .to_string_lossy()
+          .to_str()
+          .expect("path should be UTF-8")
           .to_string(),
       )],
     )],
@@ -318,7 +321,12 @@ async fn alias_try_fragment_as_path() {
   let resolver = Resolver::new(ResolveOptions {
     alias: vec![(
       "#".to_string(),
-      vec![AliasValue::Path(f.join("#").to_string_lossy().to_string())],
+      vec![AliasValue::Path(
+        f.join("#")
+          .to_str()
+          .expect("path should be UTF-8")
+          .to_string(),
+      )],
     )],
     ..ResolveOptions::default()
   });

--- a/src/tests/browser_field.rs
+++ b/src/tests/browser_field.rs
@@ -162,7 +162,9 @@ async fn crypto_js() {
     alias_fields: vec![vec!["browser".into()]],
     fallback: vec![(
       "crypto".into(),
-      vec![AliasValue::from(f.join("lib.js").to_string_lossy())],
+      vec![AliasValue::from(
+        f.join("lib.js").to_str().expect("path should be UTF-8"),
+      )],
     )],
     ..ResolveOptions::default()
   });

--- a/src/tests/memory_fs.rs
+++ b/src/tests/memory_fs.rs
@@ -5,6 +5,10 @@ use std::{
 
 use crate::{FileMetadata, FileSystem};
 
+fn path_to_str(path: &Path) -> &str {
+  path.to_str().expect("path should be UTF-8")
+}
+
 #[derive(Default)]
 pub struct MemoryFS {
   fs: vfs::MemoryFS,
@@ -32,13 +36,13 @@ impl MemoryFS {
     let fs = &mut self.fs;
     // Create all parent directories
     for path in path.ancestors().collect::<Vec<_>>().iter().rev() {
-      let path = path.to_string_lossy();
-      if !fs.exists(path.as_ref()).unwrap() {
-        fs.create_dir(path.as_ref()).unwrap();
+      let path = path_to_str(path);
+      if !fs.exists(path).unwrap() {
+        fs.create_dir(path).unwrap();
       }
     }
     // Create file
-    let mut file = fs.create_file(path.to_string_lossy().as_ref()).unwrap();
+    let mut file = fs.create_file(path_to_str(path)).unwrap();
     file.write_all(content.as_bytes()).unwrap();
   }
 }
@@ -48,7 +52,7 @@ impl FileSystem for MemoryFS {
     use vfs::FileSystem;
     let mut file = self
       .fs
-      .open_file(path.to_string_lossy().as_ref())
+      .open_file(path_to_str(path))
       .map_err(|err| io::Error::new(io::ErrorKind::NotFound, err))?;
     let mut buffer = String::new();
     file.read_to_string(&mut buffer).unwrap();
@@ -63,7 +67,7 @@ impl FileSystem for MemoryFS {
     use vfs::FileSystem;
     let metadata = self
       .fs
-      .metadata(path.to_string_lossy().as_ref())
+      .metadata(path_to_str(path))
       .map_err(|err| io::Error::new(io::ErrorKind::NotFound, err))?;
     let is_file = metadata.file_type == vfs::VfsFileType::File;
     let is_dir = metadata.file_type == vfs::VfsFileType::Directory;

--- a/src/tests/missing.rs
+++ b/src/tests/missing.rs
@@ -82,13 +82,19 @@ async fn alias_and_extensions() {
       (
         "@scope-js/package-name/dir$".into(),
         vec![AliasValue::Path(
-          f.join("foo/index.js").to_string_lossy().to_string(),
+          f.join("foo/index.js")
+            .to_str()
+            .expect("path should be UTF-8")
+            .to_string(),
         )],
       ),
       (
         "react-dom".into(),
         vec![AliasValue::Path(
-          f.join("foo/index.js").to_string_lossy().to_string(),
+          f.join("foo/index.js")
+            .to_str()
+            .expect("path should be UTF-8")
+            .to_string(),
         )],
       ),
     ],

--- a/src/tests/pnp.rs
+++ b/src/tests/pnp.rs
@@ -137,18 +137,25 @@ async fn pnp_resolve_description_file() {
     .join(
       ".yarn/cache/preact-npm-10.25.4-2dd2c0aa44-33a009d614.zip/node_modules/preact/dist/preact.js",
     )
-    .to_string_lossy()
+    .to_str()
+    .expect("path should be UTF-8")
     .to_string();
 
   let r = resolver.resolve(&fixture, &full_path).await.unwrap();
 
   assert_eq!(
-    r.package_json.unwrap().path.to_string_lossy().to_string(),
+    r.package_json
+      .unwrap()
+      .path
+      .to_str()
+      .expect("path should be UTF-8")
+      .to_string(),
     fixture
       .join(".yarn/cache/preact-npm-10.25.4-2dd2c0aa44-33a009d614.zip/node_modules/preact")
       .join("package.json")
       .normalize()
-      .to_string_lossy()
+      .to_str()
+      .expect("path should be UTF-8")
       .to_string()
   );
 }
@@ -208,7 +215,10 @@ async fn resolve_pnp_with_global_cache_enabled_windows() {
     .unwrap();
 
   let module_root = resolved.parent().unwrap();
-  let module_root_str = module_root.to_string_lossy().replace('\\', "/");
+  let module_root_str = module_root
+    .to_str()
+    .expect("path should be UTF-8")
+    .replace('\\', "/");
   assert!(
     module_root_str.contains("/Yarn/Berry/cache/path-to-regexp"),
     "Expected global cache path, got: {module_root_str}"
@@ -219,7 +229,8 @@ async fn resolve_pnp_with_global_cache_enabled_windows() {
     .await
     .map(|r| {
       r.full_path()
-        .to_string_lossy()
+        .to_str()
+        .expect("path should be UTF-8")
         .replace('\\', "/")
         .to_string()
     })
@@ -248,7 +259,7 @@ async fn resolve_pnp_with_global_cache_enabled_unix() {
     .unwrap();
 
   let module_root = resolved.parent().unwrap();
-  let module_root_str = module_root.to_string_lossy();
+  let module_root_str = module_root.to_str().expect("path should be UTF-8");
   assert!(
     module_root_str.contains("/.yarn/berry/cache/path-to-regexp"),
     "Expected global cache path, got: {module_root_str}"
@@ -259,7 +270,7 @@ async fn resolve_pnp_with_global_cache_enabled_unix() {
     .await
     .map(|r| r.full_path())
     .unwrap();
-  let resolved_str = resolved_from_cache.to_string_lossy();
+  let resolved_str = resolved_from_cache.to_str().expect("path should be UTF-8");
   assert!(
     resolved_str.contains("/.yarn/berry/cache/path-to-regexp"),
     "Expected global cache path, got: {resolved_str}"
@@ -289,7 +300,8 @@ async fn resolve_pnp_transitive_dep_from_global_cache() {
     .await
     .map(|r| {
       r.full_path()
-        .to_string_lossy()
+        .to_str()
+        .expect("path should be UTF-8")
         .replace('\\', "/")
         .to_lowercase()
         .to_string()

--- a/src/tests/resolve.rs
+++ b/src/tests/resolve.rs
@@ -8,7 +8,11 @@ async fn resolve() {
 
   let resolver = Resolver::default();
 
-  let main1_js_path = f.join("main1.js").to_string_lossy().to_string();
+  let main1_js_path = f
+    .join("main1.js")
+    .to_str()
+    .expect("path should be UTF-8")
+    .to_string();
 
   #[rustfmt::skip]
     let pass = [

--- a/src/tests/roots.rs
+++ b/src/tests/roots.rs
@@ -73,7 +73,7 @@ async fn prefer_absolute() {
 
   #[rustfmt::skip]
     let pass = [
-        ("should resolve an absolute path (prefer absolute)", f.join("b.js").to_string_lossy().to_string(), f.join("b.js")),
+        ("should resolve an absolute path (prefer absolute)", f.join("b.js").to_str().expect("path should be UTF-8").to_string(), f.join("b.js")),
     ];
 
   for (comment, request, expected) in pass {
@@ -86,7 +86,7 @@ async fn prefer_absolute() {
 async fn roots_fall_through() {
   let f = super::fixture();
   let absolute_path = f.join("roots_fall_through/index.js");
-  let specifier = absolute_path.to_string_lossy();
+  let specifier = absolute_path.to_str().expect("path should be UTF-8");
   let resolution = Resolver::new(ResolveOptions::default().with_root(&f))
     .resolve(&f, &specifier)
     .await;

--- a/src/tests/windows.rs
+++ b/src/tests/windows.rs
@@ -36,7 +36,11 @@ mod tests {
       .resolve_with_context(&file, &specifier, &mut ctx)
       .await
       .unwrap();
-    let resolved_path_string = resolved.path.to_string_lossy().to_string();
+    let resolved_path_string = resolved
+      .path
+      .to_str()
+      .expect("path should be UTF-8")
+      .to_string();
     let actual_file_deps = ctx
       .file_dependencies
       .iter()
@@ -48,6 +52,10 @@ mod tests {
   }
 
   fn to_string<P: AsRef<Path>>(p: P) -> String {
-    p.as_ref().normalize().to_string_lossy().to_string()
+    p.as_ref()
+      .normalize()
+      .to_str()
+      .expect("path should be UTF-8")
+      .to_string()
   }
 }

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 use rustc_hash::FxHasher;
 use serde::Deserialize;
 
-use crate::PathUtil;
+use crate::path::{path_to_str, PathUtil};
 
 pub type CompilerOptionsPathsMap = IndexMap<String, Vec<String>, BuildHasherDefault<FxHasher>>;
 
@@ -78,7 +78,7 @@ pub struct ProjectReference {
 }
 
 impl TsConfig {
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %path.to_string_lossy())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(path))))]
   pub fn parse(root: bool, path: &Path, json: &mut str) -> Result<Self, serde_json::Error> {
     _ = json_strip_comments::strip(json);
     if json.trim().is_empty() {
@@ -121,16 +121,12 @@ impl TsConfig {
         }
       }
 
-      let mut p = self
-        .compiler_options
-        .paths_base
-        .to_string_lossy()
-        .to_string();
+      let mut p = path_to_str(&self.compiler_options.paths_base).to_string();
       Self::substitute_template_variable(&dir, &mut p);
       self.compiler_options.paths_base = p.into();
 
       if let Some(base_url) = self.compiler_options.base_url.as_mut() {
-        let mut p = base_url.to_string_lossy().to_string();
+        let mut p = path_to_str(base_url).to_string();
         Self::substitute_template_variable(&dir, &mut p);
         *base_url = p.into();
       }
@@ -262,9 +258,9 @@ impl TsConfig {
   fn substitute_template_variable(directory: &Path, path: &mut String) {
     if let Some(stripped_path) = path.strip_prefix(TEMPLATE_VARIABLE) {
       if let Some(unleashed_path) = stripped_path.strip_prefix("/") {
-        *path = directory.join(unleashed_path).to_string_lossy().to_string();
+        *path = path_to_str(&directory.join(unleashed_path)).to_string();
       } else {
-        *path = directory.join(stripped_path).to_string_lossy().to_string();
+        *path = path_to_str(&directory.join(stripped_path)).to_string();
       }
     }
   }


### PR DESCRIPTION
## What changed
Rspack support UTF8 only Path so it's not necessary for rspack-resolver to support non utf8-path
- Replaced lossy path-to-string conversions in resolver, tsconfig, filesystem, NAPI, and tests with strict UTF-8 conversions.
- Added a small shared `path_to_str` helper for core path assertions.
- Kept path extension and alias string construction on borrowed UTF-8 path strings where possible.

## Why

rspack-resolver only needs to support UTF-8 paths, so lossy conversions can silently hide invalid path data and add unnecessary conversion work.

## Performance notes

CodSpeed reports this PR improves three resolver benchmarks:

| Benchmark | Base | Head | Efficiency |
| --- | ---: | ---: | ---: |
| `resolver[multi-thread]` | 65.1 ms | 63 ms | +3.29% |
| `resolver[resolve from symlinks multi thread]` | 123.7 ms | 115.1 ms | +7.5% |
| `resolver[resolve from symlinks]` | 195.6 ms | 186 ms | +5.15% |

Local callgrind comparison for `resolver/resolve from symlinks` (`8975e38` -> `85e0cec`) shows the same direction:

| Metric | Base | Head | Delta |
| --- | ---: | ---: | ---: |
| `Ir` | 3,073,208,626 | 3,000,439,756 | -72,768,870 / -2.37% |
| `Dr` | 798,591,590 | 787,908,689 | -1.34% |
| `Dw` | 594,749,952 | 592,901,782 | -0.31% |
| accesses | 4,466,550,168 | 4,381,250,227 | -1.91% |

The main reason is removing the `core::str::lossy::Utf8Chunks::next` hot path from repeated `to_string_lossy()` calls. In the base profile it accounts for about `52.5M Ir`; after this PR it is replaced by cheaper strict UTF-8 validation (`core::str::converts::from_utf8`, about `7.7M Ir`). The affected hot paths are primarily `load_extensions` and `load_alias_or_file`, where resolver candidate paths are converted repeatedly.

Measurement command shape:

```bash
RUSTFLAGS='-C debuginfo=1 -C strip=none -g' cargo bench --bench resolver --no-run
valgrind --tool=callgrind --cache-sim=yes \
  --callgrind-out-file=optimization-artifacts/valgrind/callgrind/pr219-symbols/{base,head}/callgrind.out \
  target/release/deps/resolver-* 'resolve from symlinks'
```

## Validation

- `cargo fmt --all --check`
- `cargo check --workspace`
- `cargo check --workspace --features enable_instrument`
- `cargo clippy --all-features -- -D warnings`
- `cargo test -p rspack_resolver --lib -- --skip pnp`
- GitHub Actions PR checks are passing, including Clippy, tests, benchmark, coverage, build, doc, wasm, format.

Full `cargo test --workspace` was also run locally. It still fails on existing environment-sensitive fixtures: PnP tests need `fixtures/pnp/.pnp.cjs`, and integration resolve tests need local pnpm node_modules content.
