### PR TITLE
[codex] Use camino UTF-8 path API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1016,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 name = "rspack_napi_resolver"
 version = "0.0.0"
 dependencies = [
+ "camino",
  "napi",
  "napi-build",
  "napi-derive",
@@ -1021,6 +1031,7 @@ version = "0.8.0"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "camino",
  "cfg-if",
  "codspeed-criterion-compat",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ multiple_crate_versions = "allow"
 name = "resolver"
 
 [dependencies]
+camino = { version = "1.1.12", features = ["serde1"] }
 dashmap = "6.1.0"
 serde = { version = "1.0.228", features = ["derive"] } # derive for Deserialize from package.json
 serde_json = { version = "1.0.145", features = [

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -6,10 +6,10 @@ use std::{
   fs::read_to_string,
   future::Future,
   io::{self, Write},
-  path::{Path, PathBuf},
   sync::Arc,
 };
 
+use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 #[global_allocator]
 #[cfg(not(target_family = "wasm"))]
 static GLOBAL: NeverGrowInPlaceAllocator<mimalloc::MiMalloc> =
@@ -57,17 +57,19 @@ use tokio::{
 fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
   #[cfg(target_family = "unix")]
   {
-    std::os::unix::fs::symlink(original, link)
+    std::os::unix::fs::symlink(original.as_ref().as_std_path(), link.as_ref().as_std_path())
   }
 
   #[cfg(target_family = "windows")]
   {
-    std::os::windows::fs::symlink_file(original, link)
+    std::os::windows::fs::symlink_file(original.as_ref().as_std_path(), link.as_ref().as_std_path())
   }
 }
 
 fn create_symlinks() -> io::Result<PathBuf> {
-  let root = env::current_dir()?.join("fixtures/enhanced_resolve");
+  let root = PathBuf::from_path_buf(env::current_dir()?)
+    .map_err(|path| io::Error::new(io::ErrorKind::InvalidData, path.display().to_string()))?
+    .join("fixtures/enhanced_resolve");
   let dirname = root.join("test");
   let temp_path = dirname.join("temp_symlinks");
   let create_symlink_fixtures = || -> io::Result<()> {
@@ -181,7 +183,9 @@ fn create_async_resolve_task(
 }
 
 fn bench_resolver(c: &mut Criterion) {
-  let cwd = env::current_dir().unwrap().join("benches");
+  let cwd = PathBuf::from_path_buf(env::current_dir().unwrap())
+    .unwrap()
+    .join("benches");
 
   let pkg_content = read_to_string("./benches/package.json").unwrap();
   let pkg_json: Value = serde_json::from_str(&pkg_content).unwrap();
@@ -367,7 +371,9 @@ fn bench_resolver(c: &mut Criterion) {
     },
   );
 
-  let pnp_workspace = env::current_dir().unwrap().join("fixtures/pnp");
+  let pnp_workspace = PathBuf::from_path_buf(env::current_dir().unwrap())
+    .unwrap()
+    .join("fixtures/pnp");
   let root_range = 1..11;
 
   group.bench_with_input(

--- a/examples/resolver.rs
+++ b/examples/resolver.rs
@@ -1,6 +1,7 @@
 ///! See documentation at <https://docs.rs/rspack_resolver>
-use std::{env, path::PathBuf};
+use std::env;
 
+use camino::Utf8PathBuf as PathBuf;
 use rspack_resolver::{AliasValue, ResolveOptions, Resolver};
 
 #[tokio::main]

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -10,6 +10,7 @@ doctest    = false
 test       = false
 
 [dependencies]
+camino             = "1.2.2"
 napi               = { version = "3.5.2", default-features = false, features = ["napi3", "serde-json", "async"] }
 napi-build         = { version = "2.3.1", default-features = false }
 napi-derive        = { version = "3.3.3" }

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -1,12 +1,9 @@
 mod options;
 mod tracing;
 
-use std::{
-  path::{Path, PathBuf},
-  sync::Arc,
-  vec,
-};
+use std::{sync::Arc, vec};
 
+use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 use napi::tokio::runtime;
 use napi_derive::napi;
 use rspack_resolver::{ResolveOptions, Resolver};
@@ -26,13 +23,7 @@ pub struct ResolveResult {
 async fn resolve(resolver: &Resolver, path: &Path, request: &str) -> ResolveResult {
   match resolver.resolve(path, request).await {
     Ok(resolution) => ResolveResult {
-      path: Some(
-        resolution
-          .full_path()
-          .to_str()
-          .expect("path should be UTF-8")
-          .to_string(),
-      ),
+      path: Some(resolution.full_path().as_str().to_string()),
       error: None,
       module_type: resolution
         .package_json()

--- a/napi/src/options.rs
+++ b/napi/src/options.rs
@@ -1,5 +1,6 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
+use camino::Utf8PathBuf as PathBuf;
 use napi::bindgen_prelude::{Either, Either3};
 use napi_derive::napi;
 use regex::Regex;
@@ -223,9 +224,7 @@ impl From<Restriction> for rspack_resolver::Restriction {
       }
       (None, Some(regex)) => {
         let re = Regex::new(&regex).unwrap_or_else(|_| panic!("Invalid regex pattern: {regex}"));
-        Self::Fn(Arc::new(move |path| {
-          re.is_match(path.to_str().unwrap_or_default())
-        }))
+        Self::Fn(Arc::new(move |path| re.is_match(path.as_str())))
       }
       (Some(path), None) => Self::Path(PathBuf::from(path)),
       (Some(_), Some(_)) => {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -5,10 +5,10 @@ use std::{
   hash::{BuildHasherDefault, Hash, Hasher},
   io,
   ops::Deref,
-  path::{Path, PathBuf},
   sync::Arc,
 };
 
+use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 use dashmap::{DashMap, DashSet};
 use futures::future::BoxFuture;
 use rustc_hash::FxHasher;
@@ -80,9 +80,7 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
     } else if meta.is_some_and(|m| m.is_dir) {
       Cow::Owned(path.join("tsconfig.json"))
     } else {
-      let mut os_string = path.to_path_buf().into_os_string();
-      os_string.push(".json");
-      Cow::Owned(PathBuf::from(os_string))
+      Cow::Owned(PathBuf::from(format!("{path}.json")))
     };
     let mut tsconfig_string = self
       .fs
@@ -228,7 +226,7 @@ impl CachedPathImpl {
           if let Some(parent) = self.parent() {
             let parent_path = parent.realpath(fs).await?;
             return Ok(Some(
-              parent_path.normalize_with(self.path.strip_prefix(&parent.path).unwrap()),
+              parent_path.normalize_with(self.path.strip_prefix(&*parent.path).unwrap()),
             ));
           }
           Ok(None)
@@ -270,7 +268,7 @@ impl CachedPathImpl {
   /// # Errors
   ///
   /// * [ResolveError::JSON]
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %self.path.display())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %self.path)))]
   pub async fn find_package_json<Fs: FileSystem + Send + Sync>(
     &self,
     fs: &Fs,
@@ -301,7 +299,7 @@ impl CachedPathImpl {
   /// # Errors
   ///
   /// * [ResolveError::JSON]
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %self.path.display())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %self.path)))]
   pub async fn package_json<Fs: FileSystem + Send + Sync>(
     &self,
     fs: &Fs,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -43,11 +43,7 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
   }
 
   pub fn value(&self, path: &Path) -> CachedPath {
-    let hash = {
-      let mut hasher = FxHasher::default();
-      path.hash(&mut hasher);
-      hasher.finish()
-    };
+    let hash = path_hash(path);
     if let Some(cache_entry) = self.paths.get((hash, path).borrow() as &dyn CacheKey) {
       return cache_entry.clone();
     }
@@ -115,7 +111,7 @@ impl Hash for CachedPath {
 
 impl PartialEq for CachedPath {
   fn eq(&self, other: &Self) -> bool {
-    self.0.path == other.0.path
+    self.0.path.as_std_path() == other.0.path.as_std_path()
   }
 }
 impl Eq for CachedPath {}
@@ -388,7 +384,7 @@ impl Hash for dyn CacheKey + '_ {
 
 impl PartialEq for dyn CacheKey + '_ {
   fn eq(&self, other: &Self) -> bool {
-    self.tuple().1 == other.tuple().1
+    self.tuple().1.as_std_path() == other.tuple().1.as_std_path()
   }
 }
 
@@ -404,6 +400,12 @@ impl<'a> Borrow<dyn CacheKey + 'a> for (u64, &'a Path) {
   fn borrow(&self) -> &(dyn CacheKey + 'a) {
     self
   }
+}
+
+fn path_hash(path: &Path) -> u64 {
+  let mut hasher = FxHasher::default();
+  path.as_std_path().hash(&mut hasher);
+  hasher.finish()
 }
 
 /// Since the cache key is memoized, use an identity hasher

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,7 +1,6 @@
-use std::{
-  ops::{Deref, DerefMut},
-  path::{Path, PathBuf},
-};
+use std::ops::{Deref, DerefMut};
+
+use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 
 use crate::error::ResolveError;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
-use std::{io, path::PathBuf, sync::Arc};
+use std::{io, sync::Arc};
 
+use camino::Utf8PathBuf as PathBuf;
 use thiserror::Error;
 
 /// All resolution errors

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -1,8 +1,8 @@
-use std::{
-  fs, io,
-  path::{Path, PathBuf},
-};
+use std::{fs, io};
 
+#[cfg(target_arch = "wasm32")]
+use camino::Utf8Component as Component;
+use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 #[cfg(not(target_arch = "wasm32"))]
 use cfg_if::cfg_if;
 #[cfg(feature = "yarn_pnp")]
@@ -144,6 +144,15 @@ impl FileSystemOs {
   }
 }
 
+fn into_utf8_path_buf(path: std::path::PathBuf) -> io::Result<PathBuf> {
+  PathBuf::from_path_buf(path).map_err(|path| {
+    io::Error::new(
+      io::ErrorKind::InvalidData,
+      format!("path is not valid UTF-8: {}", path.display()),
+    )
+  })
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 #[async_trait::async_trait]
 impl FileSystem for FileSystemOs {
@@ -151,7 +160,7 @@ impl FileSystem for FileSystemOs {
     cfg_if! {
       if #[cfg(feature = "yarn_pnp")] {
         if self.options.enable_pnp {
-            return match VPath::from(path)? {
+            return match VPath::from(path.as_std_path())? {
                 VPath::Zip(info) => self.pnp_lru.read(info.physical_base_path(), info.zip_path),
                 VPath::Virtual(info) => tokio::fs::read(info.physical_base_path()).await,
                 VPath::Native(path) => tokio::fs::read(&path).await,
@@ -159,14 +168,14 @@ impl FileSystem for FileSystemOs {
         }
     }}
 
-    tokio::fs::read(path).await
+    tokio::fs::read(path.as_std_path()).await
   }
 
   async fn read_to_string(&self, path: &Path) -> io::Result<String> {
     cfg_if! {
     if #[cfg(feature = "yarn_pnp")] {
         if self.options.enable_pnp {
-            return match VPath::from(path)? {
+            return match VPath::from(path.as_std_path())? {
                 VPath::Zip(info) => self.pnp_lru.read_to_string(info.physical_base_path(), info.zip_path),
                 VPath::Virtual(info) => tokio::fs::read_to_string(info.physical_base_path()).await,
                 VPath::Native(path) => tokio::fs::read_to_string(&path).await,
@@ -174,14 +183,14 @@ impl FileSystem for FileSystemOs {
             }
         }
     }
-    tokio::fs::read_to_string(path).await
+    tokio::fs::read_to_string(path.as_std_path()).await
   }
 
   async fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
     cfg_if! {
         if #[cfg(feature = "yarn_pnp")] {
             if self.options.enable_pnp {
-                return match VPath::from(path)? {
+                return match VPath::from(path.as_std_path())? {
                     VPath::Zip(info) => self
                         .pnp_lru
                         .file_type(info.physical_base_path(), info.zip_path)
@@ -197,11 +206,13 @@ impl FileSystem for FileSystemOs {
         }
     }
 
-    tokio::fs::metadata(path).await.map(FileMetadata::from)
+    tokio::fs::metadata(path.as_std_path())
+      .await
+      .map(FileMetadata::from)
   }
 
   async fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
-    tokio::fs::symlink_metadata(path)
+    tokio::fs::symlink_metadata(path.as_std_path())
       .await
       .map(FileMetadata::from)
   }
@@ -210,18 +221,19 @@ impl FileSystem for FileSystemOs {
     cfg_if! {
         if #[cfg(feature = "yarn_pnp")] {
             if self.options.enable_pnp {
-                return match VPath::from(path)? {
+                let canonicalized = match VPath::from(path.as_std_path())? {
                     VPath::Zip(info) => {
                         dunce::canonicalize(info.physical_base_path().join(info.zip_path))
                     }
                     VPath::Virtual(info) => dunce::canonicalize(info.physical_base_path()),
                     VPath::Native(path) => dunce::canonicalize(path),
-                }
+                }?;
+                return into_utf8_path_buf(canonicalized)
             }
         }
     }
 
-    dunce::canonicalize(path)
+    into_utf8_path_buf(dunce::canonicalize(path.as_std_path())?)
   }
 }
 
@@ -229,33 +241,32 @@ impl FileSystem for FileSystemOs {
 #[async_trait::async_trait]
 impl FileSystem for FileSystemOs {
   async fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
-    std::fs::read(path)
+    std::fs::read(path.as_std_path())
   }
 
   async fn read_to_string(&self, path: &Path) -> io::Result<String> {
-    std::fs::read_to_string(path)
+    std::fs::read_to_string(path.as_std_path())
   }
 
   async fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
     // This implementation is verbose because there might be something wrong node wasm runtime.
     // I will investigate it in the future.
-    if let Ok(m) = std::fs::metadata(path).map(FileMetadata::from) {
+    if let Ok(m) = std::fs::metadata(path.as_std_path()).map(FileMetadata::from) {
       return Ok(m);
     }
 
     self.symlink_metadata(path).await?;
     let path = self.canonicalize(path).await?;
-    std::fs::metadata(path).map(FileMetadata::from)
+    std::fs::metadata(path.as_std_path()).map(FileMetadata::from)
   }
 
   async fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
-    std::fs::symlink_metadata(path).map(FileMetadata::from)
+    std::fs::symlink_metadata(path.as_std_path()).map(FileMetadata::from)
   }
 
   async fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
-    use std::path::Component;
     let mut path_buf = path.to_path_buf();
-    let link = fs::read_link(&path_buf)?;
+    let link = into_utf8_path_buf(fs::read_link(path_buf.as_std_path())?)?;
     path_buf.pop();
     for component in link.components() {
       match component {
@@ -263,12 +274,7 @@ impl FileSystem for FileSystemOs {
           path_buf.pop();
         }
         Component::Normal(seg) => {
-          path_buf.push(
-            seg
-              .to_str()
-              .expect("path should be UTF-8")
-              .trim_end_matches('\0'),
-          );
+          path_buf.push(seg.trim_end_matches('\0'));
         }
         Component::RootDir => {
           path_buf = PathBuf::from("/");
@@ -277,7 +283,7 @@ impl FileSystem for FileSystemOs {
       }
 
       // This is not performant, we may optimize it with cache in the future
-      if fs::symlink_metadata(&path_buf).is_ok_and(|m| m.is_symlink()) {
+      if fs::symlink_metadata(path_buf.as_std_path()).is_ok_and(|m| m.is_symlink()) {
         let dir = self.canonicalize(&path_buf).await?;
         path_buf = dir;
       }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,12 +65,11 @@ mod tests;
 use std::{
   borrow::Cow,
   cmp::Ordering,
-  ffi::OsStr,
   fmt,
-  path::{Component, Path, PathBuf},
   sync::{Arc, OnceLock},
 };
 
+use camino::{Utf8Component as Component, Utf8Path as Path, Utf8PathBuf as PathBuf};
 use dashmap::DashSet;
 use futures::future::{try_join_all, BoxFuture};
 use rustc_hash::FxHashSet;
@@ -734,7 +733,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       if !path.starts_with(parent) {
         return false;
       }
-      if path.as_os_str().len() == parent.as_os_str().len() {
+      if path.as_str().len() == parent.as_str().len() {
         return true;
       }
       path
@@ -912,6 +911,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       .map(|path| {
         std::env::split_paths(&path)
           .filter(|paths| paths.is_absolute())
+          .filter_map(|path| PathBuf::from_path_buf(path).ok())
           .collect::<Vec<PathBuf>>()
       })
       .unwrap_or_default()
@@ -970,7 +970,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
     // 3. Search for `.pnp.cjs` by walking up from this path
     let base_path = cached_path.to_path_buf();
-    let Some(manifest_path) = pnp::find_closest_pnp_manifest_path(&base_path) else {
+    let Some(manifest_path) = pnp::find_closest_pnp_manifest_path(base_path.as_std_path()) else {
       self.pnp_no_manifest_cache.insert(cached_path.clone());
 
       for p in base_path.ancestors() {
@@ -986,6 +986,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     tracing::debug!("use manifest path: {:?}", manifest_path);
 
     let manifest = pnp::load_pnp_manifest(&manifest_path).ok()?;
+    let manifest_path = PathBuf::from_path_buf(manifest_path).ok()?;
     let manifest = Arc::new((manifest_path, manifest));
 
     let previous = self
@@ -1013,14 +1014,16 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     let (manifest_path, manifest) = pnp_data.as_ref();
     ctx.add_file_dependency(manifest_path);
 
-    let mut path = cached_path.to_path_buf();
-    path.push("");
-    let resolution = pnp::resolve_to_unqualified_via_manifest(manifest, specifier, &path);
+    let mut pnp_path = cached_path.to_path_buf().into_std_path_buf();
+    pnp_path.push("");
+    let resolution = pnp::resolve_to_unqualified_via_manifest(manifest, specifier, &pnp_path);
 
     tracing::debug!("pnp resolve unqualified as: {:?}", resolution);
 
     match resolution {
       Ok(pnp::Resolution::Resolved(path, subpath)) => {
+        let path = PathBuf::from_path_buf(path)
+          .map_err(|_| ResolveError::NotFound(specifier.to_string()))?;
         let cached_path = self.cache.value(&path);
 
         let export_resolution = self.load_package_self(&cached_path, specifier, ctx).await?;
@@ -1065,9 +1068,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   ) -> Option<CachedPath> {
     if module_name == "node_modules" {
       cached_path.cached_node_modules(&self.cache, ctx).await
-    } else if cached_path.path().components().next_back()
-      == Some(Component::Normal(OsStr::new(module_name)))
-    {
+    } else if cached_path.path().components().next_back() == Some(Component::Normal(module_name)) {
       Some(cached_path.clone())
     } else {
       cached_path
@@ -1167,7 +1168,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       return Ok(Some(path));
     }
 
-    let mut path_str = cached_path.path().to_str();
+    let mut path_str = Some(cached_path.path().as_str());
 
     // 3. If the RESOLVED_PATH contains `?``, it could be a path with query
     //    so try to resolve it as a file or directory without the query,
@@ -1366,7 +1367,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       .options
       .extension_alias
       .iter()
-      .find(|(ext, _)| OsStr::new(ext.trim_start_matches('.')) == path_extension)
+      .find(|(ext, _)| ext.trim_start_matches('.') == path_extension)
     else {
       return Ok(None);
     };
@@ -1378,9 +1379,9 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
     ctx.with_fully_specified(true);
     for extension in extensions {
-      let mut path_with_extension = path_without_extension.clone().into_os_string();
+      let mut path_with_extension = path_without_extension.as_str().to_string();
       path_with_extension.reserve_exact(extension.len());
-      path_with_extension.push(extension);
+      path_with_extension.push_str(extension);
       let cached_path = self.cache.value(Path::new(&path_with_extension));
       if let Some(path) = self.load_alias_or_file(&cached_path, ctx).await? {
         ctx.with_fully_specified(false);
@@ -1404,7 +1405,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       .collect::<Vec<_>>()
       .join(",");
     Err(ResolveError::ExtensionAlias(
-      filename.to_str().expect("path should be UTF-8").to_string(),
+      filename.to_string(),
       files,
       dir,
     ))
@@ -1460,7 +1461,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     Ok(None)
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip(self), fields(path = path.display().to_string())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip(self), fields(path = path.to_string())))]
   fn load_tsconfig<'a>(
     &'a self,
     root: bool,

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,9 +1,6 @@
-use std::{
-  fmt,
-  path::{Path, PathBuf},
-  sync::Arc,
-};
+use std::{fmt, sync::Arc};
 
+use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 /// Module Resolution Options
 ///
 /// Options are directly ported from [enhanced-resolve](https://github.com/webpack/enhanced-resolve#resolver-options).
@@ -209,8 +206,7 @@ impl ResolveOptions {
   /// ## Examples
   ///
   /// ```
-  /// use std::path::{Path, PathBuf};
-  ///
+  /// use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
   /// use rspack_resolver::ResolveOptions;
   ///
   /// let options = ResolveOptions::default().with_root("foo");
@@ -227,8 +223,7 @@ impl ResolveOptions {
   /// ## Examples
   ///
   /// ```
-  /// use std::path::{Path, PathBuf};
-  ///
+  /// use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
   /// use rspack_resolver::ResolveOptions;
   ///
   /// let options = ResolveOptions::default().with_extension("jsonc");
@@ -245,8 +240,7 @@ impl ResolveOptions {
   /// ## Examples
   ///
   /// ```
-  /// use std::path::{Path, PathBuf};
-  ///
+  /// use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
   /// use rspack_resolver::ResolveOptions;
   ///
   /// let options = ResolveOptions::default().with_main_field("something");
@@ -263,8 +257,7 @@ impl ResolveOptions {
   /// ## Examples
   ///
   /// ```
-  /// use std::path::{Path, PathBuf};
-  ///
+  /// use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
   /// use rspack_resolver::{EnforceExtension, ResolveOptions};
   ///
   /// let options = ResolveOptions::default().with_force_extension(EnforceExtension::Enabled);
@@ -281,8 +274,7 @@ impl ResolveOptions {
   /// ## Examples
   ///
   /// ```
-  /// use std::path::{Path, PathBuf};
-  ///
+  /// use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
   /// use rspack_resolver::ResolveOptions;
   ///
   /// let options = ResolveOptions::default().with_fully_specified(true);
@@ -298,8 +290,7 @@ impl ResolveOptions {
   /// ## Examples
   ///
   /// ```
-  /// use std::path::{Path, PathBuf};
-  ///
+  /// use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
   /// use rspack_resolver::ResolveOptions;
   ///
   /// let options = ResolveOptions::default().with_prefer_relative(true);
@@ -315,8 +306,7 @@ impl ResolveOptions {
   /// ## Examples
   ///
   /// ```
-  /// use std::path::{Path, PathBuf};
-  ///
+  /// use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
   /// use rspack_resolver::ResolveOptions;
   ///
   /// let options = ResolveOptions::default().with_prefer_absolute(true);
@@ -590,7 +580,7 @@ impl fmt::Display for ResolveOptions {
 
 #[cfg(test)]
 mod test {
-  use std::path::PathBuf;
+  use camino::Utf8PathBuf as PathBuf;
 
   use super::{
     AliasValue, EnforceExtension, ResolveOptions, Restriction, TsconfigOptions, TsconfigReferences,

--- a/src/package_json/simd.rs
+++ b/src/package_json/simd.rs
@@ -5,9 +5,9 @@
 use std::{
   fmt::{Debug, Formatter},
   marker::PhantomData,
-  path::{Path, PathBuf},
 };
 
+use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 use simd_json::{
   borrowed::Value, prelude::*, to_borrowed_value, BorrowedValue, Error as SimdParseError,
 };

--- a/src/path.rs
+++ b/src/path.rs
@@ -3,12 +3,12 @@
 //! Code adapted from the following libraries
 //! * [path-absolutize](https://docs.rs/path-absolutize)
 //! * [normalize_path](https://docs.rs/normalize-path)
-use std::path::{Component, Path, PathBuf};
+use camino::{Utf8Component as Component, Utf8Path as Path, Utf8PathBuf as PathBuf};
 
 pub const SLASH_START: &[char; 2] = &['/', '\\'];
 
 pub fn path_to_str(path: &Path) -> &str {
-  path.to_str().expect("path should be UTF-8")
+  path.as_str()
 }
 
 /// Extension trait to add path normalization to std's [`Path`].
@@ -37,7 +37,7 @@ impl PathUtil for Path {
   fn normalize(&self) -> PathBuf {
     let mut components = self.components().peekable();
     let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek() {
-      let buf = PathBuf::from(c.as_os_str());
+      let buf = PathBuf::from(c.as_str());
       components.next();
       buf
     } else {
@@ -48,7 +48,7 @@ impl PathUtil for Path {
       match component {
         Component::Prefix(..) => unreachable!("Path {:?}", self),
         Component::RootDir => {
-          ret.push(component.as_os_str());
+          ret.push(component);
         }
         Component::CurDir => {}
         Component::ParentDir => {

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -1,8 +1,6 @@
-use std::{
-  fmt,
-  path::{Path, PathBuf},
-  sync::Arc,
-};
+use std::{fmt, sync::Arc};
+
+use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 
 use crate::package_json::PackageJson;
 
@@ -66,12 +64,12 @@ impl Resolution {
 
   /// Returns the full path with query and fragment
   pub fn full_path(&self) -> PathBuf {
-    let mut path = self.path.clone().into_os_string();
+    let mut path = self.path.as_str().to_string();
     if let Some(query) = &self.query {
-      path.push(query);
+      path.push_str(query);
     }
     if let Some(fragment) = &self.fragment {
-      path.push(fragment);
+      path.push_str(fragment);
     }
     PathBuf::from(path)
   }

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -1,15 +1,15 @@
 //! <https://github.com/webpack/enhanced-resolve/blob/main/test/alias.test.js>
 
-use std::path::Path;
+use camino::Utf8Path as Path;
 
-use normalize_path::NormalizePath;
-
-use crate::{AliasValue, Resolution, ResolveContext, ResolveError, ResolveOptions, Resolver};
+use crate::{
+  path::PathUtil, AliasValue, Resolution, ResolveContext, ResolveError, ResolveOptions, Resolver,
+};
 
 #[tokio::test]
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 async fn alias() {
-  use std::path::{Path, PathBuf};
+  use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 
   use super::memory_fs::MemoryFS;
   use crate::ResolverGeneric;
@@ -152,7 +152,7 @@ async fn infinite_recursion() {
 }
 
 fn check_slash(path: &Path) {
-  let s = path.to_str().expect("path should be UTF-8").to_string();
+  let s = path.as_str().to_string();
   #[cfg(target_os = "windows")]
   {
     assert!(!s.contains('/'), "{s}");
@@ -169,11 +169,8 @@ fn check_slash(path: &Path) {
 async fn absolute_path() {
   let f = super::fixture();
   let resolver = Resolver::new(ResolveOptions {
-    alias: vec![(
-      f.join("foo").to_str().unwrap().to_string(),
-      vec![AliasValue::Ignore],
-    )],
-    modules: vec![f.clone().to_str().unwrap().to_string()],
+    alias: vec![(f.join("foo").as_str().to_string(), vec![AliasValue::Ignore])],
+    modules: vec![f.clone().as_str().to_string()],
     ..ResolveOptions::default()
   });
   let resolution = resolver.resolve(&f, "foo/index").await;
@@ -186,9 +183,7 @@ async fn system_path() {
   let resolver = Resolver::new(ResolveOptions {
     alias: vec![(
       "@app".into(),
-      vec![AliasValue::from(
-        f.join("alias").to_str().expect("path should be UTF-8"),
-      )],
+      vec![AliasValue::from(f.join("alias").as_str())],
     )],
     ..ResolveOptions::default()
   });
@@ -210,7 +205,7 @@ async fn system_path() {
 async fn alias_is_full_path() {
   let f = super::fixture();
   let dir = f.join("foo");
-  let dir_str = dir.to_str().expect("path should be UTF-8").to_string();
+  let dir_str = dir.as_str().to_string();
 
   let resolver = Resolver::new(ResolveOptions {
     alias: vec![("@".into(), vec![AliasValue::Path(dir_str.clone())])],
@@ -258,11 +253,7 @@ async fn all_alias_values_are_not_found() {
     alias: vec![(
       "m1".to_string(),
       vec![AliasValue::Path(
-        f.join("node_modules")
-          .join("m2")
-          .to_str()
-          .expect("path should be UTF-8")
-          .to_string(),
+        f.join("node_modules").join("m2").as_str().to_string(),
       )],
     )],
     ..ResolveOptions::default()
@@ -321,12 +312,7 @@ async fn alias_try_fragment_as_path() {
   let resolver = Resolver::new(ResolveOptions {
     alias: vec![(
       "#".to_string(),
-      vec![AliasValue::Path(
-        f.join("#")
-          .to_str()
-          .expect("path should be UTF-8")
-          .to_string(),
-      )],
+      vec![AliasValue::Path(f.join("#").as_str().to_string())],
     )],
     ..ResolveOptions::default()
   });

--- a/src/tests/browser_field.rs
+++ b/src/tests/browser_field.rs
@@ -162,9 +162,7 @@ async fn crypto_js() {
     alias_fields: vec![vec!["browser".into()]],
     fallback: vec![(
       "crypto".into(),
-      vec![AliasValue::from(
-        f.join("lib.js").to_str().expect("path should be UTF-8"),
-      )],
+      vec![AliasValue::from(f.join("lib.js").as_str())],
     )],
     ..ResolveOptions::default()
   });

--- a/src/tests/builtins.rs
+++ b/src/tests/builtins.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use camino::Utf8Path as Path;
 
 use crate::{ResolveError, ResolveOptions, Resolver};
 

--- a/src/tests/dependencies.rs
+++ b/src/tests/dependencies.rs
@@ -2,8 +2,7 @@
 
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 mod windows {
-  use std::path::PathBuf;
-
+  use camino::Utf8PathBuf as PathBuf;
   use rustc_hash::FxHashSet;
 
   use super::super::memory_fs::MemoryFS;

--- a/src/tests/exports_field.rs
+++ b/src/tests/exports_field.rs
@@ -2,8 +2,7 @@
 //!
 //! The huge exports field test cases are at the bottom of this file.
 
-use std::path::Path;
-
+use camino::Utf8Path as Path;
 use simd_json::json;
 
 use crate::{package_json, Ctx, PathUtil, ResolveError, ResolveOptions, Resolver};

--- a/src/tests/fallback.rs
+++ b/src/tests/fallback.rs
@@ -3,7 +3,7 @@
 #[tokio::test]
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 async fn fallback() {
-  use std::path::{Path, PathBuf};
+  use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 
   use super::memory_fs::MemoryFS;
   use crate::{AliasValue, ResolveError, ResolveOptions, ResolverGeneric};

--- a/src/tests/full_specified.rs
+++ b/src/tests/full_specified.rs
@@ -2,7 +2,7 @@
 
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 mod windows {
-  use std::path::PathBuf;
+  use camino::Utf8PathBuf as PathBuf;
 
   use super::super::memory_fs::MemoryFS;
   use crate::{AliasValue, ResolveOptions, ResolverGeneric};

--- a/src/tests/imports_field.rs
+++ b/src/tests/imports_field.rs
@@ -2,8 +2,7 @@
 //!
 //! The huge imports field test cases are at the bottom of this file.
 
-use std::path::Path;
-
+use camino::Utf8Path as Path;
 use simd_json::{json, prelude::*};
 
 use crate::{package_json::JSONValue, Ctx, PathUtil, ResolveError, ResolveOptions, Resolver};

--- a/src/tests/memory_fs.rs
+++ b/src/tests/memory_fs.rs
@@ -1,12 +1,11 @@
-use std::{
-  io,
-  path::{Path, PathBuf},
-};
+use std::io;
+
+use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 
 use crate::{FileMetadata, FileSystem};
 
 fn path_to_str(path: &Path) -> &str {
-  path.to_str().expect("path should be UTF-8")
+  path.as_str()
 }
 
 #[derive(Default)]

--- a/src/tests/missing.rs
+++ b/src/tests/missing.rs
@@ -1,8 +1,6 @@
 //! https://github.com/webpack/enhanced-resolve/blob/main/test/missing.test.js
 
-use normalize_path::NormalizePath;
-
-use crate::{AliasValue, ResolveContext, ResolveOptions, Resolver};
+use crate::{path::PathUtil, AliasValue, ResolveContext, ResolveOptions, Resolver};
 
 #[tokio::test]
 async fn test() {
@@ -82,19 +80,13 @@ async fn alias_and_extensions() {
       (
         "@scope-js/package-name/dir$".into(),
         vec![AliasValue::Path(
-          f.join("foo/index.js")
-            .to_str()
-            .expect("path should be UTF-8")
-            .to_string(),
+          f.join("foo/index.js").as_str().to_string(),
         )],
       ),
       (
         "react-dom".into(),
         vec![AliasValue::Path(
-          f.join("foo/index.js")
-            .to_str()
-            .expect("path should be UTF-8")
-            .to_string(),
+          f.join("foo/index.js").as_str().to_string(),
         )],
       ),
     ],

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -28,12 +28,16 @@ mod tsconfig_project_references;
 #[cfg(windows)]
 mod windows;
 
-use std::{env, path::PathBuf, sync::Arc, thread};
+use std::{env, sync::Arc, thread};
+
+use camino::Utf8PathBuf as PathBuf;
 
 use crate::Resolver;
 
 pub fn fixture_root() -> PathBuf {
-  env::current_dir().unwrap().join("fixtures")
+  PathBuf::from_path_buf(env::current_dir().unwrap())
+    .unwrap()
+    .join("fixtures")
 }
 
 pub fn fixture() -> PathBuf {
@@ -45,7 +49,7 @@ pub fn fixture() -> PathBuf {
 
 #[tokio::test]
 async fn threaded_environment() {
-  let cwd = env::current_dir().unwrap();
+  let cwd = PathBuf::from_path_buf(env::current_dir().unwrap()).unwrap();
   let resolver = Arc::new(Resolver::default());
   for _ in 0..2 {
     _ = thread::spawn({

--- a/src/tests/node_path.rs
+++ b/src/tests/node_path.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 
 use super::memory_fs::MemoryFS;
 use crate::{ResolveOptions, ResolverGeneric};

--- a/src/tests/package_json.rs
+++ b/src/tests/package_json.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-  use std::path::PathBuf;
+  use camino::Utf8PathBuf as PathBuf;
 
   use crate::{package_json::ParseError, PackageJson};
 

--- a/src/tests/pnp.rs
+++ b/src/tests/pnp.rs
@@ -137,25 +137,18 @@ async fn pnp_resolve_description_file() {
     .join(
       ".yarn/cache/preact-npm-10.25.4-2dd2c0aa44-33a009d614.zip/node_modules/preact/dist/preact.js",
     )
-    .to_str()
-    .expect("path should be UTF-8")
+    .as_str()
     .to_string();
 
   let r = resolver.resolve(&fixture, &full_path).await.unwrap();
 
   assert_eq!(
-    r.package_json
-      .unwrap()
-      .path
-      .to_str()
-      .expect("path should be UTF-8")
-      .to_string(),
+    r.package_json.unwrap().path.as_str().to_string(),
     fixture
       .join(".yarn/cache/preact-npm-10.25.4-2dd2c0aa44-33a009d614.zip/node_modules/preact")
       .join("package.json")
       .normalize()
-      .to_str()
-      .expect("path should be UTF-8")
+      .as_str()
       .to_string()
   );
 }
@@ -215,10 +208,7 @@ async fn resolve_pnp_with_global_cache_enabled_windows() {
     .unwrap();
 
   let module_root = resolved.parent().unwrap();
-  let module_root_str = module_root
-    .to_str()
-    .expect("path should be UTF-8")
-    .replace('\\', "/");
+  let module_root_str = module_root.as_str().replace('\\', "/");
   assert!(
     module_root_str.contains("/Yarn/Berry/cache/path-to-regexp"),
     "Expected global cache path, got: {module_root_str}"
@@ -227,13 +217,7 @@ async fn resolve_pnp_with_global_cache_enabled_windows() {
   let resolved_from_cache = resolver
     .resolve(module_root, "./index.js")
     .await
-    .map(|r| {
-      r.full_path()
-        .to_str()
-        .expect("path should be UTF-8")
-        .replace('\\', "/")
-        .to_string()
-    })
+    .map(|r| r.full_path().as_str().replace('\\', "/").to_string())
     .unwrap();
   assert!(
     resolved_from_cache.contains("/Yarn/Berry/cache/path-to-regexp"),
@@ -259,7 +243,7 @@ async fn resolve_pnp_with_global_cache_enabled_unix() {
     .unwrap();
 
   let module_root = resolved.parent().unwrap();
-  let module_root_str = module_root.to_str().expect("path should be UTF-8");
+  let module_root_str = module_root.as_str();
   assert!(
     module_root_str.contains("/.yarn/berry/cache/path-to-regexp"),
     "Expected global cache path, got: {module_root_str}"
@@ -270,7 +254,7 @@ async fn resolve_pnp_with_global_cache_enabled_unix() {
     .await
     .map(|r| r.full_path())
     .unwrap();
-  let resolved_str = resolved_from_cache.to_str().expect("path should be UTF-8");
+  let resolved_str = resolved_from_cache.as_str();
   assert!(
     resolved_str.contains("/.yarn/berry/cache/path-to-regexp"),
     "Expected global cache path, got: {resolved_str}"
@@ -300,8 +284,7 @@ async fn resolve_pnp_transitive_dep_from_global_cache() {
     .await
     .map(|r| {
       r.full_path()
-        .to_str()
-        .expect("path should be UTF-8")
+        .as_str()
         .replace('\\', "/")
         .to_lowercase()
         .to_string()

--- a/src/tests/resolve.rs
+++ b/src/tests/resolve.rs
@@ -8,11 +8,7 @@ async fn resolve() {
 
   let resolver = Resolver::default();
 
-  let main1_js_path = f
-    .join("main1.js")
-    .to_str()
-    .expect("path should be UTF-8")
-    .to_string();
+  let main1_js_path = f.join("main1.js").as_str().to_string();
 
   #[rustfmt::skip]
     let pass = [

--- a/src/tests/restrictions.rs
+++ b/src/tests/restrictions.rs
@@ -14,7 +14,7 @@ async fn should_respect_regexp_restriction() {
   let resolver1 = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
     restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-      path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
+      re.is_match(path.as_str())
     }))],
     ..ResolveOptions::default()
   });
@@ -32,7 +32,7 @@ async fn should_try_to_find_alternative_1() {
     extensions: vec![".js".into(), ".css".into()],
     main_files: vec!["index".into()],
     restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-      path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
+      re.is_match(path.as_str())
     }))],
     ..ResolveOptions::default()
   });
@@ -65,7 +65,7 @@ async fn should_try_to_find_alternative_2() {
     extensions: vec![".js".into(), ".css".into()],
     main_fields: vec!["main".into(), "style".into()],
     restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-      path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
+      re.is_match(path.as_str())
     }))],
     ..ResolveOptions::default()
   });
@@ -83,7 +83,7 @@ async fn should_try_to_find_alternative_3() {
     extensions: vec![".js".into()],
     main_fields: vec!["main".into(), "module".into(), "style".into()],
     restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-      path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
+      re.is_match(path.as_str())
     }))],
     ..ResolveOptions::default()
   });
@@ -102,7 +102,7 @@ async fn should_try_to_find_alternative_4() {
     main_fields: vec!["main".into()],
     extension_alias: vec![(".js".into(), vec![".js".into(), ".jsx".into()])],
     restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-      path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
+      re.is_match(path.as_str())
     }))],
     ..ResolveOptions::default()
   });

--- a/src/tests/roots.rs
+++ b/src/tests/roots.rs
@@ -1,6 +1,6 @@
 //! <https://github.com/webpack/enhanced-resolve/blob/main/test/roots.test.js>
 
-use std::path::PathBuf;
+use camino::Utf8PathBuf as PathBuf;
 
 use crate::{AliasValue, ResolveError, ResolveOptions, Resolver};
 
@@ -73,7 +73,7 @@ async fn prefer_absolute() {
 
   #[rustfmt::skip]
     let pass = [
-        ("should resolve an absolute path (prefer absolute)", f.join("b.js").to_str().expect("path should be UTF-8").to_string(), f.join("b.js")),
+        ("should resolve an absolute path (prefer absolute)", f.join("b.js").as_str().to_string(), f.join("b.js")),
     ];
 
   for (comment, request, expected) in pass {
@@ -86,7 +86,7 @@ async fn prefer_absolute() {
 async fn roots_fall_through() {
   let f = super::fixture();
   let absolute_path = f.join("roots_fall_through/index.js");
-  let specifier = absolute_path.to_str().expect("path should be UTF-8");
+  let specifier = absolute_path.as_str();
   let resolution = Resolver::new(ResolveOptions::default().with_root(&f))
     .resolve(&f, &specifier)
     .await;

--- a/src/tests/simple.rs
+++ b/src/tests/simple.rs
@@ -2,12 +2,16 @@
 
 use std::env;
 
+use camino::Utf8PathBuf as PathBuf;
+
 use crate::Resolver;
 
 #[tokio::test]
 async fn resolve_abs_main() {
   let resolver = Resolver::default();
-  let dirname = env::current_dir().unwrap().join("fixtures");
+  let dirname = PathBuf::from_path_buf(env::current_dir().unwrap())
+    .unwrap()
+    .join("fixtures");
   let f = dirname.join("invalid/main.js");
   // a's main field id `/dist/index.js`
   let resolution = resolver.resolve(&f, "a").await.unwrap();
@@ -21,7 +25,9 @@ async fn resolve_abs_main() {
 #[tokio::test]
 async fn simple() {
   // mimic `enhanced-resolve/test/simple.test.js`
-  let dirname = env::current_dir().unwrap().join("fixtures");
+  let dirname = PathBuf::from_path_buf(env::current_dir().unwrap())
+    .unwrap()
+    .join("fixtures");
   let f = dirname.join("enhanced_resolve/test");
 
   let resolver = Resolver::default();
@@ -93,7 +99,7 @@ mod windows {
 
   #[tokio::test]
   async fn no_package() {
-    use std::path::Path;
+    use camino::Utf8Path as Path;
 
     use crate::ResolverGeneric;
     let f = Path::new("/");

--- a/src/tests/symlink.rs
+++ b/src/tests/symlink.rs
@@ -1,4 +1,6 @@
-use std::{fs, io, path::Path};
+use std::{fs, io};
+
+use camino::Utf8Path as Path;
 
 use crate::{ResolveOptions, Resolver};
 
@@ -9,80 +11,67 @@ enum FileType {
 }
 
 #[allow(unused_variables)]
-fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(
-  original: P,
-  link: Q,
-  file_type: FileType,
-) -> io::Result<()> {
+fn symlink(original: &std::path::Path, link: &Path, file_type: FileType) -> io::Result<()> {
   #[cfg(target_family = "unix")]
   {
-    std::os::unix::fs::symlink(original, link)
+    std::os::unix::fs::symlink(original, link.as_std_path())
   }
 
   #[cfg(target_family = "windows")]
   match file_type {
-    FileType::File => std::os::windows::fs::symlink_file(original, link),
-    FileType::Dir => std::os::windows::fs::symlink_dir(original, link),
+    FileType::File => std::os::windows::fs::symlink_file(original, link.as_std_path()),
+    FileType::Dir => std::os::windows::fs::symlink_dir(original, link.as_std_path()),
   }
 }
 
 fn init(dirname: &Path, temp_path: &Path) -> io::Result<()> {
   if temp_path.exists() {
-    _ = fs::remove_dir_all(temp_path);
+    _ = fs::remove_dir_all(temp_path.as_std_path());
   }
-  fs::create_dir(temp_path)?;
+  fs::create_dir(temp_path.as_std_path())?;
   symlink(
-    dirname.join("../lib/index.js"),
-    temp_path.join("test"),
+    dirname.join("../lib/index.js").as_std_path(),
+    &temp_path.join("test"),
     FileType::File,
   )?;
   symlink(
-    dirname.join("../lib"),
-    temp_path.join("test2"),
+    dirname.join("../lib").as_std_path(),
+    &temp_path.join("test2"),
     FileType::Dir,
   )?;
-  fs::remove_file(temp_path.join("test"))?;
-  fs::remove_file(temp_path.join("test2"))?;
-  fs::remove_dir(temp_path)
+  fs::remove_file(temp_path.join("test").as_std_path())?;
+  fs::remove_file(temp_path.join("test2").as_std_path())?;
+  fs::remove_dir(temp_path.as_std_path())
 }
 
 fn create_symlinks(dirname: &Path, temp_path: &Path) -> io::Result<()> {
-  fs::create_dir(temp_path).unwrap();
+  fs::create_dir(temp_path.as_std_path()).unwrap();
+  let index = dirname.join("../lib/index.js").canonicalize().unwrap();
+  symlink(index.as_path(), &temp_path.join("index.js"), FileType::File)?;
+  let lib = dirname.join("../lib").canonicalize().unwrap();
+  symlink(lib.as_path(), &temp_path.join("lib"), FileType::Dir)?;
+  let parent = dirname.join("..").canonicalize().unwrap();
+  symlink(parent.as_path(), &temp_path.join("this"), FileType::Dir)?;
   symlink(
-    dirname.join("../lib/index.js").canonicalize().unwrap(),
-    temp_path.join("index.js"),
+    temp_path.join("this").as_std_path(),
+    &temp_path.join("that"),
+    FileType::Dir,
+  )?;
+  symlink(
+    Path::new("../../lib/index.js").as_std_path(),
+    &temp_path.join("node.relative.js"),
     FileType::File,
   )?;
   symlink(
-    dirname.join("../lib").canonicalize().unwrap(),
-    temp_path.join("lib"),
-    FileType::Dir,
-  )?;
-  symlink(
-    dirname.join("..").canonicalize().unwrap(),
-    temp_path.join("this"),
-    FileType::Dir,
-  )?;
-  symlink(
-    temp_path.join("this"),
-    temp_path.join("that"),
-    FileType::Dir,
-  )?;
-  symlink(
-    Path::new("../../lib/index.js"),
-    temp_path.join("node.relative.js"),
-    FileType::File,
-  )?;
-  symlink(
-    Path::new("./node.relative.js"),
-    temp_path.join("node.relative.sym.js"),
+    Path::new("./node.relative.js").as_std_path(),
+    &temp_path.join("node.relative.sym.js"),
     FileType::File,
   )?;
   Ok(())
 }
 
 fn cleanup_symlinks(temp_path: &Path) {
-  _ = fs::remove_dir_all(temp_path);
+  _ = fs::remove_dir_all(temp_path.as_std_path());
 }
 
 #[tokio::test]

--- a/src/tests/tsconfig_paths.rs
+++ b/src/tests/tsconfig_paths.rs
@@ -2,7 +2,7 @@
 //!
 //! Fixtures copied from <https://github.com/parcel-bundler/parcel/tree/v2/packages/utils/node-resolver-core/test/fixture/tsconfig>.
 
-use std::path::{Path, PathBuf};
+use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 
 use crate::{
   JSONError, ResolveError, ResolveOptions, Resolver, TsConfig, TsconfigOptions, TsconfigReferences,
@@ -307,7 +307,7 @@ async fn tsconfig_paths_scoped_pkg_fallthrough() {
 
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 mod windows_test {
-  use std::path::{Path, PathBuf};
+  use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 
   use super::super::memory_fs::MemoryFS;
   use crate::{ResolveError, ResolveOptions, ResolverGeneric, TsconfigOptions, TsconfigReferences};

--- a/src/tests/windows.rs
+++ b/src/tests/windows.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod tests {
-  use std::{collections::HashSet, path::Path};
+  use std::collections::HashSet;
+
+  use camino::Utf8Path as Path;
 
   use crate::{path::PathUtil, tests::fixture, FileSystemOs, ResolverGeneric};
 
@@ -36,11 +38,7 @@ mod tests {
       .resolve_with_context(&file, &specifier, &mut ctx)
       .await
       .unwrap();
-    let resolved_path_string = resolved
-      .path
-      .to_str()
-      .expect("path should be UTF-8")
-      .to_string();
+    let resolved_path_string = resolved.path.as_str().to_string();
     let actual_file_deps = ctx
       .file_dependencies
       .iter()
@@ -52,10 +50,6 @@ mod tests {
   }
 
   fn to_string<P: AsRef<Path>>(p: P) -> String {
-    p.as_ref()
-      .normalize()
-      .to_str()
-      .expect("path should be UTF-8")
-      .to_string()
+    p.as_ref().normalize().as_str().to_string()
   }
 }

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -1,9 +1,6 @@
-use std::{
-  hash::BuildHasherDefault,
-  path::{Path, PathBuf},
-  sync::Arc,
-};
+use std::{hash::BuildHasherDefault, sync::Arc};
 
+use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 use indexmap::IndexMap;
 use rustc_hash::FxHasher;
 use serde::Deserialize;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,13 +1,14 @@
 //! Test public APIs
 
-use std::{env, path::PathBuf};
+use std::env;
 
+use camino::Utf8PathBuf as PathBuf;
 use rspack_resolver::{
   EnforceExtension, ModuleType, Resolution, ResolveContext, ResolveOptions, Resolver,
 };
 
 fn dir() -> PathBuf {
-  env::current_dir().unwrap()
+  PathBuf::from_path_buf(env::current_dir().unwrap()).unwrap()
 }
 
 async fn resolve(specifier: &str) -> Resolution {

--- a/tests/resolve_test.rs
+++ b/tests/resolve_test.rs
@@ -1,9 +1,10 @@
-use std::{env, path::PathBuf};
+use std::env;
 
+use camino::Utf8PathBuf as PathBuf;
 use rspack_resolver::{ResolveError, ResolveOptions, Resolver};
 
 fn dir() -> PathBuf {
-  env::current_dir().unwrap()
+  PathBuf::from_path_buf(env::current_dir().unwrap()).unwrap()
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Switch the public resolver path API from `std::path::{Path, PathBuf}` to `camino::{Utf8Path, Utf8PathBuf}`.
- Carry UTF-8 path types through resolver results, errors, options, contexts, tsconfig/package metadata, cache, and the `FileSystem` trait.
- Replace internal UTF-8 `to_str().expect(...)` conversions with `Utf8Path::as_str()` and explicit std-path boundary conversions.
- Update napi, examples, benches, and tests to use the new UTF-8 path API.

## Impact

Callers now pass and receive UTF-8 path types at the Rust API boundary, making the resolver's UTF-8 requirement explicit and avoiding hidden unwraps during internal path-to-string conversion. OS/PnP calls still cross through std paths via `as_std_path()`, and canonicalized std paths are converted back with an `InvalidData` error if they are not valid UTF-8.

## Validation

- `cargo check --workspace`
- `cargo check --benches`
- `cargo test --no-run`
- pre-commit: `cargo fmt`, `pnpm exec taplo format`, `cargo clippy --all-features -- -D warnings`

Note: `cargo test --lib` runs and passes 125 tests locally, but 6 PnP runtime tests fail because the local `fixtures/pnp` directory does not contain a `.pnp.cjs` manifest for `pnp::find_closest_pnp_manifest_path` to discover.