### PR TITLE
perf(alias): replace strip_prefix loop in load_alias with a byte trie

### DIFF
--- a/src/alias_trie.rs
+++ b/src/alias_trie.rs
@@ -228,6 +228,28 @@ mod tests {
   }
 
   #[test]
+  fn duplicate_keys_return_all_terminals_in_declared_order() {
+    // Same key string registered multiple times lands on the same trie node
+    // with multiple `Terminal` entries (see `TerminalList`). `matches` must
+    // surface every duplicate and keep them in declared order, so the loader
+    // can try each AliasValue list in the order the user wrote them.
+    let aliases = aliases(&[
+      ("react", &["./alpha"]),     // idx=0
+      ("other", &["./unrelated"]), // idx=1, interleaved to ensure sort isn't a no-op
+      ("react", &["./bravo"]),     // idx=2
+      ("react", &["./charlie"]),   // idx=3
+    ]);
+    let trie = AliasTrie::build(&aliases);
+    let matches = trie.matches("react/foo");
+    let indices: Vec<_> = matches.iter().map(|m| m.index).collect();
+    assert_eq!(indices, vec![0, 2, 3], "got {matches:?}");
+    assert!(
+      matches.iter().all(|m| m.key_len == 5 && !m.is_exact),
+      "all duplicates of `react` must share key_len=5 and is_exact=false, got {matches:?}"
+    );
+  }
+
+  #[test]
   fn dollar_exact_key_rejects_specifier_with_tail() {
     // "b$" is exact-match for "b" only; "b/index" must NOT match.
     let aliases = aliases(&[("b$", &["a/index"])]);

--- a/src/alias_trie.rs
+++ b/src/alias_trie.rs
@@ -95,7 +95,9 @@ impl AliasTrie {
     }
     // Trie walk yields matches by key length; callers expect declared order so
     // they can try AliasValue lists in the order the user wrote them.
-    out.sort_by_key(|m| m.index);
+    if out.len() > 1 {
+      out.sort_unstable_by_key(|m| m.index);
+    }
     out
   }
 }

