### PR TITLE
perf(cache): skip async state-machine on OnceCell cache hit

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -184,6 +184,11 @@ impl CachedPathImpl {
   }
 
   async fn meta<Fs: Send + Sync + FileSystem>(&self, fs: &Fs) -> Option<FileMetadata> {
+    // Skip the Future state-machine + poll on cache hit. `tokio::sync::OnceCell::get`
+    // is sync and bypasses constructing the `get_or_init` future entirely.
+    if let Some(m) = self.meta.get() {
+      return *m;
+    }
     *self
       .meta
       .get_or_init(|| async { fs.metadata(&self.path).await.ok() })
@@ -215,6 +220,15 @@ impl CachedPathImpl {
     fs: &'a Fs,
   ) -> BoxFuture<'a, io::Result<PathBuf>> {
     let fut = async move {
+      // Cache hit: return immediately and avoid the recursive parent walk +
+      // `Box::pin` per call on the hot path.
+      if let Some(cached) = self.canonicalized.get() {
+        return Ok(
+          cached
+            .clone()
+            .unwrap_or_else(|| self.path.clone().to_path_buf()),
+        );
+      }
       self
         .canonicalized
         .get_or_try_init(|| async move {
@@ -258,6 +272,9 @@ impl CachedPathImpl {
     cache: &Cache<Fs>,
     ctx: &mut Ctx,
   ) -> Option<CachedPath> {
+    if let Some(nm) = self.node_modules.get() {
+      return nm.clone();
+    }
     self
       .node_modules
       .get_or_init(|| self.module_directory("node_modules", cache, ctx))
@@ -308,6 +325,18 @@ impl CachedPathImpl {
     options: &ResolveOptions,
     ctx: &mut Ctx,
   ) -> Result<Option<Arc<PackageJson>>, ResolveError> {
+    if let Some(pkg) = self.package_json.get() {
+      // Preserve ctx dependency tracking on cache hit.
+      match pkg {
+        Some(package_json) => ctx.add_file_dependency(&package_json.path),
+        None => {
+          if let Some(deps) = &mut ctx.missing_dependencies {
+            deps.push(self.path.join("package.json"));
+          }
+        }
+      }
+      return Ok(pkg.clone());
+    }
     // Change to `std::sync::OnceLock::get_or_try_init` when it is stable.
     let result = self
       .package_json


### PR DESCRIPTION
## Why

`tokio::sync::OnceCell::get_or_init` always **constructs and polls a Future** even when the slot is already populated. For warm-cache hits on `CachedPath::{meta, realpath, cached_node_modules, package_json}` that is pure overhead — `realpath` in particular allocates via `Box::pin` on every call.

`OnceCell::get()` is a sync atomic load. Calling it first lets us bypass the async state-machine entirely on cache hits and keep the existing `get_or_init` path for the cold case.

## What

Add a leading `if let Some(v) = self.<slot>.get()` to each of the four hot accessors. The cold/init path is untouched.

For `package_json`, the cache-hit branch also replays `ctx.add_file_dependency` / `missing_dependencies.push(...)` so `resolve_with_context` keeps populating `ResolveContext` exactly as before.

## Before / after (local, warm-cache)

Measured on Apple M4 Pro with a long-lived `Resolver` (`LazyLock`-shared so the cache survives across criterion samples) — the configuration that matches webpack/rspack's actual usage of a long-lived resolver. Criterion baseline diff:

| Scenario | main | PR | change |
|---|---|---|---|
| single-thread (40 cases) | 83.7 µs | 69.7 µs | **−20.0%** |
| multi-thread (40 cases) | 92.8 µs | 84.9 µs | **−8.1%** |
| symlinks (10000 resolves) | 13.4 ms | 11.2 ms | **−15.9%** |

The official `benches/resolver.rs` calls `clear_cache()` per iter (cold cache), so it won't show the same magnitude — CodSpeed CI should still surface the instruction-count reduction.

## Test plan

- [x] `cargo test --lib` — 125 pass, 6 pre-existing pnp fixture failures unrelated
- [x] `cargo clippy --all-features -- -D warnings` (via pre-commit hook)
- [x] Hot paths exercised by `benches/resolver.rs` and downstream rspack
