### PR TITLE
perf(alias): short-circuit load_alias with a 1+2 byte prefix index

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,10 +110,61 @@ pub struct ResolveContext {
 /// Resolver with the current operating system as the file system
 pub type Resolver = ResolverGeneric<FileSystemOs>;
 
+/// Pre-computed accelerator for [`ResolverGeneric::load_alias`].
+///
+/// Records which 1-byte and 2-byte specifier prefixes could possibly match an
+/// alias key. The check lets `load_alias` short-circuit before iterating every
+/// alias entry when the specifier can't match anything (e.g. a relative request
+/// like `./foo` against bare-name aliases).
+#[derive(Clone)]
+struct AliasFirstBytes {
+  byte1_only: [bool; 256],
+  byte12: rustc_hash::FxHashSet<u16>,
+}
+
+impl AliasFirstBytes {
+  fn build(aliases: &Alias) -> Self {
+    let mut byte1_only = [false; 256];
+    let mut byte12 = rustc_hash::FxHashSet::default();
+    for (key, _) in aliases {
+      // `$`-suffixed keys are exact-match aliases — index by the stripped key.
+      let effective = key.strip_suffix('$').unwrap_or(key);
+      let bytes = effective.as_bytes();
+      match bytes {
+        [b1] => byte1_only[*b1 as usize] = true,
+        [b1, b2, ..] => {
+          byte12.insert(u16::from(*b1) << 8 | u16::from(*b2));
+        }
+        [] => {}
+      }
+    }
+    Self { byte1_only, byte12 }
+  }
+
+  fn may_match_bytes(&self, bytes: &[u8]) -> bool {
+    match bytes {
+      [] => false,
+      [b1] => self.byte1_only[*b1 as usize],
+      [b1, b2, ..] => {
+        self.byte1_only[*b1 as usize]
+          || self
+            .byte12
+            .contains(&(u16::from(*b1) << 8 | u16::from(*b2)))
+      }
+    }
+  }
+
+  fn may_match(&self, specifier: &str) -> bool {
+    self.may_match_bytes(specifier.as_bytes())
+  }
+}
+
 /// Generic implementation of the resolver, can be configured by the [FileSystem] trait
 pub struct ResolverGeneric<Fs> {
   options: ResolveOptions,
   cache: Arc<Cache<Fs>>,
+  alias_first_bytes: AliasFirstBytes,
+  fallback_first_bytes: AliasFirstBytes,
   #[cfg(feature = "yarn_pnp")]
   pnp_manifest: Arc<arc_swap::ArcSwapOption<(PathBuf, pnp::Manifest)>>,
   /// Paths that have been searched and confirmed to have no `.pnp.cjs` reachable by filesystem walk.
@@ -137,9 +188,14 @@ impl<Fs: Send + Sync + FileSystem + Default> Default for ResolverGeneric<Fs> {
 
 impl<Fs: Send + Sync + FileSystem + Default> ResolverGeneric<Fs> {
   pub fn new(options: ResolveOptions) -> Self {
+    let options = options.sanitize();
+    let alias_first_bytes = AliasFirstBytes::build(&options.alias);
+    let fallback_first_bytes = AliasFirstBytes::build(&options.fallback);
     Self {
-      options: options.sanitize(),
+      options,
       cache: Arc::new(Cache::new(Fs::default())),
+      alias_first_bytes,
+      fallback_first_bytes,
       #[cfg(feature = "yarn_pnp")]
       pnp_manifest: Arc::new(arc_swap::ArcSwapOption::empty()),
       #[cfg(feature = "yarn_pnp")]
@@ -151,9 +207,14 @@ impl<Fs: Send + Sync + FileSystem + Default> ResolverGeneric<Fs> {
 
 impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   pub fn new_with_file_system(file_system: Fs, options: ResolveOptions) -> Self {
+    let options = options.sanitize();
+    let alias_first_bytes = AliasFirstBytes::build(&options.alias);
+    let fallback_first_bytes = AliasFirstBytes::build(&options.fallback);
     Self {
-      options: options.sanitize(),
+      options,
       cache: Arc::new(Cache::new(file_system)),
+      alias_first_bytes,
+      fallback_first_bytes,
       #[cfg(feature = "yarn_pnp")]
       pnp_manifest: Arc::new(arc_swap::ArcSwapOption::empty()),
       #[cfg(feature = "yarn_pnp")]
@@ -165,9 +226,14 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   /// Clone the resolver using the same underlying cache.
   #[must_use]
   pub fn clone_with_options(&self, options: ResolveOptions) -> Self {
+    let options = options.sanitize();
+    let alias_first_bytes = AliasFirstBytes::build(&options.alias);
+    let fallback_first_bytes = AliasFirstBytes::build(&options.fallback);
     Self {
-      options: options.sanitize(),
+      options,
       cache: Arc::clone(&self.cache),
+      alias_first_bytes,
+      fallback_first_bytes,
       #[cfg(feature = "yarn_pnp")]
       pnp_manifest: Arc::clone(&self.pnp_manifest),
       #[cfg(feature = "yarn_pnp")]
@@ -330,7 +396,13 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
     // enhanced-resolve: try alias
     if let Some(path) = self
-      .load_alias(cached_path, specifier, &self.options.alias, ctx)
+      .load_alias(
+        cached_path,
+        specifier,
+        &self.options.alias,
+        &self.alias_first_bytes,
+        ctx,
+      )
       .await?
     {
       return Ok(path);
@@ -370,7 +442,13 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
         }
         // enhanced-resolve: try fallback
         self
-          .load_alias(cached_path, specifier, &self.options.fallback, ctx)
+          .load_alias(
+            cached_path,
+            specifier,
+            &self.options.fallback,
+            &self.fallback_first_bytes,
+            ctx,
+          )
           .await
           .and_then(|value| value.ok_or(err))
       }
@@ -800,7 +878,13 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     // enhanced-resolve: try file as alias
     let alias_specifier = cached_path.path().to_string_lossy();
     if let Some(path) = self
-      .load_alias(cached_path, &alias_specifier, &self.options.alias, ctx)
+      .load_alias(
+        cached_path,
+        &alias_specifier,
+        &self.options.alias,
+        &self.alias_first_bytes,
+        ctx,
+      )
       .await?
     {
       return Ok(Some(path));
@@ -1248,8 +1332,14 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     cached_path: &CachedPath,
     specifier: &str,
     aliases: &Alias,
+    first_bytes: &AliasFirstBytes,
     ctx: &mut Ctx,
   ) -> ResolveResult {
+    // Quick reject: if the specifier's first 1–2 bytes can't match any alias
+    // key prefix, no `strip_prefix` in the loop below can succeed.
+    if !first_bytes.may_match(specifier) {
+      return Ok(None);
+    }
     for (alias_key_raw, specifiers) in aliases {
       let alias_key = if let Some(alias_key) = alias_key_raw.strip_suffix('$') {
         if alias_key != specifier {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,12 +120,17 @@ pub type Resolver = ResolverGeneric<FileSystemOs>;
 struct AliasFirstBytes {
   byte1_only: [bool; 256],
   byte12: rustc_hash::FxHashSet<u16>,
+  /// An empty alias key (or a bare `$` exact-match) matches any absolute
+  /// specifier in enhanced-resolve. When present, the prefix gate must
+  /// fall through to the full loop instead of short-circuiting.
+  wildcard: bool,
 }
 
 impl AliasFirstBytes {
   fn build(aliases: &Alias) -> Self {
     let mut byte1_only = [false; 256];
     let mut byte12 = rustc_hash::FxHashSet::default();
+    let mut wildcard = false;
     for (key, _) in aliases {
       // `$`-suffixed keys are exact-match aliases — index by the stripped key.
       let effective = key.strip_suffix('$').unwrap_or(key);
@@ -135,13 +140,20 @@ impl AliasFirstBytes {
         [b1, b2, ..] => {
           byte12.insert(u16::from(*b1) << 8 | u16::from(*b2));
         }
-        [] => {}
+        [] => wildcard = true,
       }
     }
-    Self { byte1_only, byte12 }
+    Self {
+      byte1_only,
+      byte12,
+      wildcard,
+    }
   }
 
   fn may_match_bytes(&self, bytes: &[u8]) -> bool {
+    if self.wildcard {
+      return true;
+    }
     match bytes {
       [] => false,
       [b1] => self.byte1_only[*b1 as usize],

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -376,3 +376,22 @@ async fn star_alias_key_to_ignored_is_literal_prefix() {
     "non-'*' specifier must NOT be ignored, got {normal:?}"
   );
 }
+
+// `"$"` strips down to `""` — an exact-match alias whose key is the empty
+// string, so it can only match the empty specifier. The prefix accelerator
+// records its effective key as a wildcard (to keep the fall-through path
+// open for empty-key aliases), so this test guards against the wildcard flag
+// over-reaching and ignoring normal specifiers.
+#[tokio::test]
+async fn dollar_alias_key_to_ignored_is_exact_match_only() {
+  let f = super::fixture();
+  let resolver = Resolver::new(ResolveOptions {
+    alias: vec![("$".into(), vec![AliasValue::Ignore])],
+    ..ResolveOptions::default()
+  });
+  let normal = resolver.resolve(&f, "./a.js").await;
+  assert!(
+    !matches!(normal, Err(ResolveError::Ignored(_))),
+    "non-empty specifier must NOT be ignored by '$' exact-match alias, got {normal:?}"
+  );
+}

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -353,3 +353,26 @@ async fn empty_alias_key_matches_absolute_specifier() {
     "empty alias key must match an absolute specifier, got {resolution:?}"
   );
 }
+
+// `options.alias` does not interpret `*` as a glob — it's a literal prefix.
+// A specifier starting with `*` should hit the alias, anything else should
+// fall through. Pinning this so the prefix-byte accelerator keeps treating
+// `*` as a normal 1-byte alias key (registered in `byte1_only`).
+#[tokio::test]
+async fn star_alias_key_to_ignored_is_literal_prefix() {
+  let f = super::fixture();
+  let resolver = Resolver::new(ResolveOptions {
+    alias: vec![("*".into(), vec![AliasValue::Ignore])],
+    ..ResolveOptions::default()
+  });
+  let starred = resolver.resolve(&f, "*/anything").await;
+  assert!(
+    matches!(starred, Err(ResolveError::Ignored(_))),
+    "'*'-prefixed specifier must match the literal-prefix alias, got {starred:?}"
+  );
+  let normal = resolver.resolve(&f, "./a.js").await;
+  assert!(
+    !matches!(normal, Err(ResolveError::Ignored(_))),
+    "non-'*' specifier must NOT be ignored, got {normal:?}"
+  );
+}

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -336,19 +336,22 @@ async fn alias_try_fragment_as_path() {
 
 // Regression for the alias prefix-byte accelerator.
 // enhanced-resolve treats an alias key of "" as a wildcard that matches any
-// absolute specifier (`strip_prefix("")` succeeds and the tail starts with
-// `/`). The prefix index must keep this path open instead of short-circuiting.
+// specifier whose tail starts with `/` or `\` (see `path::SLASH_START`). The
+// prefix index must keep this path open instead of short-circuiting.
+//
+// We use a synthesised slash-prefixed specifier instead of the fixture's real
+// absolute path because Windows drive-letter paths (e.g. `D:\...`) don't
+// satisfy `strip_package_name`'s SLASH_START filter on `main` — the alias
+// match would skip there regardless of the prefix index.
 #[tokio::test]
 async fn empty_alias_key_matches_absolute_specifier() {
-  let f = super::fixture();
   let resolver = Resolver::new(ResolveOptions {
     alias: vec![(String::new(), vec![AliasValue::Ignore])],
     ..ResolveOptions::default()
   });
-  let absolute = f.join("a.js").to_str().unwrap().to_string();
-  let resolution = resolver.resolve(&f, &absolute).await;
+  let resolution = resolver.resolve(super::fixture(), "/foo").await;
   assert!(
     matches!(resolution, Err(ResolveError::Ignored(_))),
-    "empty alias key must match an absolute specifier, got {resolution:?}"
+    "empty alias key must match a slash-prefixed specifier, got {resolution:?}"
   );
 }

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -339,7 +339,6 @@ async fn alias_try_fragment_as_path() {
 // absolute specifier (`strip_prefix("")` succeeds and the tail starts with
 // `/`). The prefix index must keep this path open instead of short-circuiting.
 #[tokio::test]
-#[cfg(not(target_os = "windows"))]
 async fn empty_alias_key_matches_absolute_specifier() {
   let f = super::fixture();
   let resolver = Resolver::new(ResolveOptions {
@@ -351,47 +350,5 @@ async fn empty_alias_key_matches_absolute_specifier() {
   assert!(
     matches!(resolution, Err(ResolveError::Ignored(_))),
     "empty alias key must match an absolute specifier, got {resolution:?}"
-  );
-}
-
-// `options.alias` does not interpret `*` as a glob — it's a literal prefix.
-// A specifier starting with `*` should hit the alias, anything else should
-// fall through. Pinning this so the prefix-byte accelerator keeps treating
-// `*` as a normal 1-byte alias key (registered in `byte1_only`).
-#[tokio::test]
-async fn star_alias_key_to_ignored_is_literal_prefix() {
-  let f = super::fixture();
-  let resolver = Resolver::new(ResolveOptions {
-    alias: vec![("*".into(), vec![AliasValue::Ignore])],
-    ..ResolveOptions::default()
-  });
-  let starred = resolver.resolve(&f, "*/anything").await;
-  assert!(
-    matches!(starred, Err(ResolveError::Ignored(_))),
-    "'*'-prefixed specifier must match the literal-prefix alias, got {starred:?}"
-  );
-  let normal = resolver.resolve(&f, "./a.js").await;
-  assert!(
-    !matches!(normal, Err(ResolveError::Ignored(_))),
-    "non-'*' specifier must NOT be ignored, got {normal:?}"
-  );
-}
-
-// `"$"` strips down to `""` — an exact-match alias whose key is the empty
-// string, so it can only match the empty specifier. The prefix accelerator
-// records its effective key as a wildcard (to keep the fall-through path
-// open for empty-key aliases), so this test guards against the wildcard flag
-// over-reaching and ignoring normal specifiers.
-#[tokio::test]
-async fn dollar_alias_key_to_ignored_is_exact_match_only() {
-  let f = super::fixture();
-  let resolver = Resolver::new(ResolveOptions {
-    alias: vec![("$".into(), vec![AliasValue::Ignore])],
-    ..ResolveOptions::default()
-  });
-  let normal = resolver.resolve(&f, "./a.js").await;
-  assert!(
-    !matches!(normal, Err(ResolveError::Ignored(_))),
-    "non-empty specifier must NOT be ignored by '$' exact-match alias, got {normal:?}"
   );
 }

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -333,3 +333,23 @@ async fn alias_try_fragment_as_path() {
   let resolution = resolver.resolve(&f, "#/a").await.map(|r| r.full_path());
   assert_eq!(resolution, Ok(f.join("#").join("a.js")));
 }
+
+// Regression for the alias prefix-byte accelerator.
+// enhanced-resolve treats an alias key of "" as a wildcard that matches any
+// absolute specifier (`strip_prefix("")` succeeds and the tail starts with
+// `/`). The prefix index must keep this path open instead of short-circuiting.
+#[tokio::test]
+#[cfg(not(target_os = "windows"))]
+async fn empty_alias_key_matches_absolute_specifier() {
+  let f = super::fixture();
+  let resolver = Resolver::new(ResolveOptions {
+    alias: vec![(String::new(), vec![AliasValue::Ignore])],
+    ..ResolveOptions::default()
+  });
+  let absolute = f.join("a.js").to_str().unwrap().to_string();
+  let resolution = resolver.resolve(&f, &absolute).await;
+  assert!(
+    matches!(resolution, Err(ResolveError::Ignored(_))),
+    "empty alias key must match an absolute specifier, got {resolution:?}"
+  );
+}


### PR DESCRIPTION
## Why

`load_alias` runs a `strip_prefix` against every alias key for every resolve, even when the specifier's first character can already rule out every key — `./foo` against bare-name aliases like `react`, `@scope/x`, etc. For configs with a few dozen aliases this adds up; the test suite uses 23 aliases and the loop becomes a measurable per-resolve tax.

A tiny precomputed prefix index turns the common "no possible match" case into a single byte-table lookup.

## What

- New `AliasFirstBytes` accelerator built once per `Resolver`:
  - `[bool; 256]` for first-byte hits of length-1 alias keys (e.g. `"@"`)
  - `FxHashSet<u16>` for the first 2 bytes of longer alias keys
- `load_alias` calls `first_bytes.may_match(specifier)` upfront and returns `Ok(None)` immediately when nothing can match.
- `ResolverGeneric` gains two fields (`alias_first_bytes`, `fallback_first_bytes`), populated in `new` / `new_with_file_system` / `clone_with_options`.

### Edge cases

- `$`-suffixed exact-match keys are indexed by their **stripped** form, so alias `"b$"` records first byte `b`, and specifier `"b"` still enters the matching loop.
- Single-byte alias keys are tracked separately so any specifier starting with that byte enters the loop regardless of its second byte.

## Before / after (local, warm-cache)

Measured on Apple M4 Pro with a long-lived `Resolver` (`LazyLock`-shared so the cache survives across criterion samples). Criterion baseline diff:

| Scenario | main | PR | change |
|---|---|---|---|
| single-thread (40 cases) | 83.7 µs | 64.0 µs | **−26.3%** |
| multi-thread (40 cases) | 92.8 µs | 82.2 µs | **−12.7%** |
| symlinks (10000 resolves) | 13.4 ms | 9.3 ms | **−30.4%** |

The official `benches/resolver.rs` does `clear_cache()` per iter (cold cache); the alias-loop short-circuit still applies there but is overshadowed by FS I/O. CodSpeed CI should still surface the per-resolve instruction-count drop.

## Test plan

- [x] `cargo test --lib` — 125 pass, 6 pre-existing pnp fixture failures unrelated
- [x] `cargo clippy --all-features -- -D warnings` (via pre-commit hook)
- [x] Aligns with existing `load_alias` semantics — the existing `strip_prefix` loop is unchanged behind the gate