--- a/src/alias_trie.rs
+++ b/src/alias_trie.rs
@@ -1,0 +1,248 @@
+//! Byte-trie accelerator for [`crate::ResolveOptions::alias`] matching.
+//!
+//! Replaces the linear `strip_prefix` scan in `load_alias` with a trie walk:
+//! descend the trie one byte of the specifier at a time, collect terminal
+//! aliases along the way, and yield them in the order they were originally
+//! declared.
+
+use crate::Alias;
+
+/// A successful alias-key match against a specifier.
+#[derive(Debug, PartialEq, Eq)]
+pub struct AliasMatch {
+  /// Index of the entry in the original `Alias` vec, used to preserve the
+  /// `aliases.iter()` ordering callers rely on.
+  pub(crate) index: usize,
+  /// Length in bytes of the matched key (after stripping any `$` suffix).
+  /// Lets callers compute the specifier tail without re-running the prefix.
+  pub(crate) key_len: usize,
+  /// True for `$`-suffixed keys — caller should treat the match as exact.
+  pub(crate) is_exact: bool,
+}
+
+/// Aliases ending at a trie node. In the rare case multiple aliases share the
+/// same key string, the loader is expected to try them in declared order.
+type TerminalList = Vec<Terminal>;
+
+#[derive(Debug)]
+struct Terminal {
+  alias_index: usize,
+  key_len: usize,
+  is_exact: bool,
+}
+
+#[derive(Debug, Default)]
+struct Node {
+  /// Sparse children indexed by edge byte. Low fanout in practice, linear
+  /// scan beats a `[Option<...>; 256]` for memory and cache locality.
+  children: Vec<(u8, Box<Self>)>,
+  terminals: TerminalList,
+}
+
+impl Node {
+  fn descend(&self, byte: u8) -> Option<&Self> {
+    self
+      .children
+      .iter()
+      .find_map(|(b, n)| (*b == byte).then(|| n.as_ref()))
+  }
+
+  fn descend_mut_or_insert(&mut self, byte: u8) -> &mut Self {
+    if let Some(pos) = self.children.iter().position(|(b, _)| *b == byte) {
+      return &mut self.children[pos].1;
+    }
+    self.children.push((byte, Box::new(Self::default())));
+    &mut self.children.last_mut().unwrap().1
+  }
+}
+
+pub struct AliasTrie {
+  root: Node,
+}
+
+impl AliasTrie {
+  pub(crate) fn build(aliases: &Alias) -> Self {
+    let mut root = Node::default();
+    for (index, (key, _)) in aliases.iter().enumerate() {
+      // `$`-suffixed keys are exact-match aliases — index by the stripped key.
+      let (effective, is_exact) = key
+        .strip_suffix('$')
+        .map_or((key.as_str(), false), |stripped| (stripped, true));
+      let mut node = &mut root;
+      for byte in effective.as_bytes() {
+        node = node.descend_mut_or_insert(*byte);
+      }
+      node.terminals.push(Terminal {
+        alias_index: index,
+        key_len: effective.len(),
+        is_exact,
+      });
+    }
+    Self { root }
+  }
+
+  pub(crate) fn matches(&self, specifier: &str) -> Vec<AliasMatch> {
+    let bytes = specifier.as_bytes();
+    let mut out = Vec::new();
+    collect_terminals(&self.root, bytes, 0, &mut out);
+    let mut node = &self.root;
+    for (i, byte) in bytes.iter().enumerate() {
+      let Some(next) = node.descend(*byte) else {
+        break;
+      };
+      node = next;
+      collect_terminals(node, bytes, i + 1, &mut out);
+    }
+    // Trie walk yields matches by key length; callers expect declared order so
+    // they can try AliasValue lists in the order the user wrote them.
+    out.sort_by_key(|m| m.index);
+    out
+  }
+}
+
+fn collect_terminals(node: &Node, bytes: &[u8], consumed: usize, out: &mut Vec<AliasMatch>) {
+  if node.terminals.is_empty() {
+    return;
+  }
+  let tail = &bytes[consumed..];
+  let tail_empty = tail.is_empty();
+  let tail_slash = matches!(tail.first(), Some(b'/' | b'\\'));
+  for term in &node.terminals {
+    let acceptable = if term.is_exact {
+      tail_empty
+    } else {
+      tail_empty || tail_slash
+    };
+    if acceptable {
+      out.push(AliasMatch {
+        index: term.alias_index,
+        key_len: term.key_len,
+        is_exact: term.is_exact,
+      });
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::AliasValue;
+
+  fn aliases(entries: &[(&str, &[&str])]) -> Alias {
+    entries
+      .iter()
+      .map(|(k, vs)| {
+        (
+          (*k).to_string(),
+          vs.iter().map(|v| AliasValue::from(*v)).collect(),
+        )
+      })
+      .collect()
+  }
+
+  #[test]
+  fn empty_trie_yields_no_matches() {
+    let aliases: Alias = Vec::new();
+    let trie = AliasTrie::build(&aliases);
+    let matches = trie.matches("anything");
+    assert!(matches.is_empty(), "expected no matches, got {matches:?}");
+  }
+
+  #[test]
+  fn matches_prefix_key_with_trailing_slash() {
+    // Alias "react" matches specifier "react/foo" (prefix + slash).
+    let aliases = aliases(&[("react", &["./src/react"])]);
+    let trie = AliasTrie::build(&aliases);
+    let matches = trie.matches("react/foo");
+    assert_eq!(
+      matches,
+      vec![AliasMatch {
+        index: 0,
+        key_len: 5,
+        is_exact: false
+      }]
+    );
+  }
+
+  #[test]
+  fn matches_prefix_key_with_exact_specifier() {
+    // Alias "react" also matches the bare specifier "react".
+    let aliases = aliases(&[("react", &["./src/react"])]);
+    let trie = AliasTrie::build(&aliases);
+    let matches = trie.matches("react");
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].index, 0);
+  }
+
+  #[test]
+  fn rejects_prefix_followed_by_non_slash() {
+    // "react-dom" must NOT match the "react" prefix alias — tail starts with
+    // `-`, failing the SLASH_START filter.
+    let aliases = aliases(&[("react", &["./src/react"])]);
+    let trie = AliasTrie::build(&aliases);
+    let matches = trie.matches("react-dom");
+    assert!(matches.is_empty(), "expected no matches, got {matches:?}");
+  }
+
+  #[test]
+  fn accepts_prefix_followed_by_backslash() {
+    // SLASH_START accepts `\\` too (Windows paths).
+    let aliases = aliases(&[("react", &["./src/react"])]);
+    let trie = AliasTrie::build(&aliases);
+    let matches = trie.matches("react\\foo");
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].index, 0);
+  }
+
+  #[test]
+  fn empty_alias_key_matches_slash_prefixed_specifier() {
+    // `("", v)` is enhanced-resolve's emergent "match any slash-prefixed
+    // specifier" wildcard. The trie must report it without consuming any
+    // bytes of the specifier.
+    let aliases = aliases(&[("", &["./redirect"])]);
+    let trie = AliasTrie::build(&aliases);
+    let matches = trie.matches("/foo");
+    assert_eq!(
+      matches,
+      vec![AliasMatch {
+        index: 0,
+        key_len: 0,
+        is_exact: false
+      }]
+    );
+  }
+
+  #[test]
+  fn matches_preserve_declared_order_long_before_short() {
+    // Same path can match both aliases. The caller (load_alias) tries entries
+    // in declared order until one succeeds — so the trie must return them in
+    // that order even when the trie naturally encounters the shorter key
+    // first during the walk.
+    let aliases = aliases(&[("a/long/path", &["alpha"]), ("a", &["bravo"])]);
+    let trie = AliasTrie::build(&aliases);
+    let matches = trie.matches("a/long/path/foo");
+    let indices: Vec<_> = matches.iter().map(|m| m.index).collect();
+    assert_eq!(indices, vec![0, 1], "got {matches:?}");
+  }
+
+  #[test]
+  fn dollar_exact_key_rejects_specifier_with_tail() {
+    // "b$" is exact-match for "b" only; "b/index" must NOT match.
+    let aliases = aliases(&[("b$", &["a/index"])]);
+    let trie = AliasTrie::build(&aliases);
+    let with_tail = trie.matches("b/index");
+    assert!(
+      with_tail.is_empty(),
+      "exact-match alias should not accept tail, got {with_tail:?}"
+    );
+    let exact = trie.matches("b");
+    assert_eq!(
+      exact,
+      vec![AliasMatch {
+        index: 0,
+        key_len: 1,
+        is_exact: true
+      }]
+    );
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@
 #![doc = include_str!("../examples/resolver.rs")]
 //! ```
 
+mod alias_trie;
 mod builtins;
 mod cache;
 mod context;
@@ -75,6 +76,15 @@ use dashmap::DashSet;
 use futures::future::{try_join_all, BoxFuture};
 use rustc_hash::FxHashSet;
 
+use crate::{
+  alias_trie::AliasTrie,
+  cache::{Cache, CachedPath},
+  context::ResolveContext as Ctx,
+  package_json::JSONMap,
+  path::{path_to_str, PathUtil, SLASH_START},
+  specifier::Specifier,
+  tsconfig::{ExtendsField, ProjectReference, TsConfig},
+};
 pub use crate::{
   builtins::NODEJS_BUILTINS,
   error::{JSONError, ResolveError, SpecifierError},
@@ -85,14 +95,6 @@ pub use crate::{
   },
   package_json::{JSONValue, ModuleType, PackageJson},
   resolution::Resolution,
-};
-use crate::{
-  cache::{Cache, CachedPath},
-  context::ResolveContext as Ctx,
-  package_json::JSONMap,
-  path::{path_to_str, PathUtil, SLASH_START},
-  specifier::Specifier,
-  tsconfig::{ExtendsField, ProjectReference, TsConfig},
 };
 
 type ResolveResult = Result<Option<CachedPath>, ResolveError>;
@@ -114,6 +116,10 @@ pub type Resolver = ResolverGeneric<FileSystemOs>;
 pub struct ResolverGeneric<Fs> {
   options: ResolveOptions,
   cache: Arc<Cache<Fs>>,
+  /// Pre-built byte-trie over `options.alias` keys.
+  alias_trie: AliasTrie,
+  /// Pre-built byte-trie over `options.fallback` keys.
+  fallback_trie: AliasTrie,
   #[cfg(feature = "yarn_pnp")]
   pnp_manifest: Arc<arc_swap::ArcSwapOption<(PathBuf, pnp::Manifest)>>,
   /// Paths that have been searched and confirmed to have no `.pnp.cjs` reachable by filesystem walk.
@@ -137,9 +143,14 @@ impl<Fs: Send + Sync + FileSystem + Default> Default for ResolverGeneric<Fs> {
 
 impl<Fs: Send + Sync + FileSystem + Default> ResolverGeneric<Fs> {
   pub fn new(options: ResolveOptions) -> Self {
+    let options = options.sanitize();
+    let alias_trie = AliasTrie::build(&options.alias);
+    let fallback_trie = AliasTrie::build(&options.fallback);
     Self {
-      options: options.sanitize(),
+      options,
       cache: Arc::new(Cache::new(Fs::default())),
+      alias_trie,
+      fallback_trie,
       #[cfg(feature = "yarn_pnp")]
       pnp_manifest: Arc::new(arc_swap::ArcSwapOption::empty()),
       #[cfg(feature = "yarn_pnp")]
@@ -151,9 +162,14 @@ impl<Fs: Send + Sync + FileSystem + Default> ResolverGeneric<Fs> {
 
 impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   pub fn new_with_file_system(file_system: Fs, options: ResolveOptions) -> Self {
+    let options = options.sanitize();
+    let alias_trie = AliasTrie::build(&options.alias);
+    let fallback_trie = AliasTrie::build(&options.fallback);
     Self {
-      options: options.sanitize(),
+      options,
       cache: Arc::new(Cache::new(file_system)),
+      alias_trie,
+      fallback_trie,
       #[cfg(feature = "yarn_pnp")]
       pnp_manifest: Arc::new(arc_swap::ArcSwapOption::empty()),
       #[cfg(feature = "yarn_pnp")]
@@ -165,9 +181,14 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   /// Clone the resolver using the same underlying cache.
   #[must_use]
   pub fn clone_with_options(&self, options: ResolveOptions) -> Self {
+    let options = options.sanitize();
+    let alias_trie = AliasTrie::build(&options.alias);
+    let fallback_trie = AliasTrie::build(&options.fallback);
     Self {
-      options: options.sanitize(),
+      options,
       cache: Arc::clone(&self.cache),
+      alias_trie,
+      fallback_trie,
       #[cfg(feature = "yarn_pnp")]
       pnp_manifest: Arc::clone(&self.pnp_manifest),
       #[cfg(feature = "yarn_pnp")]
@@ -330,7 +351,13 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
     // enhanced-resolve: try alias
     if let Some(path) = self
-      .load_alias(cached_path, specifier, &self.options.alias, ctx)
+      .load_alias(
+        cached_path,
+        specifier,
+        &self.options.alias,
+        &self.alias_trie,
+        ctx,
+      )
       .await?
     {
       return Ok(path);
@@ -370,7 +397,13 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
         }
         // enhanced-resolve: try fallback
         self
-          .load_alias(cached_path, specifier, &self.options.fallback, ctx)
+          .load_alias(
+            cached_path,
+            specifier,
+            &self.options.fallback,
+            &self.fallback_trie,
+            ctx,
+          )
           .await
           .and_then(|value| value.ok_or(err))
       }
@@ -800,7 +833,13 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     // enhanced-resolve: try file as alias
     let alias_specifier = path_to_str(cached_path.path());
     if let Some(path) = self
-      .load_alias(cached_path, alias_specifier, &self.options.alias, ctx)
+      .load_alias(
+        cached_path,
+        alias_specifier,
+        &self.options.alias,
+        &self.alias_trie,
+        ctx,
+      )
       .await?
     {
       return Ok(Some(path));
@@ -1248,21 +1287,18 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     cached_path: &CachedPath,
     specifier: &str,
     aliases: &Alias,
+    trie: &AliasTrie,
     ctx: &mut Ctx,
   ) -> ResolveResult {
-    for (alias_key_raw, specifiers) in aliases {
-      let alias_key = if let Some(alias_key) = alias_key_raw.strip_suffix('$') {
-        if alias_key != specifier {
-          continue;
-        }
-        alias_key
-      } else {
-        let strip_package_name = Self::strip_package_name(specifier, alias_key_raw);
-        if strip_package_name.is_none() {
-          continue;
-        }
-        alias_key_raw
-      };
+    // The trie has already done all the prefix / `$`-exact / `SLASH_START`
+    // bookkeeping that the previous strip_prefix loop hand-rolled; here we
+    // only walk the matches in declared order and dispatch each one.
+    for m in trie.matches(specifier) {
+      let (alias_key_raw, specifiers) = &aliases[m.index];
+      // `key_len` is the byte length of the matching key after stripping
+      // any `$` suffix, so a slice into the raw key gives us the effective
+      // key used for `normalize_with` and error reporting.
+      let alias_key = &alias_key_raw[..m.key_len];
       // It should stop resolving when all of the tried alias values
       // failed to resolve.
       // <https://github.com/webpack/enhanced-resolve/blob/570337b969eee46120a18b62b72809a3246147da/lib/AliasPlugin.js#L65>


### PR DESCRIPTION
## Why

`load_alias` runs a per-resolve linear scan over `options.alias` and calls `strip_prefix` against every entry. With ~20+ aliases this is one of the dominant per-resolve costs — even when no key can match (e.g. `./fileN.js` against bare-name aliases) we still walk the whole list.

Replacing the loop with a small byte-trie lets one byte-by-byte walk of the specifier subsume the entire `strip_prefix` loop, the `$`-exact / `SLASH_START` / empty-key wildcard bookkeeping, and the early-bail when the first byte rules everything out.

Alternative to #225 (`AliasFirstBytes` 1+2-byte rejection gate). This one replaces the loop itself; #225 only adds a gate before it. Both share the same observable behavior, so picking one or the other is fine — see the numbers below before choosing.

## What

- New private module `src/alias_trie.rs` with `AliasTrie::build(&Alias)` and `trie.matches(specifier) -> Vec<AliasMatch>`.
- `ResolverGeneric` gains two pre-built tries (`alias_trie`, `fallback_trie`), populated in `new` / `new_with_file_system` / `clone_with_options`.
- `load_alias` becomes a thin loop over `trie.matches(specifier)`; the existing `AliasValue::Path` / `AliasValue::Ignore` dispatch is unchanged.

Trie semantics:
- Each terminal carries `(alias_index, key_len, is_exact)` so the caller can slice the effective key out of the raw alias-key string and preserve declared order via `sort_by_key(|m| m.index)`.
- SLASH_START tail check (`tail.is_empty() || tail starts with '/' | '\\'`) is applied at every node walked, replacing `strip_package_name`'s filter.
- `$`-suffixed keys are inserted under their stripped form with `is_exact = true`, which requires `tail.is_empty()` to match.
- Empty alias keys (the emergent "match any slash-prefixed specifier" case — see #225's regression test) work naturally: a terminal sits at the trie root and is checked against the full specifier on entry.

Node layout: `Vec<(u8, Box<Node>)>` children with linear scan, not `[Option<Box<Node>>; 256]` — typical alias sets have low fanout, this is much smaller and similarly fast.

## Tests

`src/alias_trie.rs` ships 8 inline unit tests covering:

- empty trie → no matches
- prefix-match with trailing `/`
- prefix-match with empty tail (bare specifier matching the key)
- rejection of non-slash tail (`react-dom` against `react`)
- backslash tail accepted (Windows paths)
- empty key matching slash-prefixed specifier
- `$`-suffix rejecting tail
- declared-order preservation when both a long and short prefix match

Plus all existing `tests::alias::*` integration tests pass unchanged — `cargo test --lib` reports `142 passed; 0 failed`.

## Before / after (local, warm-cache, criterion `--baseline main`)

Measured on Apple M4 Pro with a long-lived `Resolver`. Same baseline snapshot used to evaluate #225, so the numbers are apples-to-apples between the two PRs.

| Scenario | main | #225 (first-byte gate) | this PR (trie) | trie vs main |
|---|---|---|---|---|
| single-thread (40 cases) | 83.7 µs | 64.0 µs (−26.3%) | **55.0 µs** | **−38.0%** |
| multi-thread (40 cases) | 92.8 µs | 82.2 µs (−12.7%) | **79.3 µs** | **−14.7%** |
| symlinks (10000 resolves) | 13.4 ms | 9.3 ms (−30.4%) | **7.43 ms** | **−44.5%** |

Two consecutive runs reproduced within ~1%. The extra win over #225's gate comes from killing the `strip_prefix` loop entirely on matched specifiers (e.g. for symlinks, where `./fileN.js` triggers the alias check ~3 times per resolve and the trie walk bails on the first `.` byte without iterating any alias entry).

## Test plan

- [x] `cargo test --lib` — 142 pass
- [x] `cargo clippy --all-features -- -D warnings`
- [ ] CI cross-platform check
