### PR TITLE
chore(bench): warm pnp manifest outside the timed loop

### DIFF
--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -375,23 +375,22 @@ fn bench_resolver(c: &mut Criterion) {
     &root_range,
     |b, data| {
       let runner = runtime::Runtime::new().expect("failed to create tokio runtime");
+      let setup_runner = runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to create setup tokio runtime");
       let rspack_resolver = Arc::new(rspack_resolver(true));
-
-      // Warm the PnP manifest (one-time work in real usage). Without this,
-      // `pnp::load_pnp_manifest` — which reads and regex-compiles a ~250KB
-      // `.pnp.cjs` — dominated the inner loop and made the resolver's own
-      // cost ~28% of the sample, drowning small resolver-level deltas.
-      //
-      // The FS metadata cache is still cleared per-iteration via
-      // `clear_fs_cache` so each measurement reflects real resolver work,
-      // not a fully-hot run.
-      runner.block_on(async {
-        let _ = rspack_resolver.resolve(pnp_workspace.join("1"), "preact").await;
-      });
 
       b.to_async(runner).iter_with_setup(
         || {
-          rspack_resolver.clear_fs_cache();
+          // Drop all caches, then resolve once so the PnP manifest is loaded
+          // and parsed before the timed body starts. Without this, the inner
+          // resolve re-runs `pnp::load_pnp_manifest` (a ~250KB regex compile)
+          // every iteration and drowns out resolver-level deltas.
+          rspack_resolver.clear_cache();
+          setup_runner.block_on(async {
+            let _ = rspack_resolver.resolve(pnp_workspace.join("1"), "preact").await;
+          });
         },
         |_| async {
           for i in data.clone() {

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -375,22 +375,29 @@ fn bench_resolver(c: &mut Criterion) {
     &root_range,
     |b, data| {
       let runner = runtime::Runtime::new().expect("failed to create tokio runtime");
-      let setup_runner = runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("failed to create setup tokio runtime");
       let rspack_resolver = Arc::new(rspack_resolver(true));
 
       b.to_async(runner).iter_with_setup(
         || {
-          // Drop all caches, then resolve once so the PnP manifest is loaded
-          // and parsed before the timed body starts. Without this, the inner
-          // resolve re-runs `pnp::load_pnp_manifest` (a ~250KB regex compile)
-          // every iteration and drowns out resolver-level deltas.
+          // Drop all caches, then reload the PnP manifest before the timed
+          // body runs. The manifest re-parse (~250KB regex compile) is
+          // one-time work in real usage; keeping it out of the timed loop
+          // lets resolver-level deltas surface.
+          //
+          // `iter_with_setup`'s setup runs inside the outer
+          // `runner.block_on`, so a nested `block_on` would panic. Spawn the
+          // warmup onto the same multi-thread runtime and sync-wait on a
+          // channel; another worker drives the future while this thread
+          // blocks on `recv`.
           rspack_resolver.clear_cache();
-          setup_runner.block_on(async {
-            let _ = rspack_resolver.resolve(pnp_workspace.join("1"), "preact").await;
+          let resolver = Arc::clone(&rspack_resolver);
+          let workspace = pnp_workspace.clone();
+          let (tx, rx) = std::sync::mpsc::channel();
+          tokio::runtime::Handle::current().spawn(async move {
+            let _ = resolver.resolve(workspace.join("1"), "preact").await;
+            let _ = tx.send(());
           });
+          rx.recv().expect("pnp manifest warmup failed");
         },
         |_| async {
           for i in data.clone() {

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -377,18 +377,23 @@ fn bench_resolver(c: &mut Criterion) {
       let runner = runtime::Runtime::new().expect("failed to create tokio runtime");
       let rspack_resolver = Arc::new(rspack_resolver(true));
 
-      b.to_async(runner).iter_with_setup(
-        || {
-          rspack_resolver.clear_cache();
-        },
-        |_| async {
-          for i in data.clone() {
-            let _ = rspack_resolver
-              .resolve(pnp_workspace.join(format!("{i}")), "preact")
-              .await;
-          }
-        },
-      );
+      // Warm the PnP manifest (one-time work in real usage). Without this,
+      // `pnp::load_pnp_manifest` — which reads and regex-compiles a ~250KB
+      // `.pnp.cjs` — dominated the inner loop and made the resolver's own
+      // cost ~28% of the sample, drowning small resolver-level deltas.
+      runner.block_on(async {
+        for i in data.clone() {
+          let _ =
+            rspack_resolver.resolve(pnp_workspace.join(format!("{i}")), "preact").await;
+        }
+      });
+
+      b.to_async(runner).iter(|| async {
+        for i in data.clone() {
+          let _ =
+            rspack_resolver.resolve(pnp_workspace.join(format!("{i}")), "preact").await;
+        }
+      });
     },
   );
 }

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -377,34 +377,27 @@ fn bench_resolver(c: &mut Criterion) {
       let runner = runtime::Runtime::new().expect("failed to create tokio runtime");
       let rspack_resolver = Arc::new(rspack_resolver(true));
 
-      b.to_async(runner).iter_with_setup(
+      b.iter_with_setup(
         || {
           // Drop all caches, then reload the PnP manifest before the timed
           // body runs. The manifest re-parse (~250KB regex compile) is
           // one-time work in real usage; keeping it out of the timed loop
           // lets resolver-level deltas surface.
-          //
-          // `iter_with_setup`'s setup runs inside the outer
-          // `runner.block_on`, so a nested `block_on` would panic. Spawn the
-          // warmup onto the same multi-thread runtime and sync-wait on a
-          // channel; another worker drives the future while this thread
-          // blocks on `recv`.
           rspack_resolver.clear_cache();
-          let resolver = Arc::clone(&rspack_resolver);
-          let workspace = pnp_workspace.clone();
-          let (tx, rx) = std::sync::mpsc::channel();
-          tokio::runtime::Handle::current().spawn(async move {
-            let _ = resolver.resolve(workspace.join("1"), "preact").await;
-            let _ = tx.send(());
-          });
-          rx.recv().expect("pnp manifest warmup failed");
-        },
-        |_| async {
-          for i in data.clone() {
+          runner.block_on(async {
             let _ = rspack_resolver
-              .resolve(pnp_workspace.join(format!("{i}")), "preact")
+              .resolve(pnp_workspace.join("1"), "preact")
               .await;
-          }
+          });
+        },
+        |_| {
+          runner.block_on(async {
+            for i in data.clone() {
+              let _ = rspack_resolver
+                .resolve(pnp_workspace.join(format!("{i}")), "preact")
+                .await;
+            }
+          });
         },
       );
     },

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -381,19 +381,26 @@ fn bench_resolver(c: &mut Criterion) {
       // `pnp::load_pnp_manifest` — which reads and regex-compiles a ~250KB
       // `.pnp.cjs` — dominated the inner loop and made the resolver's own
       // cost ~28% of the sample, drowning small resolver-level deltas.
+      //
+      // The FS metadata cache is still cleared per-iteration via
+      // `clear_fs_cache` so each measurement reflects real resolver work,
+      // not a fully-hot run.
       runner.block_on(async {
-        for i in data.clone() {
-          let _ =
-            rspack_resolver.resolve(pnp_workspace.join(format!("{i}")), "preact").await;
-        }
+        let _ = rspack_resolver.resolve(pnp_workspace.join("1"), "preact").await;
       });
 
-      b.to_async(runner).iter(|| async {
-        for i in data.clone() {
-          let _ =
-            rspack_resolver.resolve(pnp_workspace.join(format!("{i}")), "preact").await;
-        }
-      });
+      b.to_async(runner).iter_with_setup(
+        || {
+          rspack_resolver.clear_fs_cache();
+        },
+        |_| async {
+          for i in data.clone() {
+            let _ = rspack_resolver
+              .resolve(pnp_workspace.join(format!("{i}")), "preact")
+              .await;
+          }
+        },
+      );
     },
   );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,16 +191,6 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     }
   }
 
-  /// Clear only the filesystem metadata cache.
-  ///
-  /// Unlike [`Self::clear_cache`], any loaded PnP manifest is preserved. Used
-  /// by the `pnp resolve` benchmark to keep manifest bootstrap out of the
-  /// hot path while still measuring real FS-cold resolver work.
-  #[doc(hidden)]
-  pub fn clear_fs_cache(&self) {
-    self.cache.clear();
-  }
-
   /// Resolve `specifier` at an absolute path to a `directory`.
   ///
   /// A specifier is the string passed to require or import, i.e. `require("specifier")` or `import "specifier"`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,16 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     }
   }
 
+  /// Clear only the filesystem metadata cache.
+  ///
+  /// Unlike [`Self::clear_cache`], any loaded PnP manifest is preserved. Used
+  /// by the `pnp resolve` benchmark to keep manifest bootstrap out of the
+  /// hot path while still measuring real FS-cold resolver work.
+  #[doc(hidden)]
+  pub fn clear_fs_cache(&self) {
+    self.cache.clear();
+  }
+
   /// Resolve `specifier` at an absolute path to a `directory`.
   ///
   /// A specifier is the string passed to require or import, i.e. `require("specifier")` or `import "specifier"`.


### PR DESCRIPTION
## Notice
Not a performance improvement; make the benchmark focus just on resolving PnP deps by excluding PnP manifest loading noise.

Manifest loading will be benchmarked in another case.


## Why

The `pnp resolve` benchmark called `clear_cache()` before every iteration. That dropped the loaded PnP manifest, so the next `resolve()` re-ran `pnp::load_pnp_manifest`, which reads and regex-compiles a ~250KB `.pnp.cjs`.

Looking at the [flame graph](https://codspeed.io/rstackjs/rspack-resolver/branches/perf_micro_opt_1?uri=benches%2Fresolver.rs%3A%3Aresolver%3A%3Abench_resolver%3A%3Aresolver%255Bpnp%2520resolve%255D&runnerMode=Simulation):

| Where time goes | Share |
| --- | ---: |
| `pnp::load_pnp_manifest` (one-time bootstrap, mostly `fancy_regex::compile`) | **~72%** |
| `rspack_resolver` code under test | ~28% |

That means small resolver-level deltas (1–5%) are swallowed by manifest-load noise. The `perf_micro_opt_1` branch shipped real wins on every other benchmark (single-thread +6%, multi-thread +5%, symlinks +12%) but appeared as a `-3.86%` "regression" here purely because the dominant 72% term is unrelated bootstrap.

## What

In the `iter_with_setup` setup callback: keep the existing `clear_cache()`, then resolve once against the PnP workspace on a separate current-thread runtime. The single resolve re-loads the manifest before the timed body runs.

Net effect per iteration:
- Manifest: **warm** (loaded once in setup, not timed)
- FS metadata caches for the 10 timed paths: **cold** (only one path's ancestors were warmed in setup; the other 9 still hit cold cache)

So each measurement reflects real resolver work — cold metadata lookups, cold `package.json` parses, PnP lookup against an in-memory manifest — without the one-time 250KB regex compile dominating the sample.