### PR TITLE
perf(cache): hash CachedPath by raw bytes on unix

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,3 +1,5 @@
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
 use std::{
   borrow::{Borrow, Cow},
   convert::AsRef,
@@ -45,6 +47,12 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
   pub fn value(&self, path: &Path) -> CachedPath {
     let hash = {
       let mut hasher = FxHasher::default();
+      // On Unix, hash the raw path bytes in one bulk `Hasher::write`. The std
+      // `Path::hash` impl walks components (utf8 split + per-segment write)
+      // and dominated profile samples on this cache-lookup hot path.
+      #[cfg(unix)]
+      hasher.write(path.as_os_str().as_bytes());
+      #[cfg(not(unix))]
       path.hash(&mut hasher);
       hasher.finish()
     };


### PR DESCRIPTION
## Why

`Cache::value` runs `std::path::Path::hash` on every cache probe. The std impl walks components (utf8 split on `/`) and calls `Hasher::write` once per segment plus a final length write. On the resolver hot path this hashing alone accounted for **~8.3% of total Ir** in callgrind.

This PR collapses that into a single bulk `Hasher::write` over `OsStr::as_bytes()` (Unix only, to stay within the crate's `1.70` MSRV). **`PartialEq` is intentionally left as `Path::eq`** so semantic equality is unchanged — strict hash-only variant.

Trade-off: two `Path::eq` paths that differ only in trailing `/` or repeated `/` will now hash to different buckets, potentially creating duplicate cache entries. This is correctness-preserving (cache is pure memoization, parent chains converge because `Path::parent()` strips trailing/repeated separators), and never occurs for resolver-internal lookups which all go through `PathBuf::join`.

## Before / after (codspeed simulation, full `resolver` bench, linux/amd64)

| Metric            | Before        | After         | Delta      |
| ----------------- | ------------: | ------------: | ---------: |
| Ir                | 1,010,344,675 |   941,577,435 | **-6.81%** |
| accesses          | 1,438,723,887 | 1,361,182,810 | **-5.39%** |
| estimated_cycles  | 1,766,209,707 | 1,678,706,195 | **-4.95%** |

`Path::hash` (formerly the #3 hotspot at ~30M Ir) no longer appears in the top hotspots after this change.

## CodSpeed results (full matrix vs main)

| Bench | Mode | Base | Head | Δ |
| ----- | ---- | ---: | ---: | ---: |
| `single-thread` | Simulation | 55.5 ms | 52.2 ms | **+6.21%** |
| `[single-threaded]resolve with many extensions` | Simulation | 142.7 ms | 131.5 ms | **+8.52%** |
| `multi-thread` | Simulation | 62.9 ms | 60.4 ms | **+4.11%** |
| `resolve from symlinks` | Simulation | 180.7 ms | 160.4 ms | **+12.63%** |
| `resolve from symlinks multi thread` | Simulation | 109.5 ms | 97.2 ms | **+12.66%** |
| `pnp resolve` | Simulation | 274.7 µs | 266.4 µs | **+3.14%** |
| `pnp resolve` | Memory | 8.8 KB | 8.4 KB | **+4.26%** |
| `multi-thread` | Memory | 10.7 MB | 11.9 MB | **-10.41%** |
| others (Memory) | — | — | — | unchanged |

### Note on the `multi-thread` Memory regression (+1.2 MB)

The byte-hash itself never allocates (`as_bytes()` is a transmute on Unix, FxHasher is a u64 state machine) and the `CachedPathImpl` layout is identical. The regression is timing-driven: the regression is observed only in the one bench that has **both** high concurrency (1000 simultaneously-spawned tasks) **and** high path diversity (every task hits a different package), so every task takes the cache-miss path through `Arc::new(CachedPathImpl::new(...))`. Faster `Cache::value` lets each task race to the I/O-wait phase sooner, so more in-flight tasks coexist at peak, raising CodSpeed's peak-alloc metric by ~1.2 MB. Evidence:

- `single-thread` / `[single-threaded]resolve with many extensions` (no concurrency burst) — Memory unchanged.
- `resolve from symlinks multi thread` (concurrency burst, but all 10000 tasks share the same parent chain, so almost no miss-path allocations) — Memory unchanged (-0.86%, within noise).
- `multi-thread` Simulation also improved (+4.11%), confirming the work-per-task is lower — the trade is "less CPU per task, more tasks alive at once".

Real-world build tools stream resolves through a bounded executor rather than spawning 1000 simultaneously, so this peak should not be observable outside the bench.

## Correctness

132 of 134 lib/integration tests pass — identical to `main`. The 2 `tests::pnp::*` failures pre-exist on `main` and need a yarn global cache fixture not present locally (verified by stashing and re-running on the parent commit).