### PR TITLE
[codex] speed up non-PnP resolve

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -24,25 +24,61 @@ use crate::{
 #[derive(Default)]
 pub struct Cache<Fs> {
   pub(crate) fs: Fs,
+  exact_paths: DashMap<u64, Vec<CachedPath>, BuildHasherDefault<IdentityHasher>>,
   paths: DashSet<CachedPath, BuildHasherDefault<IdentityHasher>>,
+  use_exact_paths: bool,
   tsconfigs: DashMap<PathBuf, Arc<TsConfig>, BuildHasherDefault<FxHasher>>,
 }
 
 impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
-  pub fn new(fs: Fs) -> Self {
+  pub fn new(fs: Fs, use_exact_paths: bool) -> Self {
     Self {
       fs,
+      exact_paths: DashMap::default(),
       paths: DashSet::default(),
+      use_exact_paths,
       tsconfigs: DashMap::default(),
     }
   }
 
   pub fn clear(&self) {
+    self.exact_paths.clear();
     self.paths.clear();
     self.tsconfigs.clear();
   }
 
   pub fn value(&self, path: &Path) -> CachedPath {
+    if self.use_exact_paths {
+      return self.value_exact(path);
+    }
+    self.value_semantic(path)
+  }
+
+  fn value_exact(&self, path: &Path) -> CachedPath {
+    let hash = {
+      let mut hasher = FxHasher::default();
+      path.as_os_str().hash(&mut hasher);
+      hasher.finish()
+    };
+    if let Some(cache_entry) = self.exact_paths.get(&hash).and_then(|cache_entries| {
+      cache_entries
+        .iter()
+        .find(|cache_entry| cache_entry.path().as_os_str() == path.as_os_str())
+        .cloned()
+    }) {
+      return cache_entry;
+    }
+    let parent = path.parent().map(|p| self.value_exact(p));
+    let data = CachedPath(Arc::new(CachedPathImpl::new(
+      hash,
+      path.to_path_buf().into_boxed_path(),
+      parent,
+    )));
+    self.exact_paths.entry(hash).or_default().push(data.clone());
+    data
+  }
+
+  fn value_semantic(&self, path: &Path) -> CachedPath {
     let hash = {
       let mut hasher = FxHasher::default();
       path.hash(&mut hasher);
@@ -51,7 +87,7 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
     if let Some(cache_entry) = self.paths.get((hash, path).borrow() as &dyn CacheKey) {
       return cache_entry.clone();
     }
-    let parent = path.parent().map(|p| self.value(p));
+    let parent = path.parent().map(|p| self.value_semantic(p));
     let data = CachedPath(Arc::new(CachedPathImpl::new(
       hash,
       path.to_path_buf().into_boxed_path(),

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -9,6 +9,8 @@ use cfg_if::cfg_if;
 use pnp::fs::LruZipCache;
 #[cfg(all(feature = "yarn_pnp", not(target_arch = "wasm32")))]
 use pnp::fs::{VPath, VPathInfo, ZipCache};
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::runtime::{Handle, RuntimeFlavor};
 
 /// File System abstraction used for `ResolverGeneric`
 #[async_trait::async_trait]
@@ -145,6 +147,11 @@ impl FileSystemOs {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+fn use_direct_fs_calls() -> bool {
+  Handle::try_current().is_ok_and(|handle| handle.runtime_flavor() == RuntimeFlavor::CurrentThread)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 #[async_trait::async_trait]
 impl FileSystem for FileSystemOs {
   async fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
@@ -158,6 +165,10 @@ impl FileSystem for FileSystemOs {
             }
         }
     }}
+
+    if use_direct_fs_calls() {
+      return fs::read(path);
+    }
 
     tokio::fs::read(path).await
   }
@@ -173,6 +184,9 @@ impl FileSystem for FileSystemOs {
                 }
             }
         }
+    }
+    if use_direct_fs_calls() {
+      return fs::read_to_string(path);
     }
     tokio::fs::read_to_string(path).await
   }
@@ -197,10 +211,18 @@ impl FileSystem for FileSystemOs {
         }
     }
 
+    if use_direct_fs_calls() {
+      return fs::metadata(path).map(FileMetadata::from);
+    }
+
     tokio::fs::metadata(path).await.map(FileMetadata::from)
   }
 
   async fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+    if use_direct_fs_calls() {
+      return fs::symlink_metadata(path).map(FileMetadata::from);
+    }
+
     tokio::fs::symlink_metadata(path)
       .await
       .map(FileMetadata::from)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,9 +137,20 @@ impl<Fs: Send + Sync + FileSystem + Default> Default for ResolverGeneric<Fs> {
 
 impl<Fs: Send + Sync + FileSystem + Default> ResolverGeneric<Fs> {
   pub fn new(options: ResolveOptions) -> Self {
+    let options = options.sanitize();
+    let use_exact_paths = {
+      #[cfg(feature = "yarn_pnp")]
+      {
+        !options.enable_pnp
+      }
+      #[cfg(not(feature = "yarn_pnp"))]
+      {
+        true
+      }
+    };
     Self {
-      options: options.sanitize(),
-      cache: Arc::new(Cache::new(Fs::default())),
+      options,
+      cache: Arc::new(Cache::new(Fs::default(), use_exact_paths)),
       #[cfg(feature = "yarn_pnp")]
       pnp_manifest: Arc::new(arc_swap::ArcSwapOption::empty()),
       #[cfg(feature = "yarn_pnp")]
@@ -151,9 +162,20 @@ impl<Fs: Send + Sync + FileSystem + Default> ResolverGeneric<Fs> {
 
 impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   pub fn new_with_file_system(file_system: Fs, options: ResolveOptions) -> Self {
+    let options = options.sanitize();
+    let use_exact_paths = {
+      #[cfg(feature = "yarn_pnp")]
+      {
+        !options.enable_pnp
+      }
+      #[cfg(not(feature = "yarn_pnp"))]
+      {
+        true
+      }
+    };
     Self {
-      options: options.sanitize(),
-      cache: Arc::new(Cache::new(file_system)),
+      options,
+      cache: Arc::new(Cache::new(file_system, use_exact_paths)),
       #[cfg(feature = "yarn_pnp")]
       pnp_manifest: Arc::new(arc_swap::ArcSwapOption::empty()),
       #[cfg(feature = "yarn_pnp")]


### PR DESCRIPTION
## Summary

- use an exact-path cache for non-PnP resolver instances to avoid repeated semantic path hashing
- bypass `tokio::fs` blocking handoff on current-thread runtimes while keeping multithreaded behavior unchanged

## Why

The single-thread resolver benchmark was spending a measurable amount of time in path-cache hashing and Tokio fs handoff overhead. These changes keep PnP-enabled behavior on the existing path while optimizing the non-PnP hot path used by the benchmark.

## Impact

- faster non-PnP module resolution in the current-thread benchmark path
- no intended behavior change for PnP-enabled resolution

## Validation

- `cargo clippy --all-features -- -D warnings`
- `cargo fmt --check`
- `cargo test` still has the same 6 pre-existing PnP failures observed on `origin/main`
- CodSpeed simulation baseline: `resolver[single-thread]` 54.77 ms, `resolver[[single-threaded]resolve with many extensions]` 132.01 ms
- CodSpeed simulation final: `resolver[single-thread]` 39.85 ms (-27.24%), `resolver[[single-threaded]resolve with many extensions]` 124.84 ms (-5.43%)

## Artifacts

- baseline: `optimization-artifacts/codspeed/20260518-223013-baseline2/run.log`
- final: `optimization-artifacts/codspeed/20260518-223853-exact-cache-plus-direct-fs/run.log`
