### PR TITLE
codex: use camino for UTF-8 path assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,6 +1027,7 @@ version = "0.8.0"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "camino",
  "cfg-if",
  "codspeed-criterion-compat",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,8 +84,8 @@ tracing = "0.1.41"
 
 simd-json = { version = "0.17.0", features = ["serde_impl", "runtime-detection"], default-features = false }
 
-cfg-if              = "1.0"
 camino              = "1.2.1"
+cfg-if              = "1.0"
 dunce               = "1.0.5"                                                             # Normalize Windows paths to the most compatible format, avoiding UNC where possible
 indexmap            = { version = "2.12.0", features = ["serde"] }
 json-strip-comments = "3.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ tracing = "0.1.41"
 simd-json = { version = "0.17.0", features = ["serde_impl", "runtime-detection"], default-features = false }
 
 cfg-if              = "1.0"
+camino              = "1.2.1"
 dunce               = "1.0.5"                                                             # Normalize Windows paths to the most compatible format, avoiding UNC where possible
 indexmap            = { version = "2.12.0", features = ["serde"] }
 json-strip-comments = "3.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ use crate::{
   cache::{Cache, CachedPath},
   context::ResolveContext as Ctx,
   package_json::JSONMap,
-  path::{path_to_str, PathUtil, SLASH_START},
+  path::{path_to_str, path_to_utf8, PathUtil, SLASH_START},
   specifier::Specifier,
   tsconfig::{ExtendsField, ProjectReference, TsConfig},
 };
@@ -691,7 +691,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     if ctx.fully_specified {
       return Ok(None);
     }
-    let path = path_to_str(path.path());
+    let path = path_to_utf8(path.path()).as_str();
     // 8 is wild guess for max extension length
     let mut path_with_extension_buffer = String::with_capacity(path.len() + 8);
     path_with_extension_buffer.push_str(path);
@@ -1332,7 +1332,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
           Cow::Borrowed(alias_value)
         } else {
           let normalized = alias_path.normalize_with(tail);
-          Cow::Owned(path_to_str(&normalized).to_string())
+          Cow::Owned(path_to_utf8(&normalized).as_str().to_string())
         }
       };
 
@@ -1397,14 +1397,14 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     // Create a meaningful error message.
     let dir = path.parent().unwrap().to_path_buf();
     let filename_without_extension = Path::new(filename).with_extension("");
-    let filename_without_extension = path_to_str(&filename_without_extension);
+    let filename_without_extension = path_to_utf8(&filename_without_extension).as_str();
     let files = extensions
       .iter()
       .map(|ext| format!("{filename_without_extension}{ext}"))
       .collect::<Vec<_>>()
       .join(",");
     Err(ResolveError::ExtensionAlias(
-      filename.to_str().expect("path should be UTF-8").to_string(),
+      path_to_utf8(Path::new(filename)).as_str().to_string(),
       files,
       dir,
     ))

--- a/src/path.rs
+++ b/src/path.rs
@@ -5,10 +5,16 @@
 //! * [normalize_path](https://docs.rs/normalize-path)
 use std::path::{Component, Path, PathBuf};
 
+use camino::Utf8Path;
+
 pub const SLASH_START: &[char; 2] = &['/', '\\'];
 
+pub fn path_to_utf8(path: &Path) -> &Utf8Path {
+  Utf8Path::from_path(path).expect("path should be UTF-8")
+}
+
 pub fn path_to_str(path: &Path) -> &str {
-  path.to_str().expect("path should be UTF-8")
+  path_to_utf8(path).as_str()
 }
 
 /// Extension trait to add path normalization to std's [`Path`].

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 use rustc_hash::FxHasher;
 use serde::Deserialize;
 
-use crate::path::{path_to_str, PathUtil};
+use crate::path::{path_to_utf8, PathUtil};
 
 pub type CompilerOptionsPathsMap = IndexMap<String, Vec<String>, BuildHasherDefault<FxHasher>>;
 
@@ -78,7 +78,7 @@ pub struct ProjectReference {
 }
 
 impl TsConfig {
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(path))))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_utf8(path).as_str())))]
   pub fn parse(root: bool, path: &Path, json: &mut str) -> Result<Self, serde_json::Error> {
     _ = json_strip_comments::strip(json);
     if json.trim().is_empty() {
@@ -121,12 +121,14 @@ impl TsConfig {
         }
       }
 
-      let mut p = path_to_str(&self.compiler_options.paths_base).to_string();
+      let mut p = path_to_utf8(&self.compiler_options.paths_base)
+        .as_str()
+        .to_string();
       Self::substitute_template_variable(&dir, &mut p);
       self.compiler_options.paths_base = p.into();
 
       if let Some(base_url) = self.compiler_options.base_url.as_mut() {
-        let mut p = path_to_str(base_url).to_string();
+        let mut p = path_to_utf8(base_url).as_str().to_string();
         Self::substitute_template_variable(&dir, &mut p);
         *base_url = p.into();
       }
@@ -258,9 +260,13 @@ impl TsConfig {
   fn substitute_template_variable(directory: &Path, path: &mut String) {
     if let Some(stripped_path) = path.strip_prefix(TEMPLATE_VARIABLE) {
       if let Some(unleashed_path) = stripped_path.strip_prefix("/") {
-        *path = path_to_str(&directory.join(unleashed_path)).to_string();
+        *path = path_to_utf8(&directory.join(unleashed_path))
+          .as_str()
+          .to_string();
       } else {
-        *path = path_to_str(&directory.join(stripped_path)).to_string();
+        *path = path_to_utf8(&directory.join(stripped_path))
+          .as_str()
+          .to_string();
       }
     }
   }


### PR DESCRIPTION
## What changed

- Adds `camino` and introduces `path_to_utf8(&Path) -> &Utf8Path` as the central UTF-8 path assertion helper.
- Reworks internal UTF-8 path string access in resolver and tsconfig code to go through `Utf8Path::as_str()`.
- Keeps the public API on `std::path` for now, so this stacked PR avoids a breaking API migration.

## Why

This builds on #219 by making the UTF-8-only path invariant explicit with a dedicated UTF-8 path type instead of ad hoc `Path::to_str()` assertions.

## Scope

This is intentionally a low-risk first camino step. It does not migrate public `PathBuf`/`Path` API types, filesystem traits, errors, or option structs to `Utf8PathBuf` yet. Those can be handled in follow-up PRs if we want a full public API migration.

## Validation

- `cargo fmt --all --check`
- `cargo check --workspace`
- `cargo clippy --all-features -- -D warnings`
- `cargo test -p rspack_resolver --lib -- --skip pnp`
