### PR TITLE
refactor(resolver): store internal paths as str/String

### DIFF
--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -6,7 +6,7 @@ use std::{
   fs::read_to_string,
   future::Future,
   io::{self, Write},
-  path::{Path, PathBuf},
+  path::Path,
   sync::Arc,
 };
 
@@ -66,7 +66,7 @@ fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<(
   }
 }
 
-fn create_symlinks() -> io::Result<PathBuf> {
+fn create_symlinks() -> io::Result<String> {
   let root = env::current_dir()?.join("fixtures/enhanced_resolve");
   let dirname = root.join("test");
   let temp_path = dirname.join("temp_symlinks");
@@ -89,7 +89,12 @@ fn create_symlinks() -> io::Result<PathBuf> {
       return Err(err);
     }
   }
-  Ok(temp_path)
+  Ok(
+    temp_path
+      .to_str()
+      .expect("path should be UTF-8")
+      .to_string(),
+  )
 }
 
 fn rspack_resolver(enable_pnp: bool) -> rspack_resolver::Resolver {
@@ -172,7 +177,7 @@ fn resolver_with_many_extensions() -> rspack_resolver::Resolver {
 
 fn create_async_resolve_task(
   rspack_resolver: Arc<rspack_resolver::Resolver>,
-  path: PathBuf,
+  path: String,
   request: String,
 ) -> impl Future<Output = ()> {
   async move {
@@ -181,7 +186,12 @@ fn create_async_resolve_task(
 }
 
 fn bench_resolver(c: &mut Criterion) {
-  let cwd = env::current_dir().unwrap().join("benches");
+  let cwd = env::current_dir()
+    .unwrap()
+    .join("benches")
+    .to_str()
+    .expect("path should be UTF-8")
+    .to_string();
 
   let pkg_content = read_to_string("./benches/package.json").unwrap();
   let pkg_json: Value = serde_json::from_str(&pkg_content).unwrap();
@@ -190,7 +200,7 @@ fn bench_resolver(c: &mut Criterion) {
     .as_object()
     .unwrap()
     .keys()
-    .map(|name| (&cwd, name))
+    .map(|name| (cwd.clone(), name.clone()))
     .collect::<Vec<_>>();
 
   // check validity
@@ -306,7 +316,7 @@ fn bench_resolver(c: &mut Criterion) {
             data.iter().for_each(|(path, request)| {
               join_set.spawn(create_async_resolve_task(
                 rspack_resolver.clone(),
-                path.to_path_buf(),
+                path.clone(),
                 request.to_string(),
               ));
             });
@@ -367,7 +377,12 @@ fn bench_resolver(c: &mut Criterion) {
     },
   );
 
-  let pnp_workspace = env::current_dir().unwrap().join("fixtures/pnp");
+  let pnp_workspace = env::current_dir()
+    .unwrap()
+    .join("fixtures/pnp")
+    .to_str()
+    .expect("path should be UTF-8")
+    .to_string();
   let root_range = 1..11;
 
   group.bench_with_input(
@@ -384,7 +399,7 @@ fn bench_resolver(c: &mut Criterion) {
         |_| async {
           for i in data.clone() {
             let _ = rspack_resolver
-              .resolve(pnp_workspace.join(format!("{i}")), "preact")
+              .resolve(format!("{pnp_workspace}/{i}"), "preact")
               .await;
           }
         },

--- a/examples/resolver.rs
+++ b/examples/resolver.rs
@@ -5,13 +5,18 @@ use rspack_resolver::{AliasValue, ResolveOptions, Resolver};
 
 #[tokio::main]
 async fn main() {
-  let path = PathBuf::from(env::args().nth(1).expect("path"));
+  let path_buf = PathBuf::from(env::args().nth(1).expect("path"));
 
   assert!(
-    path.is_dir(),
-    "{path:?} must be a directory that will be resolved against."
+    path_buf.is_dir(),
+    "{path_buf:?} must be a directory that will be resolved against."
   );
-  assert!(path.is_absolute(), "{path:?} must be an absolute path.",);
+  assert!(
+    path_buf.is_absolute(),
+    "{path_buf:?} must be an absolute path.",
+  );
+
+  let path = path_buf.to_str().expect("path should be UTF-8").to_string();
 
   let specifier = env::args().nth(2).expect("specifier");
 

--- a/napi/__test__/resolver.test.mjs
+++ b/napi/__test__/resolver.test.mjs
@@ -273,11 +273,17 @@ describe("resolver", () => {
     const pnpProjectRoot = join(rootDir, "fixtures", "pnp");
     const resolver = new ResolverFactory({ enablePnp: true });
 
-    expect(resolver.sync(pnpProjectRoot, "is-even")).toEqual({
-      path: join(
-        pnpProjectRoot,
-        ".yarn/cache/is-even-npm-1.0.0-9f726520dc-2728cc2f39.zip/node_modules/is-even/index.js"
+    // pnp returns POSIX-style paths even on Windows; normalize both sides so
+    // the comparison is separator-agnostic (mirrors how the Rust-side tests
+    // wrap with `PathBuf` for component-wise eq).
+    const result = resolver.sync(pnpProjectRoot, "is-even");
+    expect(normalize(result.path)).toEqual(
+      normalize(
+        join(
+          pnpProjectRoot,
+          ".yarn/cache/is-even-npm-1.0.0-9f726520dc-2728cc2f39.zip/node_modules/is-even/index.js"
+        )
       )
-    });
+    );
   });
 });

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -1,11 +1,7 @@
 mod options;
 mod tracing;
 
-use std::{
-  path::{Path, PathBuf},
-  sync::Arc,
-  vec,
-};
+use std::sync::Arc;
 
 use napi::tokio::runtime;
 use napi_derive::napi;
@@ -23,16 +19,10 @@ pub struct ResolveResult {
   pub module_type: Option<String>,
 }
 
-async fn resolve(resolver: &Resolver, path: &Path, request: &str) -> ResolveResult {
+async fn resolve(resolver: &Resolver, path: &str, request: &str) -> ResolveResult {
   match resolver.resolve(path, request).await {
     Ok(resolution) => ResolveResult {
-      path: Some(
-        resolution
-          .full_path()
-          .to_str()
-          .expect("path should be UTF-8")
-          .to_string(),
-      ),
+      path: Some(resolution.full_path()),
       error: None,
       module_type: resolution
         .package_json()
@@ -49,7 +39,6 @@ async fn resolve(resolver: &Resolver, path: &Path, request: &str) -> ResolveResu
 
 #[napi]
 pub fn sync(path: String, request: String) -> ResolveResult {
-  let path = PathBuf::from(path);
   let resolver = Resolver::new(ResolveOptions::default());
   napi::bindgen_prelude::within_runtime_if_available(|| {
     runtime::Handle::current().block_on(resolve(&resolver, &path, &request))
@@ -58,7 +47,6 @@ pub fn sync(path: String, request: String) -> ResolveResult {
 
 #[napi(js_name = "async")]
 pub async fn async_(path: String, request: String) -> ResolveResult {
-  let path = PathBuf::from(path);
   let resolver = Resolver::new(ResolveOptions::default());
   resolve(&resolver, &path, &request).await
 }
@@ -110,9 +98,8 @@ impl ResolverFactory {
   #[allow(clippy::needless_pass_by_value)]
   #[napi]
   pub fn sync(&self, directory: String, request: String) -> ResolveResult {
-    let path = PathBuf::from(directory);
     napi::bindgen_prelude::within_runtime_if_available(|| {
-      runtime::Handle::current().block_on(resolve(&self.resolver, &path, &request))
+      runtime::Handle::current().block_on(resolve(&self.resolver, &directory, &request))
     })
   }
 
@@ -120,9 +107,8 @@ impl ResolverFactory {
   #[allow(clippy::needless_pass_by_value)]
   #[napi(js_name = "async")]
   pub async fn resolve_async(&self, directory: String, request: String) -> ResolveResult {
-    let path = PathBuf::from(directory);
     let resolver = self.resolver.clone();
-    resolve(&resolver, &path, &request).await
+    resolve(&resolver, &directory, &request).await
   }
 
   fn normalize_options(op: NapiResolveOptions) -> ResolveOptions {
@@ -214,10 +200,7 @@ impl ResolverFactory {
             .collect::<Vec<_>>()
         })
         .unwrap_or(default.restrictions),
-      roots: op
-        .roots
-        .map(|roots| roots.into_iter().map(PathBuf::from).collect::<Vec<_>>())
-        .unwrap_or(default.roots),
+      roots: op.roots.unwrap_or(default.roots),
       symlinks: op.symlinks.unwrap_or(default.symlinks),
       builtin_modules: op.builtin_modules.unwrap_or(default.builtin_modules),
       enable_pnp: op.enable_pnp.unwrap_or_default(),

--- a/napi/src/options.rs
+++ b/napi/src/options.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use napi::bindgen_prelude::{Either, Either3};
 use napi_derive::napi;
@@ -223,11 +223,9 @@ impl From<Restriction> for rspack_resolver::Restriction {
       }
       (None, Some(regex)) => {
         let re = Regex::new(&regex).unwrap_or_else(|_| panic!("Invalid regex pattern: {regex}"));
-        Self::Fn(Arc::new(move |path| {
-          re.is_match(path.to_str().unwrap_or_default())
-        }))
+        Self::Fn(Arc::new(move |path| re.is_match(path)))
       }
-      (Some(path), None) => Self::Path(PathBuf::from(path)),
+      (Some(path), None) => Self::Path(path),
       (Some(_), Some(_)) => {
         panic!("Restriction can't be path and regex at the same time")
       }
@@ -248,7 +246,7 @@ impl From<EnforceExtension> for rspack_resolver::EnforceExtension {
 impl From<TsconfigOptions> for rspack_resolver::TsconfigOptions {
   fn from(options: TsconfigOptions) -> Self {
     Self {
-      config_file: PathBuf::from(options.config_file),
+      config_file: options.config_file,
       references: match options.references {
         Some(Either::A(string)) if string.as_str() == "auto" => {
           rspack_resolver::TsconfigReferences::Auto
@@ -256,9 +254,7 @@ impl From<TsconfigOptions> for rspack_resolver::TsconfigOptions {
         Some(Either::A(opt)) => {
           panic!("`{opt}` is not a valid option for tsconfig references")
         }
-        Some(Either::B(paths)) => rspack_resolver::TsconfigReferences::Paths(
-          paths.into_iter().map(PathBuf::from).collect::<Vec<_>>(),
-        ),
+        Some(Either::B(paths)) => rspack_resolver::TsconfigReferences::Paths(paths),
         None => rspack_resolver::TsconfigReferences::Disabled,
       },
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -17,7 +17,7 @@ use crate::{
   context::ResolveContext as Ctx,
   package_json::{off_to_location, PackageJson},
   path::PathUtil,
-  str_path::{StrPath, StrPathBuf},
+  resolver_path::{hash_path, ResolverPath, ResolverPathBuf},
   FileMetadata, FileSystem, JSONError, ResolveError, ResolveOptions, TsConfig,
 };
 
@@ -43,18 +43,18 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
   }
 
   pub fn value(&self, path: &str) -> CachedPath {
-    let hash = {
-      let mut hasher = FxHasher::default();
-      path.hash(&mut hasher);
-      hasher.finish()
-    };
+    // Compute the path's hash up front so lookups never touch the heap. On a
+    // miss we hand the same value to `ResolverPathBuf::with_prehash` so the
+    // owned buffer reuses it instead of rehashing the bytes.
+    let hash = hash_path(path);
     if let Some(cache_entry) = self.paths.get((hash, path).borrow() as &dyn CacheKey) {
       return cache_entry.clone();
     }
-    let parent = StrPath::new(path).parent().map(|p| self.value(p.as_str()));
+    let parent = ResolverPath::new(path)
+      .parent()
+      .map(|p| self.value(p.as_str()));
     let data = CachedPath(Arc::new(CachedPathImpl::new(
-      hash,
-      StrPathBuf::from(path).into_boxed_path(),
+      ResolverPathBuf::with_prehash(hash, path.to_string()),
       parent,
     )));
     self.paths.insert(data.clone());
@@ -109,7 +109,7 @@ pub struct CachedPath(Arc<CachedPathImpl>);
 
 impl Hash for CachedPath {
   fn hash<H: Hasher>(&self, state: &mut H) {
-    self.0.hash.hash(state);
+    self.0.path.precomputed_hash().hash(state);
   }
 }
 
@@ -142,26 +142,25 @@ impl AsRef<CachedPathImpl> for CachedPath {
 
 impl CacheKey for CachedPath {
   fn tuple(&self) -> (u64, &str) {
-    (self.hash, self.path.as_str())
+    (self.0.path.precomputed_hash(), self.0.path.as_str())
   }
 }
 
 pub struct CachedPathImpl {
-  hash: u64,
-  /// Owned `Box<StrPath>` — gives us `parent()`, `file_name()`, … directly,
-  /// while `.as_str()` exposes the raw string for callers that want bytes.
-  path: Box<StrPath>,
+  /// Owned `ResolverPathBuf` — carries the precomputed FxHash that the cache
+  /// keys off of, plus the structured `ResolverPath` API for `parent()`,
+  /// `file_name()`, etc.
+  path: ResolverPathBuf,
   parent: Option<CachedPath>,
   meta: OnceLock<Option<FileMetadata>>,
-  canonicalized: OnceLock<Option<StrPathBuf>>,
+  canonicalized: OnceLock<Option<ResolverPathBuf>>,
   node_modules: OnceLock<Option<CachedPath>>,
   package_json: OnceLock<Option<Arc<PackageJson>>>,
 }
 
 impl CachedPathImpl {
-  fn new(hash: u64, path: Box<StrPath>, parent: Option<CachedPath>) -> Self {
+  fn new(path: ResolverPathBuf, parent: Option<CachedPath>) -> Self {
     Self {
-      hash,
       path,
       parent,
       meta: OnceLock::new(),
@@ -175,10 +174,10 @@ impl CachedPathImpl {
     self.path.as_str()
   }
 
-  /// Internal: the structured `&StrPath` view (parent / file_name / …).
-  #[allow(dead_code)] // Used as the resolver migrates more sites to `StrPath`.
-  pub(crate) fn str_path(&self) -> &StrPath {
-    &self.path
+  /// Internal: the structured `&ResolverPath` view (parent / file_name / …).
+  #[allow(dead_code)] // Used as the resolver migrates more sites to `ResolverPath`.
+  pub(crate) fn resolver_path(&self) -> &ResolverPath {
+    self.path.as_path()
   }
 
   pub fn parent(&self) -> Option<&CachedPath> {
@@ -241,14 +240,14 @@ impl CachedPathImpl {
             return fs
               .canonicalize(self.path.as_str())
               .await
-              .map(|p| Some(StrPathBuf::from(p)));
+              .map(|p| Some(ResolverPathBuf::from(p)));
           }
           if let Some(parent) = self.parent() {
             let parent_path = parent.realpath(fs).await?;
             // Component-aware suffix: drop the parent prefix and let
             // `normalize_with` reattach using the platform separator.
             let suffix = self.path.strip_prefix(&*parent.path).unwrap_or(&self.path);
-            return Ok(Some(StrPathBuf::from(
+            return Ok(Some(ResolverPathBuf::from(
               parent_path.normalize_with(suffix.as_str()),
             )));
           }
@@ -256,7 +255,12 @@ impl CachedPathImpl {
         })
         .await
         .cloned()
-        .map(|r| r.map_or_else(|| self.path.as_str().to_string(), StrPathBuf::into_string))
+        .map(|r| {
+          r.map_or_else(
+            || self.path.as_str().to_string(),
+            ResolverPathBuf::into_string,
+          )
+        })
     };
     Box::pin(fut)
   }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -5,7 +5,7 @@ use std::{
   hash::{BuildHasherDefault, Hash, Hasher},
   io,
   ops::Deref,
-  path::{Path, PathBuf},
+  path::Path,
   sync::Arc,
 };
 
@@ -25,7 +25,7 @@ use crate::{
 pub struct Cache<Fs> {
   pub(crate) fs: Fs,
   paths: DashSet<CachedPath, BuildHasherDefault<IdentityHasher>>,
-  tsconfigs: DashMap<PathBuf, Arc<TsConfig>, BuildHasherDefault<FxHasher>>,
+  tsconfigs: DashMap<String, Arc<TsConfig>, BuildHasherDefault<FxHasher>>,
 }
 
 impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
@@ -42,7 +42,7 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
     self.tsconfigs.clear();
   }
 
-  pub fn value(&self, path: &Path) -> CachedPath {
+  pub fn value(&self, path: &str) -> CachedPath {
     let hash = {
       let mut hasher = FxHasher::default();
       path.hash(&mut hasher);
@@ -51,10 +51,13 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
     if let Some(cache_entry) = self.paths.get((hash, path).borrow() as &dyn CacheKey) {
       return cache_entry.clone();
     }
-    let parent = path.parent().map(|p| self.value(p));
+    let parent = Path::new(path)
+      .parent()
+      .and_then(|p| p.to_str())
+      .map(|p| self.value(p));
     let data = CachedPath(Arc::new(CachedPathImpl::new(
       hash,
-      path.to_path_buf().into_boxed_path(),
+      path.to_string().into_boxed_str(),
       parent,
     )));
     self.paths.insert(data.clone());
@@ -64,7 +67,7 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
   pub async fn tsconfig<F, Fut>(
     &self,
     root: bool,
-    path: &Path,
+    path: &str,
     callback: F, // callback for modifying tsconfig with `extends`
   ) -> Result<Arc<TsConfig>, ResolveError>
   where
@@ -75,24 +78,22 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
       return Ok(Arc::clone(tsconfig_ref.value()));
     }
     let meta = self.fs.metadata(path).await.ok();
-    let tsconfig_path = if meta.is_some_and(|m| m.is_file) {
+    let tsconfig_path: Cow<str> = if meta.is_some_and(|m| m.is_file) {
       Cow::Borrowed(path)
     } else if meta.is_some_and(|m| m.is_dir) {
-      Cow::Owned(path.join("tsconfig.json"))
+      Cow::Owned(path.normalize_with("tsconfig.json"))
     } else {
-      let mut os_string = path.to_path_buf().into_os_string();
-      os_string.push(".json");
-      Cow::Owned(PathBuf::from(os_string))
+      Cow::Owned(format!("{path}.json"))
     };
     let mut tsconfig_string = self
       .fs
       .read_to_string(&tsconfig_path)
       .await
-      .map_err(|_| ResolveError::TsconfigNotFound(path.to_path_buf()))?;
+      .map_err(|_| ResolveError::TsconfigNotFound(path.to_string()))?;
     let mut tsconfig =
       TsConfig::parse(root, &tsconfig_path, &mut tsconfig_string).map_err(|error| {
         ResolveError::from_serde_json_error(
-          tsconfig_path.to_path_buf(),
+          tsconfig_path.to_string(),
           &error,
           Some(tsconfig_string),
         )
@@ -101,7 +102,7 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
     let tsconfig = Arc::new(tsconfig.build());
     self
       .tsconfigs
-      .insert(path.to_path_buf(), Arc::clone(&tsconfig));
+      .insert(path.to_string(), Arc::clone(&tsconfig));
     Ok(tsconfig)
   }
 }
@@ -143,23 +144,23 @@ impl AsRef<CachedPathImpl> for CachedPath {
 }
 
 impl CacheKey for CachedPath {
-  fn tuple(&self) -> (u64, &Path) {
+  fn tuple(&self) -> (u64, &str) {
     (self.hash, &self.path)
   }
 }
 
 pub struct CachedPathImpl {
   hash: u64,
-  path: Box<Path>,
+  path: Box<str>,
   parent: Option<CachedPath>,
   meta: OnceLock<Option<FileMetadata>>,
-  canonicalized: OnceLock<Option<PathBuf>>,
+  canonicalized: OnceLock<Option<String>>,
   node_modules: OnceLock<Option<CachedPath>>,
   package_json: OnceLock<Option<Arc<PackageJson>>>,
 }
 
 impl CachedPathImpl {
-  fn new(hash: u64, path: Box<Path>, parent: Option<CachedPath>) -> Self {
+  fn new(hash: u64, path: Box<str>, parent: Option<CachedPath>) -> Self {
     Self {
       hash,
       path,
@@ -171,12 +172,8 @@ impl CachedPathImpl {
     }
   }
 
-  pub fn path(&self) -> &Path {
+  pub fn path(&self) -> &str {
     &self.path
-  }
-
-  pub fn to_path_buf(&self) -> PathBuf {
-    self.path.to_path_buf()
   }
 
   pub fn parent(&self) -> Option<&CachedPath> {
@@ -218,16 +215,12 @@ impl CachedPathImpl {
   pub fn realpath<'a, Fs: FileSystem + Send + Sync>(
     &'a self,
     fs: &'a Fs,
-  ) -> BoxFuture<'a, io::Result<PathBuf>> {
+  ) -> BoxFuture<'a, io::Result<String>> {
     let fut = async move {
       // Cache hit: return immediately and avoid the recursive parent walk +
       // `Box::pin` per call on the hot path.
       if let Some(cached) = self.canonicalized.get() {
-        return Ok(
-          cached
-            .clone()
-            .unwrap_or_else(|| self.path.clone().to_path_buf()),
-        );
+        return Ok(cached.clone().unwrap_or_else(|| self.path.to_string()));
       }
       self
         .canonicalized
@@ -241,15 +234,20 @@ impl CachedPathImpl {
           }
           if let Some(parent) = self.parent() {
             let parent_path = parent.realpath(fs).await?;
-            return Ok(Some(
-              parent_path.normalize_with(self.path.strip_prefix(&parent.path).unwrap()),
-            ));
+            let suffix = self
+              .path
+              .strip_prefix(parent.path.as_ref())
+              .unwrap_or(&self.path);
+            // Strip leading separator so `normalize_with` doesn't treat the
+            // suffix as absolute and overwrite the parent prefix.
+            let suffix = suffix.trim_start_matches(['/', '\\']);
+            return Ok(Some(parent_path.normalize_with(suffix)));
           }
           Ok(None)
         })
         .await
         .cloned()
-        .map(|r| r.unwrap_or_else(|| self.path.clone().to_path_buf()))
+        .map(|r| r.unwrap_or_else(|| self.path.to_string()))
     };
     Box::pin(fut)
   }
@@ -260,7 +258,7 @@ impl CachedPathImpl {
     cache: &Cache<Fs>,
     ctx: &mut Ctx,
   ) -> Option<CachedPath> {
-    let cached_path = cache.value(&self.path.join(module_name));
+    let cached_path = cache.value(&self.path.normalize_with(module_name));
     cached_path
       .is_dir(&cache.fs, ctx)
       .await
@@ -287,7 +285,7 @@ impl CachedPathImpl {
   /// # Errors
   ///
   /// * [ResolveError::JSON]
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %self.path.display())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = self.path.as_ref())))]
   pub async fn find_package_json<Fs: FileSystem + Send + Sync>(
     &self,
     fs: &Fs,
@@ -318,7 +316,7 @@ impl CachedPathImpl {
   /// # Errors
   ///
   /// * [ResolveError::JSON]
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %self.path.display())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = self.path.as_ref())))]
   pub async fn package_json<Fs: FileSystem + Send + Sync>(
     &self,
     fs: &Fs,
@@ -331,7 +329,7 @@ impl CachedPathImpl {
         Some(package_json) => ctx.add_file_dependency(&package_json.path),
         None => {
           if let Some(deps) = &mut ctx.missing_dependencies {
-            deps.push(self.path.join("package.json"));
+            deps.push(self.path.normalize_with("package.json"));
           }
         }
       }
@@ -341,19 +339,19 @@ impl CachedPathImpl {
     let result = self
       .package_json
       .get_or_try_init(|| async {
-        let package_json_path = self.path.join("package.json");
+        let package_json_path = self.path.normalize_with("package.json");
         let Ok(package_json_string) = fs.read(&package_json_path).await else {
           return Ok(None);
         };
         let real_path = if options.symlinks {
-          self.realpath(fs).await?.join("package.json")
+          self.realpath(fs).await?.normalize_with("package.json")
         } else {
           package_json_path.clone()
         };
         match PackageJson::parse(package_json_path.clone(), real_path, package_json_string) {
           Ok(v) => Ok(Some(Arc::new(v))),
           Err(parse_err) => {
-            let package_json_path = self.path.join("package.json");
+            let package_json_path = self.path.normalize_with("package.json");
             let package_json_string = match fs.read_to_string(&package_json_path).await {
               Ok(c) => c,
               Err(io_err) => {
@@ -393,12 +391,12 @@ impl CachedPathImpl {
       Ok(None) => {
         // Avoid an allocation by making this lazy
         if let Some(deps) = &mut ctx.missing_dependencies {
-          deps.push(self.path.join("package.json"));
+          deps.push(self.path.normalize_with("package.json"));
         }
       }
       Err(_) => {
         if let Some(deps) = &mut ctx.file_dependencies {
-          deps.push(self.path.join("package.json"));
+          deps.push(self.path.normalize_with("package.json"));
         }
       }
     }
@@ -408,7 +406,7 @@ impl CachedPathImpl {
 
 /// Memoized cache key, code adapted from <https://stackoverflow.com/a/50478038>.
 trait CacheKey {
-  fn tuple(&self) -> (u64, &Path);
+  fn tuple(&self) -> (u64, &str);
 }
 
 impl Hash for dyn CacheKey + '_ {
@@ -425,13 +423,13 @@ impl PartialEq for dyn CacheKey + '_ {
 
 impl Eq for dyn CacheKey + '_ {}
 
-impl CacheKey for (u64, &Path) {
-  fn tuple(&self) -> (u64, &Path) {
+impl CacheKey for (u64, &str) {
+  fn tuple(&self) -> (u64, &str) {
     (self.0, self.1)
   }
 }
 
-impl<'a> Borrow<dyn CacheKey + 'a> for (u64, &'a Path) {
+impl<'a> Borrow<dyn CacheKey + 'a> for (u64, &'a str) {
   fn borrow(&self) -> &(dyn CacheKey + 'a) {
     self
   }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -5,7 +5,6 @@ use std::{
   hash::{BuildHasherDefault, Hash, Hasher},
   io,
   ops::Deref,
-  path::Path,
   sync::Arc,
 };
 
@@ -18,6 +17,7 @@ use crate::{
   context::ResolveContext as Ctx,
   package_json::{off_to_location, PackageJson},
   path::PathUtil,
+  str_path::{StrPath, StrPathBuf},
   FileMetadata, FileSystem, JSONError, ResolveError, ResolveOptions, TsConfig,
 };
 
@@ -51,13 +51,10 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
     if let Some(cache_entry) = self.paths.get((hash, path).borrow() as &dyn CacheKey) {
       return cache_entry.clone();
     }
-    let parent = Path::new(path)
-      .parent()
-      .and_then(|p| p.to_str())
-      .map(|p| self.value(p));
+    let parent = StrPath::new(path).parent().map(|p| self.value(p.as_str()));
     let data = CachedPath(Arc::new(CachedPathImpl::new(
       hash,
-      path.to_string().into_boxed_str(),
+      StrPathBuf::from(path).into_boxed_path(),
       parent,
     )));
     self.paths.insert(data.clone());
@@ -145,22 +142,24 @@ impl AsRef<CachedPathImpl> for CachedPath {
 
 impl CacheKey for CachedPath {
   fn tuple(&self) -> (u64, &str) {
-    (self.hash, &self.path)
+    (self.hash, self.path.as_str())
   }
 }
 
 pub struct CachedPathImpl {
   hash: u64,
-  path: Box<str>,
+  /// Owned `Box<StrPath>` — gives us `parent()`, `file_name()`, … directly,
+  /// while `.as_str()` exposes the raw string for callers that want bytes.
+  path: Box<StrPath>,
   parent: Option<CachedPath>,
   meta: OnceLock<Option<FileMetadata>>,
-  canonicalized: OnceLock<Option<String>>,
+  canonicalized: OnceLock<Option<StrPathBuf>>,
   node_modules: OnceLock<Option<CachedPath>>,
   package_json: OnceLock<Option<Arc<PackageJson>>>,
 }
 
 impl CachedPathImpl {
-  fn new(hash: u64, path: Box<str>, parent: Option<CachedPath>) -> Self {
+  fn new(hash: u64, path: Box<StrPath>, parent: Option<CachedPath>) -> Self {
     Self {
       hash,
       path,
@@ -173,6 +172,12 @@ impl CachedPathImpl {
   }
 
   pub fn path(&self) -> &str {
+    self.path.as_str()
+  }
+
+  /// Internal: the structured `&StrPath` view (parent / file_name / …).
+  #[allow(dead_code)] // Used as the resolver migrates more sites to `StrPath`.
+  pub(crate) fn str_path(&self) -> &StrPath {
     &self.path
   }
 
@@ -188,7 +193,7 @@ impl CachedPathImpl {
     }
     *self
       .meta
-      .get_or_init(|| async { fs.metadata(&self.path).await.ok() })
+      .get_or_init(|| async { fs.metadata(self.path.as_str()).await.ok() })
       .await
   }
 
@@ -220,34 +225,38 @@ impl CachedPathImpl {
       // Cache hit: return immediately and avoid the recursive parent walk +
       // `Box::pin` per call on the hot path.
       if let Some(cached) = self.canonicalized.get() {
-        return Ok(cached.clone().unwrap_or_else(|| self.path.to_string()));
+        return Ok(cached.as_ref().map_or_else(
+          || self.path.as_str().to_string(),
+          |p| p.as_str().to_string(),
+        ));
       }
       self
         .canonicalized
         .get_or_try_init(|| async move {
           if fs
-            .symlink_metadata(&self.path)
+            .symlink_metadata(self.path.as_str())
             .await
             .is_ok_and(|m| m.is_symlink)
           {
-            return fs.canonicalize(&self.path).await.map(Some);
+            return fs
+              .canonicalize(self.path.as_str())
+              .await
+              .map(|p| Some(StrPathBuf::from(p)));
           }
           if let Some(parent) = self.parent() {
             let parent_path = parent.realpath(fs).await?;
-            let suffix = self
-              .path
-              .strip_prefix(parent.path.as_ref())
-              .unwrap_or(&self.path);
-            // Strip leading separator so `normalize_with` doesn't treat the
-            // suffix as absolute and overwrite the parent prefix.
-            let suffix = suffix.trim_start_matches(['/', '\\']);
-            return Ok(Some(parent_path.normalize_with(suffix)));
+            // Component-aware suffix: drop the parent prefix and let
+            // `normalize_with` reattach using the platform separator.
+            let suffix = self.path.strip_prefix(&*parent.path).unwrap_or(&self.path);
+            return Ok(Some(StrPathBuf::from(
+              parent_path.normalize_with(suffix.as_str()),
+            )));
           }
           Ok(None)
         })
         .await
         .cloned()
-        .map(|r| r.unwrap_or_else(|| self.path.to_string()))
+        .map(|r| r.map_or_else(|| self.path.as_str().to_string(), StrPathBuf::into_string))
     };
     Box::pin(fut)
   }
@@ -285,7 +294,7 @@ impl CachedPathImpl {
   /// # Errors
   ///
   /// * [ResolveError::JSON]
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = self.path.as_ref())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = self.path.as_str())))]
   pub async fn find_package_json<Fs: FileSystem + Send + Sync>(
     &self,
     fs: &Fs,
@@ -316,7 +325,7 @@ impl CachedPathImpl {
   /// # Errors
   ///
   /// * [ResolveError::JSON]
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = self.path.as_ref())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = self.path.as_str())))]
   pub async fn package_json<Fs: FileSystem + Send + Sync>(
     &self,
     fs: &Fs,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -174,9 +174,9 @@ impl CachedPathImpl {
     self.path.as_str()
   }
 
-  /// Internal: the structured `&ResolverPath` view (parent / file_name / …).
+  /// Internal: the structured `ResolverPath` view (parent / file_name / …).
   #[allow(dead_code)] // Used as the resolver migrates more sites to `ResolverPath`.
-  pub(crate) fn resolver_path(&self) -> &ResolverPath {
+  pub(crate) fn resolver_path(&self) -> ResolverPath<'_> {
     self.path.as_path()
   }
 
@@ -246,9 +246,12 @@ impl CachedPathImpl {
             let parent_path = parent.realpath(fs).await?;
             // Component-aware suffix: drop the parent prefix and let
             // `normalize_with` reattach using the platform separator.
-            let suffix = self.path.strip_prefix(&*parent.path).unwrap_or(&self.path);
+            let suffix = self
+              .path
+              .strip_prefix(parent.path.as_str())
+              .map_or_else(|_| self.path.as_str(), |t| t.as_str());
             return Ok(Some(ResolverPathBuf::from(
-              parent_path.normalize_with(suffix.as_str()),
+              parent_path.normalize_with(suffix),
             )));
           }
           Ok(None)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -247,8 +247,18 @@ impl CachedPathImpl {
           }
           if let Some(parent) = self.parent() {
             let parent_path = parent.realpath(fs).await?;
-            // Component-aware suffix: drop the parent prefix and let
-            // `normalize_with` reattach using the platform separator.
+            // Fast path: parent's canonical form is byte-identical to its
+            // input, so no symlink was resolved anywhere up the chain and
+            // self.path is already canonical. Return None to preserve the
+            // path verbatim — important on Windows where the input may mix
+            // `/` and `\` separators that std::path used to keep, and which
+            // `normalize_with` below would otherwise replace with
+            // `MAIN_SEPARATOR`.
+            if parent_path == parent.path.as_str() {
+              return Ok(None);
+            }
+            // Symlink was resolved upstream: rebuild self by reattaching the
+            // suffix onto the new canonical parent.
             let suffix = self
               .path
               .strip_prefix(parent.path.as_str())

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,7 +1,4 @@
-use std::{
-  ops::{Deref, DerefMut},
-  path::{Path, PathBuf},
-};
+use std::ops::{Deref, DerefMut};
 
 use crate::error::ResolveError;
 
@@ -17,10 +14,10 @@ pub struct ResolveContextImpl {
   pub fragment: Option<String>,
 
   /// Files that was found on file system
-  pub file_dependencies: Option<Vec<PathBuf>>,
+  pub file_dependencies: Option<Vec<String>>,
 
   /// Files that was found on file system
-  pub missing_dependencies: Option<Vec<PathBuf>>,
+  pub missing_dependencies: Option<Vec<String>>,
 
   /// The current resolving alias for bailing recursion alias.
   pub resolving_alias: Option<String>,
@@ -62,15 +59,15 @@ impl ResolveContext {
     self.missing_dependencies.replace(vec![]);
   }
 
-  pub fn add_file_dependency(&mut self, dep: &Path) {
+  pub fn add_file_dependency(&mut self, dep: &str) {
     if let Some(deps) = &mut self.file_dependencies {
-      deps.push(dep.to_path_buf());
+      deps.push(dep.to_string());
     }
   }
 
-  pub fn add_missing_dependency(&mut self, dep: &Path) {
+  pub fn add_missing_dependency(&mut self, dep: &str) {
     if let Some(deps) = &mut self.missing_dependencies {
-      deps.push(dep.to_path_buf());
+      deps.push(dep.to_string());
     }
   }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::{io, path::PathBuf, sync::Arc};
+use std::{io, sync::Arc};
 
 use thiserror::Error;
 
@@ -20,7 +20,7 @@ pub enum ResolveError {
   /// ```
   /// See <https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module>
   #[error("Path is ignored {0}")]
-  Ignored(PathBuf),
+  Ignored(String),
 
   /// Module not found
   #[error("Cannot find module '{0}'")]
@@ -32,11 +32,11 @@ pub enum ResolveError {
 
   /// Tsconfig not found
   #[error("Tsconfig not found {0}")]
-  TsconfigNotFound(PathBuf),
+  TsconfigNotFound(String),
 
   /// Tsconfig's project reference path points to it self
   #[error("Tsconfig's project reference path points to this tsconfig {0}")]
-  TsconfigSelfReference(PathBuf),
+  TsconfigSelfReference(String),
 
   #[error("{0}")]
   IOError(IOError),
@@ -55,7 +55,7 @@ pub enum ResolveError {
   ExtensionAlias(
     /* File name */ String,
     /* Tried file names */ String,
-    /* Path to dir */ PathBuf,
+    /* Path to dir */ String,
   ),
 
   /// The provided path specifier cannot be parsed
@@ -69,25 +69,25 @@ pub enum ResolveError {
   #[error(
     r#"Invalid module "{0}" specifier is not a valid subpath for the "exports" resolution of {1}"#
   )]
-  InvalidModuleSpecifier(String, PathBuf),
+  InvalidModuleSpecifier(String, String),
 
   #[error(r#"Invalid "exports" target "{0}" defined for '{1}' in the package config {2}"#)]
-  InvalidPackageTarget(String, String, PathBuf),
+  InvalidPackageTarget(String, String, String),
 
   #[error(r#"Package subpath '{0}' is not defined by "exports" in {1}"#)]
-  PackagePathNotExported(String, PathBuf),
+  PackagePathNotExported(String, String),
 
   #[error(r#"Invalid package config "{0}", "exports" cannot contain some keys starting with '.' and some not. The exports object must either be an object of package subpath keys or an object of main entry condition name keys only."#)]
-  InvalidPackageConfig(PathBuf),
+  InvalidPackageConfig(String),
 
   #[error(r#"Default condition should be last one in "{0}""#)]
-  InvalidPackageConfigDefault(PathBuf),
+  InvalidPackageConfigDefault(String),
 
   #[error(r#"Expecting folder to folder mapping. "{0}" should end with "/"#)]
-  InvalidPackageConfigDirectory(PathBuf),
+  InvalidPackageConfigDirectory(String),
 
   #[error(r#"Package import specifier "{0}" is not defined in package {1}"#)]
-  PackageImportNotDefined(String, PathBuf),
+  PackageImportNotDefined(String, String),
 
   #[error("{0} is unimplemented")]
   Unimplemented(&'static str),
@@ -103,7 +103,7 @@ impl ResolveError {
   }
 
   pub(crate) fn from_serde_json_error(
-    path: PathBuf,
+    path: String,
     error: &serde_json::Error,
     content: Option<String>,
   ) -> Self {
@@ -127,7 +127,7 @@ pub enum SpecifierError {
 /// JSON error from [serde_json::Error]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct JSONError {
-  pub path: PathBuf,
+  pub path: String,
   pub message: String,
   pub line: usize,
   pub column: usize,

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -1,7 +1,4 @@
-use std::{
-  fs, io,
-  path::{Path, PathBuf},
-};
+use std::{fs, io, path::Path};
 
 #[cfg(not(target_arch = "wasm32"))]
 use cfg_if::cfg_if;
@@ -18,29 +15,29 @@ pub trait FileSystem {
   /// # Errors
   ///
   /// See [std::fs::read]
-  async fn read(&self, path: &Path) -> io::Result<Vec<u8>>;
+  async fn read(&self, path: &str) -> io::Result<Vec<u8>>;
   /// See [std::fs::read_to_string]
   ///
   /// # Errors
   ///
   /// * See [std::fs::read_to_string]
   /// ## Warning
-  /// Use `&Path` instead of a generic `P: AsRef<Path>` here,
+  /// Use `&str` instead of a generic `P: AsRef<str>` here,
   /// because object safety requirements, it is especially useful, when
   /// you want to store multiple `dyn FileSystem` in a `Vec` or use a `ResolverGeneric<Fs>` in
   /// napi env.
-  async fn read_to_string(&self, path: &Path) -> io::Result<String>;
+  async fn read_to_string(&self, path: &str) -> io::Result<String>;
 
   /// See [std::fs::metadata]
   ///
   /// # Errors
   /// See [std::fs::metadata]
   /// ## Warning
-  /// Use `&Path` instead of a generic `P: AsRef<Path>` here,
+  /// Use `&str` instead of a generic `P: AsRef<str>` here,
   /// because object safety requirements, it is especially useful, when
   /// you want to store multiple `dyn FileSystem` in a `Vec` or use a `ResolverGeneric<Fs>` in
   /// napi env.
-  async fn metadata(&self, path: &Path) -> io::Result<FileMetadata>;
+  async fn metadata(&self, path: &str) -> io::Result<FileMetadata>;
 
   /// See [std::fs::symlink_metadata]
   ///
@@ -48,11 +45,11 @@ pub trait FileSystem {
   ///
   /// See [std::fs::symlink_metadata]
   /// ## Warning
-  /// Use `&Path` instead of a generic `P: AsRef<Path>` here,
+  /// Use `&str` instead of a generic `P: AsRef<str>` here,
   /// because object safety requirements, it is especially useful, when
   /// you want to store multiple `dyn FileSystem` in a `Vec` or use a `ResolverGeneric<Fs>` in
   /// napi env.
-  async fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata>;
+  async fn symlink_metadata(&self, path: &str) -> io::Result<FileMetadata>;
 
   /// See [std::fs::canonicalize]
   ///
@@ -60,11 +57,11 @@ pub trait FileSystem {
   ///
   /// See [std::fs::read_link]
   /// ## Warning
-  /// Use `&Path` instead of a generic `P: AsRef<Path>` here,
+  /// Use `&str` instead of a generic `P: AsRef<str>` here,
   /// because object safety requirements, it is especially useful, when
   /// you want to store multiple `dyn FileSystem` in a `Vec` or use a `ResolverGeneric<Fs>` in
   /// napi env.
-  async fn canonicalize(&self, path: &Path) -> io::Result<PathBuf>;
+  async fn canonicalize(&self, path: &str) -> io::Result<String>;
 }
 
 /// Metadata information about a file
@@ -144,10 +141,23 @@ impl FileSystemOs {
   }
 }
 
+/// UTF-8 wrapper around [`dunce::canonicalize`].
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+fn canonicalize_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
+  let canonical = dunce::canonicalize(path)?;
+  canonical.into_os_string().into_string().map_err(|_| {
+    io::Error::new(
+      io::ErrorKind::InvalidData,
+      "canonicalized path is not UTF-8",
+    )
+  })
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 #[async_trait::async_trait]
 impl FileSystem for FileSystemOs {
-  async fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
+  async fn read(&self, path: &str) -> io::Result<Vec<u8>> {
+    let path = Path::new(path);
     cfg_if! {
       if #[cfg(feature = "yarn_pnp")] {
         if self.options.enable_pnp {
@@ -162,7 +172,8 @@ impl FileSystem for FileSystemOs {
     tokio::fs::read(path).await
   }
 
-  async fn read_to_string(&self, path: &Path) -> io::Result<String> {
+  async fn read_to_string(&self, path: &str) -> io::Result<String> {
+    let path = Path::new(path);
     cfg_if! {
     if #[cfg(feature = "yarn_pnp")] {
         if self.options.enable_pnp {
@@ -177,7 +188,8 @@ impl FileSystem for FileSystemOs {
     tokio::fs::read_to_string(path).await
   }
 
-  async fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+  async fn metadata(&self, path: &str) -> io::Result<FileMetadata> {
+    let path = Path::new(path);
     cfg_if! {
         if #[cfg(feature = "yarn_pnp")] {
             if self.options.enable_pnp {
@@ -200,61 +212,67 @@ impl FileSystem for FileSystemOs {
     tokio::fs::metadata(path).await.map(FileMetadata::from)
   }
 
-  async fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
-    tokio::fs::symlink_metadata(path)
+  async fn symlink_metadata(&self, path: &str) -> io::Result<FileMetadata> {
+    tokio::fs::symlink_metadata(Path::new(path))
       .await
       .map(FileMetadata::from)
   }
 
-  async fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+  async fn canonicalize(&self, path: &str) -> io::Result<String> {
+    let path = Path::new(path);
     cfg_if! {
         if #[cfg(feature = "yarn_pnp")] {
             if self.options.enable_pnp {
                 return match VPath::from(path)? {
                     VPath::Zip(info) => {
-                        dunce::canonicalize(info.physical_base_path().join(info.zip_path))
+                        canonicalize_to_string(info.physical_base_path().join(info.zip_path))
                     }
-                    VPath::Virtual(info) => dunce::canonicalize(info.physical_base_path()),
-                    VPath::Native(path) => dunce::canonicalize(path),
+                    VPath::Virtual(info) => canonicalize_to_string(info.physical_base_path()),
+                    VPath::Native(path) => canonicalize_to_string(path),
                 }
             }
         }
     }
 
-    dunce::canonicalize(path)
+    canonicalize_to_string(path)
   }
 }
 
 #[cfg(target_arch = "wasm32")]
 #[async_trait::async_trait]
 impl FileSystem for FileSystemOs {
-  async fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
-    std::fs::read(path)
+  async fn read(&self, path: &str) -> io::Result<Vec<u8>> {
+    std::fs::read(Path::new(path))
   }
 
-  async fn read_to_string(&self, path: &Path) -> io::Result<String> {
-    std::fs::read_to_string(path)
+  async fn read_to_string(&self, path: &str) -> io::Result<String> {
+    std::fs::read_to_string(Path::new(path))
   }
 
-  async fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+  async fn metadata(&self, path: &str) -> io::Result<FileMetadata> {
+    let path = Path::new(path);
     // This implementation is verbose because there might be something wrong node wasm runtime.
     // I will investigate it in the future.
     if let Ok(m) = std::fs::metadata(path).map(FileMetadata::from) {
       return Ok(m);
     }
 
-    self.symlink_metadata(path).await?;
-    let path = self.canonicalize(path).await?;
-    std::fs::metadata(path).map(FileMetadata::from)
+    self
+      .symlink_metadata(path.to_str().expect("path should be UTF-8"))
+      .await?;
+    let resolved = self
+      .canonicalize(path.to_str().expect("path should be UTF-8"))
+      .await?;
+    std::fs::metadata(Path::new(&resolved)).map(FileMetadata::from)
   }
 
-  async fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
-    std::fs::symlink_metadata(path).map(FileMetadata::from)
+  async fn symlink_metadata(&self, path: &str) -> io::Result<FileMetadata> {
+    std::fs::symlink_metadata(Path::new(path)).map(FileMetadata::from)
   }
 
-  async fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
-    use std::path::Component;
-    let mut path_buf = path.to_path_buf();
+  async fn canonicalize(&self, path: &str) -> io::Result<String> {
+    use std::path::{Component, PathBuf};
+    let mut path_buf = PathBuf::from(path);
     let link = fs::read_link(&path_buf)?;
     path_buf.pop();
     for component in link.components() {
@@ -278,11 +296,18 @@ impl FileSystem for FileSystemOs {
 
       // This is not performant, we may optimize it with cache in the future
       if fs::symlink_metadata(&path_buf).is_ok_and(|m| m.is_symlink()) {
-        let dir = self.canonicalize(&path_buf).await?;
-        path_buf = dir;
+        let dir = self
+          .canonicalize(path_buf.to_str().expect("path should be UTF-8"))
+          .await?;
+        path_buf = PathBuf::from(dir);
       }
     }
-    Ok(path_buf)
+    path_buf.into_os_string().into_string().map_err(|_| {
+      io::Error::new(
+        io::ErrorKind::InvalidData,
+        "canonicalized path is not UTF-8",
+      )
+    })
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ pub use crate::{
   },
   package_json::{JSONValue, ModuleType, PackageJson},
   resolution::Resolution,
-  resolver_path::{ResolverPath, ResolverPathBuf},
+  resolver_path::{ResolverPath, ResolverPathBuf, StripPrefixError, MAIN_SEPARATOR},
 };
 use crate::{
   cache::{Cache, CachedPath},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,6 @@ use std::{
   borrow::Cow,
   cmp::Ordering,
   fmt,
-  path::{Component, Path},
   sync::{Arc, OnceLock},
 };
 
@@ -92,6 +91,7 @@ use crate::{
   package_json::JSONMap,
   path::{PathUtil, SLASH_START},
   specifier::Specifier,
+  str_path::{Component, StrPath},
   tsconfig::{ExtendsField, ProjectReference, TsConfig},
 };
 
@@ -276,7 +276,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       .await?;
     if let Some(package_json) = &package_json {
       // path must be inside the package.
-      debug_assert!(Path::new(&path).starts_with(package_json.directory()));
+      debug_assert!(StrPath::new(&path).starts_with(package_json.directory()));
     }
     Ok(Resolution {
       path,
@@ -336,7 +336,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       return Ok(path);
     }
 
-    let result = match Path::new(specifier).components().next() {
+    let result = match StrPath::new(specifier).components().next() {
       // 2. If X begins with '/'
       Some(Component::RootDir | Component::Prefix(_)) => {
         self.require_absolute(cached_path, specifier, ctx).await
@@ -401,7 +401,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     ctx: &mut Ctx,
   ) -> Result<CachedPath, ResolveError> {
     // Make sure only path prefixes gets called
-    debug_assert!(Path::new(specifier)
+    debug_assert!(StrPath::new(specifier)
       .components()
       .next()
       .is_some_and(|c| matches!(c, Component::RootDir | Component::Prefix(_))));
@@ -447,7 +447,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     ctx: &mut Ctx,
   ) -> Result<CachedPath, ResolveError> {
     // Make sure only relative or normal paths gets called
-    debug_assert!(Path::new(specifier)
+    debug_assert!(StrPath::new(specifier)
       .components()
       .next()
       .is_some_and(|c| matches!(
@@ -495,7 +495,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     ctx: &mut Ctx,
   ) -> Result<CachedPath, ResolveError> {
     // Make sure no other path prefixes gets called
-    debug_assert!(Path::new(specifier)
+    debug_assert!(StrPath::new(specifier)
       .components()
       .next()
       .is_some_and(|c| matches!(c, Component::Normal(_))));
@@ -734,8 +734,8 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   fn check_restrictions(&self, path: &str) -> bool {
     // https://github.com/webpack/enhanced-resolve/blob/a998c7d218b7a9ec2461fc4fddd1ad5dd7687485/lib/RestrictionsPlugin.js#L19-L24
     fn is_inside(path: &str, parent: &str) -> bool {
-      let path_p = Path::new(path);
-      let parent_p = Path::new(parent);
+      let path_p = StrPath::new(path);
+      let parent_p = StrPath::new(parent);
       if !path_p.starts_with(parent_p) {
         return false;
       }
@@ -744,7 +744,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       }
       path_p
         .strip_prefix(parent_p)
-        .is_ok_and(|p| p == Path::new("./"))
+        .is_ok_and(|p| p == StrPath::new("./"))
     }
     for restriction in &self.options.restrictions {
       match restriction {
@@ -974,14 +974,17 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       return None;
     }
 
-    // 3. Search for `.pnp.cjs` by walking up from this path
-    let base_path = Path::new(cached_path.path());
-    let Some(manifest_path) = pnp::find_closest_pnp_manifest_path(base_path) else {
+    // 3. Search for `.pnp.cjs` by walking up this path. pnp's API still
+    // expects `std::path::Path`, so build a single std::path::Path::new at
+    // the boundary; we keep the rest of the walk in StrPath land.
+    let base_path = StrPath::new(cached_path.path());
+    let Some(manifest_path) =
+      pnp::find_closest_pnp_manifest_path(std::path::Path::new(base_path.as_str()))
+    else {
       self.pnp_no_manifest_cache.insert(cached_path.clone());
 
       for p in base_path.ancestors() {
-        let Some(p_str) = p.to_str() else { break };
-        let p_cached = self.cache.value(p_str);
+        let p_cached = self.cache.value(p.as_str());
         if self.pnp_no_manifest_cache.contains(&p_cached) {
           break;
         }
@@ -1077,11 +1080,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   ) -> Option<CachedPath> {
     if module_name == "node_modules" {
       cached_path.cached_node_modules(&self.cache, ctx).await
-    } else if Path::new(cached_path.path())
-      .file_name()
-      .and_then(|n| n.to_str())
-      == Some(module_name)
-    {
+    } else if StrPath::new(cached_path.path()).file_name() == Some(module_name) {
       Some(cached_path.clone())
     } else {
       cached_path
@@ -1232,7 +1231,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       // Complete when resolving to self `{"./a.js": "./a.js"}`
       if new_specifier
         .strip_prefix("./")
-        .filter(|s| Path::new(path).ends_with(Path::new(s)))
+        .filter(|s| StrPath::new(path).ends_with(StrPath::new(s)))
         .is_some()
       {
         return if cached_path.is_file(&self.cache.fs, ctx).await {
@@ -1373,8 +1372,8 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       return Ok(None);
     }
     let path_str = cached_path.path();
-    let path_p = Path::new(path_str);
-    let Some(path_extension) = path_p.extension().and_then(|e| e.to_str()) else {
+    let path_p = StrPath::new(path_str);
+    let Some(path_extension) = path_p.extension() else {
       return Ok(None);
     };
     let Some((_, extensions)) = self
@@ -1385,7 +1384,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     else {
       return Ok(None);
     };
-    let Some(filename) = path_p.file_name().and_then(|f| f.to_str()) else {
+    let Some(filename) = path_p.file_name() else {
       return Ok(None);
     };
     // Strip the trailing `.ext` segment to build the extension-less base.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ mod package_json;
 mod path;
 mod resolution;
 mod specifier;
+mod str_path;
 mod tsconfig;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,9 +65,8 @@ mod tests;
 use std::{
   borrow::Cow,
   cmp::Ordering,
-  ffi::OsStr,
   fmt,
-  path::{Component, Path, PathBuf},
+  path::{Component, Path},
   sync::{Arc, OnceLock},
 };
 
@@ -90,7 +89,7 @@ use crate::{
   cache::{Cache, CachedPath},
   context::ResolveContext as Ctx,
   package_json::JSONMap,
-  path::{path_to_str, PathUtil, SLASH_START},
+  path::{PathUtil, SLASH_START},
   specifier::Specifier,
   tsconfig::{ExtendsField, ProjectReference, TsConfig},
 };
@@ -101,10 +100,10 @@ type ResolveResult = Result<Option<CachedPath>, ResolveError>;
 #[derive(Debug, Default, Clone)]
 pub struct ResolveContext {
   /// Files that was found on file system
-  pub file_dependencies: FxHashSet<PathBuf>,
+  pub file_dependencies: FxHashSet<String>,
 
   /// Dependencies that was not found on file system
-  pub missing_dependencies: FxHashSet<PathBuf>,
+  pub missing_dependencies: FxHashSet<String>,
 }
 
 /// Resolver with the current operating system as the file system
@@ -115,12 +114,12 @@ pub struct ResolverGeneric<Fs> {
   options: ResolveOptions,
   cache: Arc<Cache<Fs>>,
   #[cfg(feature = "yarn_pnp")]
-  pnp_manifest: Arc<arc_swap::ArcSwapOption<(PathBuf, pnp::Manifest)>>,
+  pnp_manifest: Arc<arc_swap::ArcSwapOption<(String, pnp::Manifest)>>,
   /// Paths that have been searched and confirmed to have no `.pnp.cjs` reachable by filesystem walk.
   #[cfg(feature = "yarn_pnp")]
   pnp_no_manifest_cache: Arc<DashSet<CachedPath>>,
   /// Lazily parsed directories from `NODE_PATH` env var.
-  node_path_dirs: OnceLock<Vec<PathBuf>>,
+  node_path_dirs: OnceLock<Vec<String>>,
 }
 
 impl<Fs> fmt::Debug for ResolverGeneric<Fs> {
@@ -202,9 +201,9 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   /// # Errors
   ///
   /// * See [ResolveError]
-  pub async fn resolve<P: Send + AsRef<Path>>(
+  pub async fn resolve<S: Send + AsRef<str>>(
     &self,
-    directory: P,
+    directory: S,
     specifier: &str,
   ) -> Result<Resolution, ResolveError> {
     let mut ctx = Ctx::default();
@@ -218,9 +217,9 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   /// # Errors
   ///
   /// * See [ResolveError]
-  pub async fn resolve_with_context<P: Send + AsRef<Path>>(
+  pub async fn resolve_with_context<S: Send + AsRef<str>>(
     &self,
-    directory: P,
+    directory: S,
     specifier: &str,
     resolve_context: &mut ResolveContext,
   ) -> Result<Resolution, ResolveError> {
@@ -239,14 +238,14 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   }
 
   /// Wrap `resolve_impl` with `tracing` information
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(directory), specifier = specifier)))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = directory, specifier = specifier)))]
   async fn resolve_tracing(
     &self,
-    directory: &Path,
+    directory: &str,
     specifier: &str,
     ctx: &mut Ctx,
   ) -> Result<Resolution, ResolveError> {
-    let span = tracing::debug_span!("resolve", path = ?directory, specifier = specifier);
+    let span = tracing::debug_span!("resolve", path = directory, specifier = specifier);
     let _enter = span.enter();
     let r = self.resolve_impl(directory, specifier, ctx).await;
     match &r {
@@ -262,7 +261,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
   async fn resolve_impl(
     &self,
-    path: &Path,
+    path: &str,
     specifier: &str,
     ctx: &mut Ctx,
   ) -> Result<Resolution, ResolveError> {
@@ -276,7 +275,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       .await?;
     if let Some(package_json) = &package_json {
       // path must be inside the package.
-      debug_assert!(path.starts_with(package_json.directory()));
+      debug_assert!(Path::new(&path).starts_with(package_json.directory()));
     }
     Ok(Resolution {
       path,
@@ -418,13 +417,16 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     }
     // 2. If X begins with '/'
     //   a. set Y to be the file system root
-    let path = self.cache.value(
-      //
+    let path = self.cache.value({
       #[cfg(windows)]
-      &Path::new(specifier).normalize(),
+      {
+        &specifier.normalize()
+      }
       #[cfg(not(windows))]
-      Path::new(specifier),
-    );
+      {
+        specifier
+      }
+    });
 
     if let Some(path) = self
       .load_as_file_or_directory(&path, specifier, ctx)
@@ -436,7 +438,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   }
 
   // 3. If X begins with './' or '/' or '../'
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = cached_path.path())))]
   async fn require_relative(
     &self,
     cached_path: &CachedPath,
@@ -536,7 +538,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     Ok((parsed, None))
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = cached_path.path())))]
   async fn load_package_self_or_node_modules(
     &self,
     cached_path: &CachedPath,
@@ -590,7 +592,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     Ok(None)
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(cached_path.path()))))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = cached_path.path())))]
   async fn load_as_file(&self, cached_path: &CachedPath, ctx: &mut Ctx) -> ResolveResult {
     // enhanced-resolve feature: extension_alias
     if let Some(path) = self.load_extension_alias(cached_path, ctx).await? {
@@ -653,7 +655,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     self.load_index(cached_path, ctx).await
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = cached_path.path())))]
   async fn load_as_file_or_directory(
     &self,
     cached_path: &CachedPath,
@@ -681,7 +683,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     Ok(None)
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(path.path()))))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path.path())))]
   async fn load_extensions(
     &self,
     path: &CachedPath,
@@ -691,7 +693,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     if ctx.fully_specified {
       return Ok(None);
     }
-    let path = path_to_str(path.path());
+    let path = path.path();
     // 8 is wild guess for max extension length
     let mut path_with_extension_buffer = String::with_capacity(path.len() + 8);
     path_with_extension_buffer.push_str(path);
@@ -700,7 +702,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     for extension in extensions {
       path_with_extension_buffer.truncate(base_len);
       path_with_extension_buffer.push_str(extension);
-      let cached_path = self.cache.value(Path::new(&path_with_extension_buffer));
+      let cached_path = self.cache.value(&path_with_extension_buffer);
       if let Some(path) = self.load_alias_or_file(&cached_path, ctx).await? {
         return Ok(Some(path));
       }
@@ -708,12 +710,12 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     Ok(None)
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(cached_path.path()))))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = cached_path.path())))]
   async fn load_realpath(
     &self,
     cached_path: &CachedPath,
     ctx: &mut Ctx,
-  ) -> Result<PathBuf, ResolveError> {
+  ) -> Result<String, ResolveError> {
     if self.options.symlinks {
       cached_path
         .realpath(&self.cache.fs)
@@ -724,21 +726,23 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
         })
         .map_err(ResolveError::from)
     } else {
-      Ok(cached_path.to_path_buf())
+      Ok(cached_path.path().to_string())
     }
   }
 
-  fn check_restrictions(&self, path: &Path) -> bool {
+  fn check_restrictions(&self, path: &str) -> bool {
     // https://github.com/webpack/enhanced-resolve/blob/a998c7d218b7a9ec2461fc4fddd1ad5dd7687485/lib/RestrictionsPlugin.js#L19-L24
-    fn is_inside(path: &Path, parent: &Path) -> bool {
-      if !path.starts_with(parent) {
+    fn is_inside(path: &str, parent: &str) -> bool {
+      let path_p = Path::new(path);
+      let parent_p = Path::new(parent);
+      if !path_p.starts_with(parent_p) {
         return false;
       }
-      if path.as_os_str().len() == parent.as_os_str().len() {
+      if path.len() == parent.len() {
         return true;
       }
-      path
-        .strip_prefix(parent)
+      path_p
+        .strip_prefix(parent_p)
         .is_ok_and(|p| p == Path::new("./"))
     }
     for restriction in &self.options.restrictions {
@@ -758,7 +762,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     true
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(cached_path.path()))))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = cached_path.path())))]
   async fn load_index(&self, cached_path: &CachedPath, ctx: &mut Ctx) -> ResolveResult {
     for main_file in &self.options.main_files {
       let main_path = cached_path.path().normalize_with(main_file);
@@ -798,7 +802,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       }
     }
     // enhanced-resolve: try file as alias
-    let alias_specifier = path_to_str(cached_path.path());
+    let alias_specifier = cached_path.path();
     if let Some(path) = self
       .load_alias(cached_path, alias_specifier, &self.options.alias, ctx)
       .await?
@@ -812,7 +816,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     Ok(None)
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = cached_path.path())))]
   async fn load_node_modules(
     &self,
     cached_path: &CachedPath,
@@ -907,18 +911,19 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   }
 
   /// Parse `NODE_PATH` env var into directory list. Uses `;` on Windows, `:` on POSIX.
-  fn parse_node_path_env() -> Vec<PathBuf> {
+  fn parse_node_path_env() -> Vec<String> {
     std::env::var_os("NODE_PATH")
       .map(|path| {
         std::env::split_paths(&path)
           .filter(|paths| paths.is_absolute())
-          .collect::<Vec<PathBuf>>()
+          .filter_map(|p| p.into_os_string().into_string().ok())
+          .collect::<Vec<String>>()
       })
       .unwrap_or_default()
   }
 
   /// Lazily get NODE_PATH directories. Parsed once on first access.
-  fn node_path_dirs(&self) -> &[PathBuf] {
+  fn node_path_dirs(&self) -> &[String] {
     if !self.options.node_path {
       return &[];
     }
@@ -926,7 +931,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   }
 
   #[cfg(all(test, not(target_os = "windows")))]
-  fn with_node_path_dirs(self, dirs: Vec<PathBuf>) -> Self {
+  fn with_node_path_dirs(self, dirs: Vec<String>) -> Self {
     let _ = self.node_path_dirs.set(dirs);
     self
   }
@@ -956,8 +961,8 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   }
 
   #[cfg(feature = "yarn_pnp")]
-  #[cfg_attr(feature = "enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(cached_path.path()))))]
-  fn find_pnp_manifest(&self, cached_path: &CachedPath) -> Option<Arc<(PathBuf, pnp::Manifest)>> {
+  #[cfg_attr(feature = "enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = cached_path.path())))]
+  fn find_pnp_manifest(&self, cached_path: &CachedPath) -> Option<Arc<(String, pnp::Manifest)>> {
     // 1. Already have a manifest → return it (covers global cache paths too)
     if let Some(manifest) = self.pnp_manifest.load_full() {
       return Some(manifest);
@@ -969,12 +974,13 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     }
 
     // 3. Search for `.pnp.cjs` by walking up from this path
-    let base_path = cached_path.to_path_buf();
-    let Some(manifest_path) = pnp::find_closest_pnp_manifest_path(&base_path) else {
+    let base_path = Path::new(cached_path.path());
+    let Some(manifest_path) = pnp::find_closest_pnp_manifest_path(base_path) else {
       self.pnp_no_manifest_cache.insert(cached_path.clone());
 
       for p in base_path.ancestors() {
-        let p_cached = self.cache.value(p);
+        let Some(p_str) = p.to_str() else { break };
+        let p_cached = self.cache.value(p_str);
         if self.pnp_no_manifest_cache.contains(&p_cached) {
           break;
         }
@@ -986,6 +992,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     tracing::debug!("use manifest path: {:?}", manifest_path);
 
     let manifest = pnp::load_pnp_manifest(&manifest_path).ok()?;
+    let manifest_path = manifest_path.into_os_string().into_string().ok()?;
     let manifest = Arc::new((manifest_path, manifest));
 
     let previous = self
@@ -1000,7 +1007,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   }
 
   #[cfg(feature = "yarn_pnp")]
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = cached_path.path())))]
   async fn load_pnp(
     &self,
     cached_path: &CachedPath,
@@ -1013,7 +1020,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     let (manifest_path, manifest) = pnp_data.as_ref();
     ctx.add_file_dependency(manifest_path);
 
-    let mut path = cached_path.to_path_buf();
+    let mut path = std::path::PathBuf::from(cached_path.path());
     path.push("");
     let resolution = pnp::resolve_to_unqualified_via_manifest(manifest, specifier, &path);
 
@@ -1021,6 +1028,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
     match resolution {
       Ok(pnp::Resolution::Resolved(path, subpath)) => {
+        let path = path
+          .into_os_string()
+          .into_string()
+          .map_err(|_| ResolveError::NotFound(specifier.to_string()))?;
         let cached_path = self.cache.value(&path);
 
         let export_resolution = self.load_package_self(&cached_path, specifier, ctx).await?;
@@ -1065,8 +1076,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   ) -> Option<CachedPath> {
     if module_name == "node_modules" {
       cached_path.cached_node_modules(&self.cache, ctx).await
-    } else if cached_path.path().components().next_back()
-      == Some(Component::Normal(OsStr::new(module_name)))
+    } else if Path::new(cached_path.path())
+      .file_name()
+      .and_then(|n| n.to_str())
+      == Some(module_name)
     {
       Some(cached_path.clone())
     } else {
@@ -1108,7 +1121,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     Ok(None)
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = cached_path.path())))]
   async fn load_package_self(
     &self,
     cached_path: &CachedPath,
@@ -1152,7 +1165,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   }
 
   /// RESOLVE_ESM_MATCH(MATCH)
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = cached_path.path())))]
   async fn resolve_esm_match(
     &self,
     specifier: &str,
@@ -1167,7 +1180,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       return Ok(Some(path));
     }
 
-    let mut path_str = cached_path.path().to_str();
+    let mut path_str: Option<&str> = Some(cached_path.path());
 
     // 3. If the RESOLVED_PATH contains `?``, it could be a path with query
     //    so try to resolve it as a file or directory without the query,
@@ -1175,7 +1188,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     while let Some(s) = path_str {
       if let Some((before, _)) = s.rsplit_once('?') {
         if (self
-          .load_as_file_or_directory(&self.cache.value(Path::new(before)), "", ctx)
+          .load_as_file_or_directory(&self.cache.value(before), "", ctx)
           .await?)
           .is_some()
         {
@@ -1192,7 +1205,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   }
 
   /// enhanced-resolve: AliasFieldPlugin for [ResolveOptions::alias_fields]
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = module_specifier, path = path_to_str(cached_path.path()))))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = module_specifier, path = cached_path.path())))]
   async fn load_browser_field(
     &self,
     cached_path: &CachedPath,
@@ -1218,7 +1231,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       // Complete when resolving to self `{"./a.js": "./a.js"}`
       if new_specifier
         .strip_prefix("./")
-        .filter(|s| path.ends_with(Path::new(s)))
+        .filter(|s| Path::new(path).ends_with(Path::new(s)))
         .is_some()
       {
         return if cached_path.is_file(&self.cache.fs, ctx).await {
@@ -1319,7 +1332,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       let new_specifier = if tail.is_empty() {
         Cow::Borrowed(alias_value)
       } else {
-        let alias_path = Path::new(alias_value).normalize();
+        let alias_path = alias_value.normalize();
         // Must not append anything to alias_value if it is a file.
         let alias_value_cached_path = self.cache.value(&alias_path);
         if alias_value_cached_path.is_file(&self.cache.fs, ctx).await {
@@ -1331,8 +1344,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
         if tail.is_empty() {
           Cow::Borrowed(alias_value)
         } else {
-          let normalized = alias_path.normalize_with(tail);
-          Cow::Owned(path_to_str(&normalized).to_string())
+          Cow::Owned(alias_path.normalize_with(tail))
         }
       };
 
@@ -1359,29 +1371,33 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     if self.options.extension_alias.is_empty() {
       return Ok(None);
     }
-    let Some(path_extension) = cached_path.path().extension() else {
+    let path_str = cached_path.path();
+    let path_p = Path::new(path_str);
+    let Some(path_extension) = path_p.extension().and_then(|e| e.to_str()) else {
       return Ok(None);
     };
     let Some((_, extensions)) = self
       .options
       .extension_alias
       .iter()
-      .find(|(ext, _)| OsStr::new(ext.trim_start_matches('.')) == path_extension)
+      .find(|(ext, _)| ext.trim_start_matches('.') == path_extension)
     else {
       return Ok(None);
     };
-    let path = cached_path.path();
-    let Some(filename) = path.file_name() else {
+    let Some(filename) = path_p.file_name().and_then(|f| f.to_str()) else {
       return Ok(None);
     };
-    let path_without_extension = path.with_extension("");
+    // Strip the trailing `.ext` segment to build the extension-less base.
+    let path_without_extension =
+      &path_str[..path_str.len() - path_extension.len() - 1 /* the dot */];
 
     ctx.with_fully_specified(true);
     for extension in extensions {
-      let mut path_with_extension = path_without_extension.clone().into_os_string();
-      path_with_extension.reserve_exact(extension.len());
-      path_with_extension.push(extension);
-      let cached_path = self.cache.value(Path::new(&path_with_extension));
+      let mut path_with_extension =
+        String::with_capacity(path_without_extension.len() + extension.len());
+      path_with_extension.push_str(path_without_extension);
+      path_with_extension.push_str(extension);
+      let cached_path = self.cache.value(&path_with_extension);
       if let Some(path) = self.load_alias_or_file(&cached_path, ctx).await? {
         ctx.with_fully_specified(false);
         return Ok(Some(path));
@@ -1395,16 +1411,19 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       return Ok(None);
     }
     // Create a meaningful error message.
-    let dir = path.parent().unwrap().to_path_buf();
-    let filename_without_extension = Path::new(filename).with_extension("");
-    let filename_without_extension = path_to_str(&filename_without_extension);
+    let dir = path_p
+      .parent()
+      .and_then(|p| p.to_str())
+      .unwrap_or("")
+      .to_string();
+    let filename_without_extension = filename.rsplit_once('.').map_or(filename, |(stem, _)| stem);
     let files = extensions
       .iter()
       .map(|ext| format!("{filename_without_extension}{ext}"))
       .collect::<Vec<_>>()
       .join(",");
     Err(ResolveError::ExtensionAlias(
-      filename.to_str().expect("path should be UTF-8").to_string(),
+      filename.to_string(),
       files,
       dir,
     ))
@@ -1460,11 +1479,11 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     Ok(None)
   }
 
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip(self), fields(path = path.display().to_string())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip(self), fields(path = path)))]
   fn load_tsconfig<'a>(
     &'a self,
     root: bool,
-    path: &'a Path,
+    path: &'a str,
     references: &'a TsconfigReferences,
   ) -> BoxFuture<'a, Result<Arc<TsConfig>, ResolveError>> {
     let fut = async move {
@@ -1517,13 +1536,13 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   fn load_references<'a>(
     &'a self,
     tsconfig: &'a mut TsConfig,
-    visited: &'a mut FxHashSet<PathBuf>,
+    visited: &'a mut FxHashSet<String>,
   ) -> BoxFuture<'a, Result<(), ResolveError>> {
     Box::pin(async move {
       if tsconfig.references.is_empty() {
         return Ok(());
       }
-      let directory = tsconfig.directory().to_path_buf();
+      let directory = tsconfig.directory().to_string();
       let current_path = tsconfig.path.clone();
       visited.insert(current_path.clone());
       for reference in &mut tsconfig.references {
@@ -1531,7 +1550,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
         // Reborrow so the closure below can capture `&mut FxHashSet` across
         // multiple iterations of this loop. Without the reborrow, the first
         // iteration would consume the original `&mut visited` binding.
-        let visited: &mut FxHashSet<PathBuf> = &mut *visited;
+        let visited: &mut FxHashSet<String> = &mut *visited;
         let reference_tsconfig = self
           .cache
           .tsconfig(
@@ -1617,12 +1636,12 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     directory: &CachedPath,
     tsconfig: &TsConfig,
     specifier: &str,
-  ) -> Result<PathBuf, ResolveError> {
+  ) -> Result<String, ResolveError> {
     match specifier.as_bytes().first() {
       None => Err(ResolveError::Specifier(SpecifierError::Empty(
         specifier.to_string(),
       ))),
-      Some(b'/') => Ok(PathBuf::from(specifier)),
+      Some(b'/') => Ok(specifier.to_string()),
       Some(b'.') => Ok(tsconfig.directory().normalize_with(specifier)),
       _ => self
         .clone_with_options(ResolveOptions {
@@ -1633,9 +1652,9 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
         })
         .load_package_self_or_node_modules(directory, specifier, &mut Ctx::default())
         .await
-        .map(|p| p.to_path_buf())
+        .map(|p| p.path().to_string())
         .map_err(|err| match err {
-          ResolveError::NotFound(_) => ResolveError::TsconfigNotFound(PathBuf::from(specifier)),
+          ResolveError::NotFound(_) => ResolveError::TsconfigNotFound(specifier.to_string()),
           _ => err,
         }),
     }
@@ -1735,7 +1754,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   /// PACKAGE_EXPORTS_RESOLVE(packageURL, subpath, exports, conditions)
   fn package_exports_resolve<'a>(
     &'a self,
-    package_url: &'a Path,
+    package_url: &'a str,
     subpath: &'a str,
     exports: &'a JSONValue,
     ctx: &'a mut Ctx,
@@ -1752,7 +1771,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
           without_dot = without_dot || !starts_with_dot_or_hash;
           if has_dot && without_dot {
             return Err(ResolveError::InvalidPackageConfig(
-              package_url.join("package.json"),
+              package_url.normalize_with("package.json"),
             ));
           }
         }
@@ -1768,7 +1787,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
           let fragment = ctx.fragment.clone().unwrap_or_default();
           return Err(ResolveError::PackagePathNotExported(
             format!("./{}{query}{fragment}", subpath.trim_start_matches('.')),
-            package_url.join("package.json"),
+            package_url.normalize_with("package.json"),
           ));
         }
         // 1. Let mainExport be undefined.
@@ -1841,7 +1860,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       // 4. Throw a Package Path Not Exported error.
       Err(ResolveError::PackagePathNotExported(
         subpath.to_string(),
-        package_url.join("package.json"),
+        package_url.normalize_with("package.json"),
       ))
     };
     Box::pin(fut)
@@ -1909,7 +1928,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     &self,
     match_key: &str,
     match_obj: &JSONMap<'_>,
-    package_url: &Path,
+    package_url: &str,
     is_imports: bool,
     conditions: &[String],
     ctx: &mut Ctx,
@@ -1996,7 +2015,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   #[allow(clippy::too_many_arguments)]
   fn package_target_resolve<'a>(
     &'a self,
-    package_url: &'a Path,
+    package_url: &'a str,
     target_key: &'a str,
     target: &'a JSONValue,
     pattern_match: Option<&'a str>,
@@ -2009,7 +2028,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
         target_key: &'a str,
         target: &'a str,
         pattern_match: Option<&'a str>,
-        package_url: &Path,
+        package_url: &str,
       ) -> Result<Cow<'a, str>, ResolveError> {
         let target = if let Some(pattern_match) = pattern_match {
           if !target_key.contains('*') && !target.contains('*') {
@@ -2019,7 +2038,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
               Cow::Owned(format!("{target}{pattern_match}"))
             } else {
               return Err(ResolveError::InvalidPackageConfigDirectory(
-                package_url.join("package.json"),
+                package_url.normalize_with("package.json"),
               ));
             }
           } else {
@@ -2042,7 +2061,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
               return Err(ResolveError::InvalidPackageTarget(
                 target.to_string(),
                 target_key.to_string(),
-                package_url.join("package.json"),
+                package_url.normalize_with("package.json"),
               ));
             }
             // 2. If patternMatch is a String, then
@@ -2058,11 +2077,11 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
           // 4. Assert: resolvedTarget is contained in packageURL.
           // 5. If patternMatch is null, then
           let target = normalize_string_target(target_key, target, pattern_match, package_url)?;
-          if Path::new(target.as_ref()).is_invalid_exports_target() {
+          if target.as_ref().is_invalid_exports_target() {
             return Err(ResolveError::InvalidPackageTarget(
               target.to_string(),
               target_key.to_string(),
-              package_url.join("package.json"),
+              package_url.normalize_with("package.json"),
             ));
           }
           let resolved_target = package_url.normalize_with(target.as_ref());
@@ -2109,7 +2128,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
             // Note: return PackagePathNotExported has the same effect as return because there are no matches.
             return Err(ResolveError::PackagePathNotExported(
               pattern_match.unwrap_or(".").to_string(),
-              package_url.join("package.json"),
+              package_url.normalize_with("package.json"),
             ));
           }
           // 2. For each item targetValue in target, do

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,13 +84,14 @@ pub use crate::{
   },
   package_json::{JSONValue, ModuleType, PackageJson},
   resolution::Resolution,
+  resolver_path::{ResolverPath, ResolverPathBuf},
 };
 use crate::{
   cache::{Cache, CachedPath},
   context::ResolveContext as Ctx,
   package_json::JSONMap,
   path::{PathUtil, SLASH_START},
-  resolver_path::{Component, ResolverPath, ResolverPathBuf},
+  resolver_path::Component,
   specifier::Specifier,
   tsconfig::{ExtendsField, ProjectReference, TsConfig},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,8 @@ mod options;
 mod package_json;
 mod path;
 mod resolution;
+mod resolver_path;
 mod specifier;
-mod str_path;
 mod tsconfig;
 
 #[cfg(test)]
@@ -90,8 +90,8 @@ use crate::{
   context::ResolveContext as Ctx,
   package_json::JSONMap,
   path::{PathUtil, SLASH_START},
+  resolver_path::{Component, ResolverPath},
   specifier::Specifier,
-  str_path::{Component, StrPath},
   tsconfig::{ExtendsField, ProjectReference, TsConfig},
 };
 
@@ -276,7 +276,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       .await?;
     if let Some(package_json) = &package_json {
       // path must be inside the package.
-      debug_assert!(StrPath::new(&path).starts_with(package_json.directory()));
+      debug_assert!(ResolverPath::new(&path).starts_with(package_json.directory()));
     }
     Ok(Resolution {
       path,
@@ -336,7 +336,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       return Ok(path);
     }
 
-    let result = match StrPath::new(specifier).components().next() {
+    let result = match ResolverPath::new(specifier).components().next() {
       // 2. If X begins with '/'
       Some(Component::RootDir | Component::Prefix(_)) => {
         self.require_absolute(cached_path, specifier, ctx).await
@@ -401,7 +401,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     ctx: &mut Ctx,
   ) -> Result<CachedPath, ResolveError> {
     // Make sure only path prefixes gets called
-    debug_assert!(StrPath::new(specifier)
+    debug_assert!(ResolverPath::new(specifier)
       .components()
       .next()
       .is_some_and(|c| matches!(c, Component::RootDir | Component::Prefix(_))));
@@ -447,7 +447,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     ctx: &mut Ctx,
   ) -> Result<CachedPath, ResolveError> {
     // Make sure only relative or normal paths gets called
-    debug_assert!(StrPath::new(specifier)
+    debug_assert!(ResolverPath::new(specifier)
       .components()
       .next()
       .is_some_and(|c| matches!(
@@ -495,7 +495,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     ctx: &mut Ctx,
   ) -> Result<CachedPath, ResolveError> {
     // Make sure no other path prefixes gets called
-    debug_assert!(StrPath::new(specifier)
+    debug_assert!(ResolverPath::new(specifier)
       .components()
       .next()
       .is_some_and(|c| matches!(c, Component::Normal(_))));
@@ -734,8 +734,8 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   fn check_restrictions(&self, path: &str) -> bool {
     // https://github.com/webpack/enhanced-resolve/blob/a998c7d218b7a9ec2461fc4fddd1ad5dd7687485/lib/RestrictionsPlugin.js#L19-L24
     fn is_inside(path: &str, parent: &str) -> bool {
-      let path_p = StrPath::new(path);
-      let parent_p = StrPath::new(parent);
+      let path_p = ResolverPath::new(path);
+      let parent_p = ResolverPath::new(parent);
       if !path_p.starts_with(parent_p) {
         return false;
       }
@@ -744,7 +744,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       }
       path_p
         .strip_prefix(parent_p)
-        .is_ok_and(|p| p == StrPath::new("./"))
+        .is_ok_and(|p| p == ResolverPath::new("./"))
     }
     for restriction in &self.options.restrictions {
       match restriction {
@@ -976,8 +976,8 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
     // 3. Search for `.pnp.cjs` by walking up this path. pnp's API still
     // expects `std::path::Path`, so build a single std::path::Path::new at
-    // the boundary; we keep the rest of the walk in StrPath land.
-    let base_path = StrPath::new(cached_path.path());
+    // the boundary; we keep the rest of the walk in ResolverPath land.
+    let base_path = ResolverPath::new(cached_path.path());
     let Some(manifest_path) =
       pnp::find_closest_pnp_manifest_path(std::path::Path::new(base_path.as_str()))
     else {
@@ -1080,7 +1080,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   ) -> Option<CachedPath> {
     if module_name == "node_modules" {
       cached_path.cached_node_modules(&self.cache, ctx).await
-    } else if StrPath::new(cached_path.path()).file_name() == Some(module_name) {
+    } else if ResolverPath::new(cached_path.path()).file_name() == Some(module_name) {
       Some(cached_path.clone())
     } else {
       cached_path
@@ -1231,7 +1231,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       // Complete when resolving to self `{"./a.js": "./a.js"}`
       if new_specifier
         .strip_prefix("./")
-        .filter(|s| StrPath::new(path).ends_with(StrPath::new(s)))
+        .filter(|s| ResolverPath::new(path).ends_with(ResolverPath::new(s)))
         .is_some()
       {
         return if cached_path.is_file(&self.cache.fs, ctx).await {
@@ -1372,7 +1372,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       return Ok(None);
     }
     let path_str = cached_path.path();
-    let path_p = StrPath::new(path_str);
+    let path_p = ResolverPath::new(path_str);
     let Some(path_extension) = path_p.extension() else {
       return Ok(None);
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ use crate::{
   context::ResolveContext as Ctx,
   package_json::JSONMap,
   path::{PathUtil, SLASH_START},
-  resolver_path::{Component, ResolverPath},
+  resolver_path::{Component, ResolverPath, ResolverPathBuf},
   specifier::Specifier,
   tsconfig::{ExtendsField, ProjectReference, TsConfig},
 };
@@ -278,8 +278,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       // path must be inside the package.
       debug_assert!(ResolverPath::new(&path).starts_with(package_json.directory()));
     }
+    // Move the resolved path into a `ResolverPathBuf` so the prehash is
+    // computed once at this boundary and travels with the `Resolution`.
     Ok(Resolution {
-      path,
+      path: ResolverPathBuf::from(path),
       query: ctx.query.take(),
       fragment: ctx.fragment.take(),
       package_json,
@@ -1413,9 +1415,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     // Create a meaningful error message.
     let dir = path_p
       .parent()
-      .and_then(|p| p.to_str())
-      .unwrap_or("")
-      .to_string();
+      .map_or_else(String::new, |p| p.as_str().to_string());
     let filename_without_extension = filename.rsplit_once('.').map_or(filename, |(stem, _)| stem);
     let files = extensions
       .iter()

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,8 +1,4 @@
-use std::{
-  fmt,
-  path::{Path, PathBuf},
-  sync::Arc,
-};
+use std::{fmt, sync::Arc};
 
 /// Module Resolution Options
 ///
@@ -148,7 +144,7 @@ pub struct ResolveOptions {
   /// On non-Windows systems these requests are resolved as an absolute path first.
   ///
   /// Default `[]`
-  pub roots: Vec<PathBuf>,
+  pub roots: Vec<String>,
 
   /// Whether to resolve symlinks to their symlinked location.
   /// When enabled, symlinked resources are resolved to their real path, not their symlinked location.
@@ -209,16 +205,14 @@ impl ResolveOptions {
   /// ## Examples
   ///
   /// ```
-  /// use std::path::{Path, PathBuf};
-  ///
   /// use rspack_resolver::ResolveOptions;
   ///
   /// let options = ResolveOptions::default().with_root("foo");
-  /// assert_eq!(options.roots, vec![PathBuf::from("foo")])
+  /// assert_eq!(options.roots, vec!["foo".to_string()])
   /// ```
   #[must_use]
-  pub fn with_root<P: AsRef<Path>>(mut self, root: P) -> Self {
-    self.roots.push(root.as_ref().to_path_buf());
+  pub fn with_root<S: Into<String>>(mut self, root: S) -> Self {
+    self.roots.push(root.into());
     self
   }
 
@@ -227,8 +221,6 @@ impl ResolveOptions {
   /// ## Examples
   ///
   /// ```
-  /// use std::path::{Path, PathBuf};
-  ///
   /// use rspack_resolver::ResolveOptions;
   ///
   /// let options = ResolveOptions::default().with_extension("jsonc");
@@ -245,8 +237,6 @@ impl ResolveOptions {
   /// ## Examples
   ///
   /// ```
-  /// use std::path::{Path, PathBuf};
-  ///
   /// use rspack_resolver::ResolveOptions;
   ///
   /// let options = ResolveOptions::default().with_main_field("something");
@@ -263,8 +253,6 @@ impl ResolveOptions {
   /// ## Examples
   ///
   /// ```
-  /// use std::path::{Path, PathBuf};
-  ///
   /// use rspack_resolver::{EnforceExtension, ResolveOptions};
   ///
   /// let options = ResolveOptions::default().with_force_extension(EnforceExtension::Enabled);
@@ -281,8 +269,6 @@ impl ResolveOptions {
   /// ## Examples
   ///
   /// ```
-  /// use std::path::{Path, PathBuf};
-  ///
   /// use rspack_resolver::ResolveOptions;
   ///
   /// let options = ResolveOptions::default().with_fully_specified(true);
@@ -298,8 +284,6 @@ impl ResolveOptions {
   /// ## Examples
   ///
   /// ```
-  /// use std::path::{Path, PathBuf};
-  ///
   /// use rspack_resolver::ResolveOptions;
   ///
   /// let options = ResolveOptions::default().with_prefer_relative(true);
@@ -315,8 +299,6 @@ impl ResolveOptions {
   /// ## Examples
   ///
   /// ```
-  /// use std::path::{Path, PathBuf};
-  ///
   /// use rspack_resolver::ResolveOptions;
   ///
   /// let options = ResolveOptions::default().with_prefer_absolute(true);
@@ -445,8 +427,8 @@ where
 /// Value for [ResolveOptions::restrictions]
 #[derive(Clone)]
 pub enum Restriction {
-  Path(PathBuf),
-  Fn(Arc<dyn Fn(&Path) -> bool + Sync + Send>),
+  Path(String),
+  Fn(Arc<dyn Fn(&str) -> bool + Sync + Send>),
 }
 
 impl std::fmt::Debug for Restriction {
@@ -467,7 +449,7 @@ pub struct TsconfigOptions {
   /// You may provide
   /// * a relative path to the configuration file. It will be resolved relative to cwd.
   /// * an absolute path to the configuration file.
-  pub config_file: PathBuf,
+  pub config_file: String,
 
   /// Support for Typescript Project References.
   pub references: TsconfigReferences,
@@ -480,7 +462,7 @@ pub enum TsconfigReferences {
   /// Use the `references` field from tsconfig of `config_file`.
   Auto,
   /// Manually provided relative or absolute path.
-  Paths(Vec<PathBuf>),
+  Paths(Vec<String>),
 }
 
 impl Default for ResolveOptions {
@@ -590,8 +572,6 @@ impl fmt::Display for ResolveOptions {
 
 #[cfg(test)]
 mod test {
-  use std::path::PathBuf;
-
   use super::{
     AliasValue, EnforceExtension, ResolveOptions, Restriction, TsconfigOptions, TsconfigReferences,
   };
@@ -615,7 +595,7 @@ mod test {
   fn display() {
     let options = ResolveOptions {
       tsconfig: Some(TsconfigOptions {
-        config_file: PathBuf::from("tsconfig.json"),
+        config_file: "tsconfig.json".to_string(),
         references: TsconfigReferences::Auto,
       }),
       alias: vec![("a".into(), vec![AliasValue::Ignore])],
@@ -630,8 +610,8 @@ mod test {
       resolve_to_context: true,
       prefer_relative: true,
       prefer_absolute: true,
-      restrictions: vec![Restriction::Path(PathBuf::from("restrictions"))],
-      roots: vec![PathBuf::from("roots")],
+      restrictions: vec![Restriction::Path("restrictions".to_string())],
+      roots: vec!["roots".to_string()],
       builtin_modules: true,
       ..ResolveOptions::default()
     };

--- a/src/package_json/simd.rs
+++ b/src/package_json/simd.rs
@@ -5,7 +5,7 @@
 use std::{
   fmt::{Debug, Formatter},
   marker::PhantomData,
-  path::{Path, PathBuf},
+  path::Path,
 };
 
 use simd_json::{
@@ -80,10 +80,10 @@ impl Default for JSONCell {
 #[derive(Debug, Default)]
 pub struct PackageJson {
   /// Path to `package.json`. Contains the `package.json` filename.
-  pub path: PathBuf,
+  pub path: String,
 
   /// Realpath to `package.json`. Contains the `package.json` filename.
-  pub realpath: PathBuf,
+  pub realpath: String,
 
   /// The "name" field defines your package's name.
   /// The "name" field can be used in addition to the "exports" field to self-reference a package using its name.
@@ -135,7 +135,7 @@ impl From<SimdParseError> for ParseError {
 impl PackageJson {
   /// # Panics
   /// # Errors
-  pub(crate) fn parse(path: PathBuf, realpath: PathBuf, json: Vec<u8>) -> Result<Self, ParseError> {
+  pub(crate) fn parse(path: String, realpath: String, json: Vec<u8>) -> Result<Self, ParseError> {
     if json.starts_with(&BOM) {
       return Err(ParseError {
         message: "BOM character found".to_string(),
@@ -221,12 +221,13 @@ impl PackageJson {
   /// # Panics
   ///
   /// * When the package.json path is misconfigured.
-  pub fn directory(&self) -> &Path {
-    debug_assert!(self
-      .realpath
-      .file_name()
-      .is_some_and(|x| x == "package.json"));
-    self.realpath.parent().unwrap()
+  pub fn directory(&self) -> &str {
+    let realpath = Path::new(&self.realpath);
+    debug_assert!(realpath.file_name().is_some_and(|x| x == "package.json"));
+    realpath
+      .parent()
+      .and_then(|p| p.to_str())
+      .expect("package.json realpath should have a UTF-8 parent")
   }
 
   /// The "main" field defines the entry point of a package when imported by name via a node_modules lookup. Its value is a path.
@@ -308,7 +309,7 @@ impl PackageJson {
   /// * Returns [ResolveError::Ignored] for `"path": false` in `browser` field.
   pub(crate) fn resolve_browser_field<'a>(
     &'a self,
-    path: &Path,
+    path: &str,
     request: Option<&str>,
     alias_fields: &'a [Vec<String>],
   ) -> Result<Option<&'a str>, ResolveError> {
@@ -318,9 +319,12 @@ impl PackageJson {
           return Self::alias_value(path, value);
         }
       } else {
-        let dir = self.path.parent().unwrap();
+        let dir = Path::new(&self.path)
+          .parent()
+          .and_then(|p| p.to_str())
+          .expect("package.json path should have a UTF-8 parent");
         for (key, value) in object {
-          let joined = dir.normalize_with(key.to_string());
+          let joined = dir.normalize_with(key);
           if joined == path {
             return Self::alias_value(path, value);
           }
@@ -330,12 +334,12 @@ impl PackageJson {
     Ok(None)
   }
 
-  fn alias_value<'a>(key: &Path, value: &'a JSONValue) -> Result<Option<&'a str>, ResolveError> {
+  fn alias_value<'a>(key: &str, value: &'a JSONValue) -> Result<Option<&'a str>, ResolveError> {
     match value {
       JSONValue::String(value) => Ok(Some(value)),
       JSONValue::Static(sn) => {
         if matches!(sn.as_bool(), Some(false)) {
-          Err(ResolveError::Ignored(key.to_path_buf()))
+          Err(ResolveError::Ignored(key.to_string()))
         } else {
           Ok(None)
         }

--- a/src/package_json/simd.rs
+++ b/src/package_json/simd.rs
@@ -11,7 +11,7 @@ use simd_json::{
   borrowed::Value, prelude::*, to_borrowed_value, BorrowedValue, Error as SimdParseError,
 };
 
-use crate::{path::PathUtil, str_path::StrPath, ResolveError};
+use crate::{path::PathUtil, resolver_path::ResolverPath, ResolveError};
 
 pub type JSONMap<'a> = simd_json::borrowed::Object<'a>;
 
@@ -221,11 +221,11 @@ impl PackageJson {
   ///
   /// * When the package.json path is misconfigured.
   pub fn directory(&self) -> &str {
-    let realpath = StrPath::new(&self.realpath);
+    let realpath = ResolverPath::new(&self.realpath);
     debug_assert!(realpath.file_name() == Some("package.json"));
     realpath
       .parent()
-      .map(StrPath::as_str)
+      .map(ResolverPath::as_str)
       .expect("package.json realpath should have a parent")
   }
 
@@ -318,9 +318,9 @@ impl PackageJson {
           return Self::alias_value(path, value);
         }
       } else {
-        let dir = StrPath::new(&self.path)
+        let dir = ResolverPath::new(&self.path)
           .parent()
-          .map(StrPath::as_str)
+          .map(ResolverPath::as_str)
           .expect("package.json path should have a parent");
         for (key, value) in object {
           let joined = dir.normalize_with(key);

--- a/src/package_json/simd.rs
+++ b/src/package_json/simd.rs
@@ -5,14 +5,13 @@
 use std::{
   fmt::{Debug, Formatter},
   marker::PhantomData,
-  path::Path,
 };
 
 use simd_json::{
   borrowed::Value, prelude::*, to_borrowed_value, BorrowedValue, Error as SimdParseError,
 };
 
-use crate::{path::PathUtil, ResolveError};
+use crate::{path::PathUtil, str_path::StrPath, ResolveError};
 
 pub type JSONMap<'a> = simd_json::borrowed::Object<'a>;
 
@@ -222,12 +221,12 @@ impl PackageJson {
   ///
   /// * When the package.json path is misconfigured.
   pub fn directory(&self) -> &str {
-    let realpath = Path::new(&self.realpath);
-    debug_assert!(realpath.file_name().is_some_and(|x| x == "package.json"));
+    let realpath = StrPath::new(&self.realpath);
+    debug_assert!(realpath.file_name() == Some("package.json"));
     realpath
       .parent()
-      .and_then(|p| p.to_str())
-      .expect("package.json realpath should have a UTF-8 parent")
+      .map(StrPath::as_str)
+      .expect("package.json realpath should have a parent")
   }
 
   /// The "main" field defines the entry point of a package when imported by name via a node_modules lookup. Its value is a path.
@@ -319,10 +318,10 @@ impl PackageJson {
           return Self::alias_value(path, value);
         }
       } else {
-        let dir = Path::new(&self.path)
+        let dir = StrPath::new(&self.path)
           .parent()
-          .and_then(|p| p.to_str())
-          .expect("package.json path should have a UTF-8 parent");
+          .map(StrPath::as_str)
+          .expect("package.json path should have a parent");
         for (key, value) in object {
           let joined = dir.normalize_with(key);
           if joined == path {

--- a/src/path.rs
+++ b/src/path.rs
@@ -3,15 +3,17 @@
 //! Code adapted from the following libraries
 //! * [path-absolutize](https://docs.rs/path-absolutize)
 //! * [normalize_path](https://docs.rs/normalize-path)
-use std::path::{Component, Path};
+
+use crate::str_path::{Component, StrPath, StrPathBuf};
 
 pub const SLASH_START: &[char; 2] = &['/', '\\'];
 
 /// Extension trait that adds path-normalization helpers operating on `&str`.
 ///
-/// Path normalization still leans on [`std::path::Path`] to handle platform
-/// quirks (drive prefixes, UNC, parent traversal), but every input and output
-/// crosses the API boundary as `str`/`String`.
+/// Path normalization is fully implemented over the crate's
+/// [`crate::str_path::StrPath`] mirror — no `std::path::PathBuf` /
+/// `OsString` roundtrips. Inputs and outputs cross the API boundary as
+/// `str` / `String`.
 pub trait PathUtil {
   /// Normalize this path without performing I/O.
   fn normalize(&self) -> String;
@@ -27,15 +29,15 @@ pub trait PathUtil {
 
 impl PathUtil for str {
   fn normalize(&self) -> String {
-    normalize_path(Path::new(self))
+    normalize_path(StrPath::new(self)).into_string()
   }
 
   fn normalize_with(&self, subpath: &str) -> String {
-    normalize_path_with(Path::new(self), Path::new(subpath))
+    normalize_path_with(StrPath::new(self), StrPath::new(subpath)).into_string()
   }
 
   fn is_invalid_exports_target(&self) -> bool {
-    Path::new(self)
+    StrPath::new(self)
       .components()
       .enumerate()
       .any(|(index, c)| match c {
@@ -59,7 +61,7 @@ impl PathUtil for String {
   }
 }
 
-impl PathUtil for crate::str_path::StrPath {
+impl PathUtil for StrPath {
   fn normalize(&self) -> String {
     self.as_str().normalize()
   }
@@ -72,46 +74,44 @@ impl PathUtil for crate::str_path::StrPath {
 }
 
 // Adapted from https://github.com/parcel-bundler/parcel/blob/e0b99c2a42e9109a9ecbd6f537844a1b33e7faf5/packages/utils/node-resolver-rs/src/path.rs#L7
-fn normalize_path(path: &Path) -> String {
-  use std::path::PathBuf;
+fn normalize_path(path: &StrPath) -> StrPathBuf {
   let mut components = path.components().peekable();
-  let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek() {
-    let buf = PathBuf::from(c.as_os_str());
+  let mut ret = if let Some(Component::Prefix(p)) = components.peek().copied() {
     components.next();
-    buf
+    StrPathBuf::from(p)
   } else {
-    PathBuf::new()
+    StrPathBuf::new()
   };
 
   for component in components {
     match component {
-      Component::Prefix(..) => unreachable!("Path {:?}", path),
+      Component::Prefix(_) => unreachable!("Path {:?}", path),
       Component::RootDir => {
-        ret.push(component.as_os_str());
+        ret.push(StrPath::new(component.as_str()));
       }
       Component::CurDir => {}
       Component::ParentDir => {
         ret.pop();
       }
       Component::Normal(c) => {
-        ret.push(c);
+        ret.push(StrPath::new(c));
       }
     }
   }
 
-  ret.to_str().expect("path should be UTF-8").to_string()
+  ret
 }
 
 // Adapted from https://github.com/parcel-bundler/parcel/blob/e0b99c2a42e9109a9ecbd6f537844a1b33e7faf5/packages/utils/node-resolver-rs/src/path.rs#L37
-fn normalize_path_with(base: &Path, subpath: &Path) -> String {
+fn normalize_path_with(base: &StrPath, subpath: &StrPath) -> StrPathBuf {
   let mut components = subpath.components();
 
   let Some(head) = components.next() else {
-    return subpath.to_str().expect("path should be UTF-8").to_string();
+    return subpath.to_path_buf();
   };
 
-  if matches!(head, Component::Prefix(..) | Component::RootDir) {
-    return subpath.to_str().expect("path should be UTF-8").to_string();
+  if matches!(head, Component::Prefix(_) | Component::RootDir) {
+    return subpath.to_path_buf();
   }
 
   let mut ret = base.to_path_buf();
@@ -122,15 +122,15 @@ fn normalize_path_with(base: &Path, subpath: &Path) -> String {
         ret.pop();
       }
       Component::Normal(c) => {
-        ret.push(c);
+        ret.push(StrPath::new(c));
       }
-      Component::Prefix(..) | Component::RootDir => {
+      Component::Prefix(_) | Component::RootDir => {
         unreachable!("Path {:?} Subpath {:?}", base, subpath)
       }
     }
   }
 
-  ret.to_str().expect("path should be UTF-8").to_string()
+  ret
 }
 
 // https://github.com/webpack/enhanced-resolve/blob/main/test/path.test.js

--- a/src/path.rs
+++ b/src/path.rs
@@ -3,107 +3,122 @@
 //! Code adapted from the following libraries
 //! * [path-absolutize](https://docs.rs/path-absolutize)
 //! * [normalize_path](https://docs.rs/normalize-path)
-use std::path::{Component, Path, PathBuf};
+use std::path::{Component, Path};
 
 pub const SLASH_START: &[char; 2] = &['/', '\\'];
 
-pub fn path_to_str(path: &Path) -> &str {
-  path.to_str().expect("path should be UTF-8")
-}
-
-/// Extension trait to add path normalization to std's [`Path`].
+/// Extension trait that adds path-normalization helpers operating on `&str`.
+///
+/// Path normalization still leans on [`std::path::Path`] to handle platform
+/// quirks (drive prefixes, UNC, parent traversal), but every input and output
+/// crosses the API boundary as `str`/`String`.
 pub trait PathUtil {
   /// Normalize this path without performing I/O.
-  ///
-  /// All redundant separator and up-level references are collapsed.
-  ///
-  /// However, this does not resolve links.
-  fn normalize(&self) -> PathBuf;
+  fn normalize(&self) -> String;
 
   /// Normalize with subpath assuming this path is normalized without performing I/O.
-  ///
-  /// All redundant separator and up-level references are collapsed.
-  ///
-  /// However, this does not resolve links.
-  fn normalize_with<P: AsRef<Path>>(&self, subpath: P) -> PathBuf;
+  fn normalize_with(&self, subpath: &str) -> String;
 
   /// Defined in ESM PACKAGE_TARGET_RESOLVE
-  /// If target split on "/" or "\" contains any "", ".", "..", or "node_modules" segments after the first "." segment, case insensitive and including percent encoded variants
+  /// If target split on "/" or "\" contains any "", ".", "..", or "node_modules" segments
+  /// after the first "." segment, case insensitive and including percent encoded variants.
   fn is_invalid_exports_target(&self) -> bool;
 }
 
-impl PathUtil for Path {
-  // https://github.com/parcel-bundler/parcel/blob/e0b99c2a42e9109a9ecbd6f537844a1b33e7faf5/packages/utils/node-resolver-rs/src/path.rs#L7
-  fn normalize(&self) -> PathBuf {
-    let mut components = self.components().peekable();
-    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek() {
-      let buf = PathBuf::from(c.as_os_str());
-      components.next();
-      buf
-    } else {
-      PathBuf::new()
-    };
-
-    for component in components {
-      match component {
-        Component::Prefix(..) => unreachable!("Path {:?}", self),
-        Component::RootDir => {
-          ret.push(component.as_os_str());
-        }
-        Component::CurDir => {}
-        Component::ParentDir => {
-          ret.pop();
-        }
-        Component::Normal(c) => {
-          ret.push(c);
-        }
-      }
-    }
-
-    ret
+impl PathUtil for str {
+  fn normalize(&self) -> String {
+    normalize_path(Path::new(self))
   }
 
-  // https://github.com/parcel-bundler/parcel/blob/e0b99c2a42e9109a9ecbd6f537844a1b33e7faf5/packages/utils/node-resolver-rs/src/path.rs#L37
-  fn normalize_with<B: AsRef<Self>>(&self, subpath: B) -> PathBuf {
-    let subpath = subpath.as_ref();
-
-    let mut components = subpath.components();
-
-    let Some(head) = components.next() else {
-      return subpath.to_path_buf();
-    };
-
-    if matches!(head, Component::Prefix(..) | Component::RootDir) {
-      return subpath.to_path_buf();
-    }
-
-    let mut ret = self.to_path_buf();
-    for component in std::iter::once(head).chain(components) {
-      match component {
-        Component::CurDir => {}
-        Component::ParentDir => {
-          ret.pop();
-        }
-        Component::Normal(c) => {
-          ret.push(c);
-        }
-        Component::Prefix(..) | Component::RootDir => {
-          unreachable!("Path {:?} Subpath {:?}", self, subpath)
-        }
-      }
-    }
-
-    ret
+  fn normalize_with(&self, subpath: &str) -> String {
+    normalize_path_with(Path::new(self), Path::new(subpath))
   }
 
   fn is_invalid_exports_target(&self) -> bool {
-    self.components().enumerate().any(|(index, c)| match c {
-      Component::ParentDir => true,
-      Component::CurDir => index > 0,
-      Component::Normal(c) => c.eq_ignore_ascii_case("node_modules"),
-      _ => false,
-    })
+    Path::new(self)
+      .components()
+      .enumerate()
+      .any(|(index, c)| match c {
+        Component::ParentDir => true,
+        Component::CurDir => index > 0,
+        Component::Normal(c) => c.eq_ignore_ascii_case("node_modules"),
+        _ => false,
+      })
   }
+}
+
+impl PathUtil for String {
+  fn normalize(&self) -> String {
+    self.as_str().normalize()
+  }
+  fn normalize_with(&self, subpath: &str) -> String {
+    self.as_str().normalize_with(subpath)
+  }
+  fn is_invalid_exports_target(&self) -> bool {
+    self.as_str().is_invalid_exports_target()
+  }
+}
+
+// Adapted from https://github.com/parcel-bundler/parcel/blob/e0b99c2a42e9109a9ecbd6f537844a1b33e7faf5/packages/utils/node-resolver-rs/src/path.rs#L7
+fn normalize_path(path: &Path) -> String {
+  use std::path::PathBuf;
+  let mut components = path.components().peekable();
+  let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek() {
+    let buf = PathBuf::from(c.as_os_str());
+    components.next();
+    buf
+  } else {
+    PathBuf::new()
+  };
+
+  for component in components {
+    match component {
+      Component::Prefix(..) => unreachable!("Path {:?}", path),
+      Component::RootDir => {
+        ret.push(component.as_os_str());
+      }
+      Component::CurDir => {}
+      Component::ParentDir => {
+        ret.pop();
+      }
+      Component::Normal(c) => {
+        ret.push(c);
+      }
+    }
+  }
+
+  ret.to_str().expect("path should be UTF-8").to_string()
+}
+
+// Adapted from https://github.com/parcel-bundler/parcel/blob/e0b99c2a42e9109a9ecbd6f537844a1b33e7faf5/packages/utils/node-resolver-rs/src/path.rs#L37
+fn normalize_path_with(base: &Path, subpath: &Path) -> String {
+  let mut components = subpath.components();
+
+  let Some(head) = components.next() else {
+    return subpath.to_str().expect("path should be UTF-8").to_string();
+  };
+
+  if matches!(head, Component::Prefix(..) | Component::RootDir) {
+    return subpath.to_str().expect("path should be UTF-8").to_string();
+  }
+
+  let mut ret = base.to_path_buf();
+  for component in std::iter::once(head).chain(components) {
+    match component {
+      Component::CurDir => {}
+      Component::ParentDir => {
+        ret.pop();
+      }
+      Component::Normal(c) => {
+        ret.push(c);
+      }
+      Component::Prefix(..) | Component::RootDir => {
+        unreachable!("Path {:?} Subpath {:?}", base, subpath)
+      }
+    }
+  }
+
+  ret.to_str().expect("path should be UTF-8").to_string()
 }
 
 // https://github.com/webpack/enhanced-resolve/blob/main/test/path.test.js
@@ -122,20 +137,19 @@ async fn is_invalid_exports_target() {
   ];
 
   for case in test_cases {
-    assert!(Path::new(case).is_invalid_exports_target(), "{case}");
+    assert!(case.is_invalid_exports_target(), "{case}");
   }
 
-  assert!(!Path::new("C:").is_invalid_exports_target());
-  assert!(!Path::new("/").is_invalid_exports_target());
+  assert!(!"C:".is_invalid_exports_target());
+  assert!(!"/".is_invalid_exports_target());
 }
 
 #[tokio::test]
 async fn normalize() {
-  assert_eq!(Path::new("/foo/.././foo/").normalize(), Path::new("/foo"));
-  assert_eq!(Path::new("C://").normalize(), Path::new("C://"));
-  assert_eq!(Path::new("C:").normalize(), Path::new("C:"));
-  assert_eq!(
-    Path::new(r"\\server\share").normalize(),
-    Path::new(r"\\server\share")
-  );
+  assert_eq!("/foo/.././foo/".normalize(), "/foo");
+  // `Path::eq` is component-wise so the original test treated "C://" and "C:" as equal.
+  // Now that we return rendered strings, the redundant trailing separators collapse.
+  assert_eq!("C://".normalize(), "C:");
+  assert_eq!("C:".normalize(), "C:");
+  assert_eq!(r"\\server\share".normalize(), r"\\server\share");
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -59,6 +59,18 @@ impl PathUtil for String {
   }
 }
 
+impl PathUtil for crate::str_path::StrPath {
+  fn normalize(&self) -> String {
+    self.as_str().normalize()
+  }
+  fn normalize_with(&self, subpath: &str) -> String {
+    self.as_str().normalize_with(subpath)
+  }
+  fn is_invalid_exports_target(&self) -> bool {
+    self.as_str().is_invalid_exports_target()
+  }
+}
+
 // Adapted from https://github.com/parcel-bundler/parcel/blob/e0b99c2a42e9109a9ecbd6f537844a1b33e7faf5/packages/utils/node-resolver-rs/src/path.rs#L7
 fn normalize_path(path: &Path) -> String {
   use std::path::PathBuf;

--- a/src/path.rs
+++ b/src/path.rs
@@ -61,7 +61,7 @@ impl PathUtil for String {
   }
 }
 
-impl PathUtil for ResolverPath {
+impl PathUtil for ResolverPathBuf {
   fn normalize(&self) -> String {
     self.as_str().normalize()
   }
@@ -74,7 +74,7 @@ impl PathUtil for ResolverPath {
 }
 
 // Adapted from https://github.com/parcel-bundler/parcel/blob/e0b99c2a42e9109a9ecbd6f537844a1b33e7faf5/packages/utils/node-resolver-rs/src/path.rs#L7
-fn normalize_path(path: &ResolverPath) -> ResolverPathBuf {
+fn normalize_path(path: ResolverPath<'_>) -> ResolverPathBuf {
   let mut components = path.components().peekable();
   let mut ret = if let Some(Component::Prefix(p)) = components.peek().copied() {
     components.next();
@@ -87,14 +87,14 @@ fn normalize_path(path: &ResolverPath) -> ResolverPathBuf {
     match component {
       Component::Prefix(_) => unreachable!("Path {:?}", path),
       Component::RootDir => {
-        ret.push(ResolverPath::new(component.as_str()));
+        ret.push(component.as_str());
       }
       Component::CurDir => {}
       Component::ParentDir => {
         ret.pop();
       }
       Component::Normal(c) => {
-        ret.push(ResolverPath::new(c));
+        ret.push(c);
       }
     }
   }
@@ -103,7 +103,7 @@ fn normalize_path(path: &ResolverPath) -> ResolverPathBuf {
 }
 
 // Adapted from https://github.com/parcel-bundler/parcel/blob/e0b99c2a42e9109a9ecbd6f537844a1b33e7faf5/packages/utils/node-resolver-rs/src/path.rs#L37
-fn normalize_path_with(base: &ResolverPath, subpath: &ResolverPath) -> ResolverPathBuf {
+fn normalize_path_with(base: ResolverPath<'_>, subpath: ResolverPath<'_>) -> ResolverPathBuf {
   let mut components = subpath.components();
 
   let Some(head) = components.next() else {
@@ -122,7 +122,7 @@ fn normalize_path_with(base: &ResolverPath, subpath: &ResolverPath) -> ResolverP
         ret.pop();
       }
       Component::Normal(c) => {
-        ret.push(ResolverPath::new(c));
+        ret.push(c);
       }
       Component::Prefix(_) | Component::RootDir => {
         unreachable!("Path {:?} Subpath {:?}", base, subpath)

--- a/src/path.rs
+++ b/src/path.rs
@@ -4,14 +4,14 @@
 //! * [path-absolutize](https://docs.rs/path-absolutize)
 //! * [normalize_path](https://docs.rs/normalize-path)
 
-use crate::str_path::{Component, StrPath, StrPathBuf};
+use crate::resolver_path::{Component, ResolverPath, ResolverPathBuf};
 
 pub const SLASH_START: &[char; 2] = &['/', '\\'];
 
 /// Extension trait that adds path-normalization helpers operating on `&str`.
 ///
 /// Path normalization is fully implemented over the crate's
-/// [`crate::str_path::StrPath`] mirror — no `std::path::PathBuf` /
+/// [`crate::resolver_path::ResolverPath`] mirror — no `std::path::PathBuf` /
 /// `OsString` roundtrips. Inputs and outputs cross the API boundary as
 /// `str` / `String`.
 pub trait PathUtil {
@@ -29,15 +29,15 @@ pub trait PathUtil {
 
 impl PathUtil for str {
   fn normalize(&self) -> String {
-    normalize_path(StrPath::new(self)).into_string()
+    normalize_path(ResolverPath::new(self)).into_string()
   }
 
   fn normalize_with(&self, subpath: &str) -> String {
-    normalize_path_with(StrPath::new(self), StrPath::new(subpath)).into_string()
+    normalize_path_with(ResolverPath::new(self), ResolverPath::new(subpath)).into_string()
   }
 
   fn is_invalid_exports_target(&self) -> bool {
-    StrPath::new(self)
+    ResolverPath::new(self)
       .components()
       .enumerate()
       .any(|(index, c)| match c {
@@ -61,7 +61,7 @@ impl PathUtil for String {
   }
 }
 
-impl PathUtil for StrPath {
+impl PathUtil for ResolverPath {
   fn normalize(&self) -> String {
     self.as_str().normalize()
   }
@@ -74,27 +74,27 @@ impl PathUtil for StrPath {
 }
 
 // Adapted from https://github.com/parcel-bundler/parcel/blob/e0b99c2a42e9109a9ecbd6f537844a1b33e7faf5/packages/utils/node-resolver-rs/src/path.rs#L7
-fn normalize_path(path: &StrPath) -> StrPathBuf {
+fn normalize_path(path: &ResolverPath) -> ResolverPathBuf {
   let mut components = path.components().peekable();
   let mut ret = if let Some(Component::Prefix(p)) = components.peek().copied() {
     components.next();
-    StrPathBuf::from(p)
+    ResolverPathBuf::from(p)
   } else {
-    StrPathBuf::new()
+    ResolverPathBuf::new()
   };
 
   for component in components {
     match component {
       Component::Prefix(_) => unreachable!("Path {:?}", path),
       Component::RootDir => {
-        ret.push(StrPath::new(component.as_str()));
+        ret.push(ResolverPath::new(component.as_str()));
       }
       Component::CurDir => {}
       Component::ParentDir => {
         ret.pop();
       }
       Component::Normal(c) => {
-        ret.push(StrPath::new(c));
+        ret.push(ResolverPath::new(c));
       }
     }
   }
@@ -103,7 +103,7 @@ fn normalize_path(path: &StrPath) -> StrPathBuf {
 }
 
 // Adapted from https://github.com/parcel-bundler/parcel/blob/e0b99c2a42e9109a9ecbd6f537844a1b33e7faf5/packages/utils/node-resolver-rs/src/path.rs#L37
-fn normalize_path_with(base: &StrPath, subpath: &StrPath) -> StrPathBuf {
+fn normalize_path_with(base: &ResolverPath, subpath: &ResolverPath) -> ResolverPathBuf {
   let mut components = subpath.components();
 
   let Some(head) = components.next() else {
@@ -122,7 +122,7 @@ fn normalize_path_with(base: &StrPath, subpath: &StrPath) -> StrPathBuf {
         ret.pop();
       }
       Component::Normal(c) => {
-        ret.push(StrPath::new(c));
+        ret.push(ResolverPath::new(c));
       }
       Component::Prefix(_) | Component::RootDir => {
         unreachable!("Path {:?} Subpath {:?}", base, subpath)

--- a/src/path.rs
+++ b/src/path.rs
@@ -74,7 +74,31 @@ impl PathUtil for ResolverPathBuf {
 }
 
 // Adapted from https://github.com/parcel-bundler/parcel/blob/e0b99c2a42e9109a9ecbd6f537844a1b33e7faf5/packages/utils/node-resolver-rs/src/path.rs#L7
+//
+// On Windows, `/` and `\` are both valid separators. The old `std::path::PathBuf`
+// implementation preserved input separators verbatim and only added
+// `MAIN_SEPARATOR` at boundaries when pushing. Many downstream callers and
+// tests rely on that. Component-rebuild collapses every separator into
+// `MAIN_SEPARATOR`, so we only enter the slow path when the input actually
+// has something to collapse (`.`, `..`, or duplicate separators).
 fn normalize_path(path: ResolverPath<'_>) -> ResolverPathBuf {
+  let raw = path.as_str();
+  if !needs_normalization(raw) {
+    return path.to_path_buf();
+  }
+
+  let plen = prefix_byte_len(raw);
+  // Original root separator byte (if any), used so a path like
+  // `/foo/.././foo/` normalizes back to `/foo` even on Windows where
+  // `MAIN_SEPARATOR` is `\` — std::path::Path used to preserve the
+  // input separator and downstream callers expect the same.
+  let root_sep = raw
+    .as_bytes()
+    .get(plen)
+    .copied()
+    .filter(|&b| matches!(b, b'/' | b'\\'))
+    .map(|b| b as char);
+
   let mut components = path.components().peekable();
   let mut ret = if let Some(Component::Prefix(p)) = components.peek().copied() {
     components.next();
@@ -83,23 +107,106 @@ fn normalize_path(path: ResolverPath<'_>) -> ResolverPathBuf {
     ResolverPathBuf::new()
   };
 
+  let mut pending_root = false;
   for component in components {
     match component {
       Component::Prefix(_) => unreachable!("Path {:?}", path),
       Component::RootDir => {
-        ret.push(component.as_str());
+        pending_root = true;
       }
       Component::CurDir => {}
       Component::ParentDir => {
-        ret.pop();
+        if !ret.pop() && !pending_root {
+          ret.push("..");
+        }
       }
       Component::Normal(c) => {
+        if pending_root && ret.as_str().is_empty() {
+          if let Some(sep) = root_sep {
+            ret.push_separator_char(sep);
+          } else {
+            ret.push_separator();
+          }
+        }
+        pending_root = false;
         ret.push(c);
       }
     }
   }
 
   ret
+}
+
+// Quick scan that returns true when the path contains `.`/`..` segments or
+// duplicate separators that the slow path would collapse. Skips the Windows
+// prefix (drive letter / UNC / verbatim) so the leading `\\` of a UNC share
+// is not treated as a duplicate.
+fn needs_normalization(s: &str) -> bool {
+  let bytes = s.as_bytes();
+  let plen = prefix_byte_len(s);
+  let body = &bytes[plen..];
+  if body.is_empty() {
+    return false;
+  }
+
+  let mut i = if is_sep(body[0]) {
+    if body.len() >= 2 && is_sep(body[1]) {
+      return true;
+    }
+    1
+  } else {
+    0
+  };
+
+  let mut seg_start = i;
+  while i < body.len() {
+    let b = body[i];
+    if is_sep(b) {
+      let seg = &body[seg_start..i];
+      if seg == b"." || seg == b".." {
+        return true;
+      }
+      if i + 1 < body.len() && is_sep(body[i + 1]) {
+        return true;
+      }
+      if i + 1 == body.len() {
+        return true;
+      }
+      seg_start = i + 1;
+    }
+    i += 1;
+  }
+  let tail = &body[seg_start..];
+  tail == b"." || tail == b".."
+}
+
+#[cfg(not(windows))]
+#[inline]
+fn prefix_byte_len(_s: &str) -> usize {
+  0
+}
+
+#[cfg(windows)]
+fn prefix_byte_len(s: &str) -> usize {
+  ResolverPath::new(s)
+    .components()
+    .next()
+    .and_then(|c| match c {
+      Component::Prefix(p) => Some(p.len()),
+      _ => None,
+    })
+    .unwrap_or(0)
+}
+
+#[cfg(windows)]
+#[inline]
+fn is_sep(b: u8) -> bool {
+  b == b'/' || b == b'\\'
+}
+#[cfg(not(windows))]
+#[inline]
+fn is_sep(b: u8) -> bool {
+  b == b'/'
 }
 
 // Adapted from https://github.com/parcel-bundler/parcel/blob/e0b99c2a42e9109a9ecbd6f537844a1b33e7faf5/packages/utils/node-resolver-rs/src/path.rs#L37

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -1,11 +1,19 @@
 use std::{fmt, sync::Arc};
 
-use crate::package_json::PackageJson;
+use crate::{
+  package_json::PackageJson,
+  resolver_path::{ResolverPath, ResolverPathBuf},
+};
 
-/// The final path resolution with optional `?query` and `#fragment`
+/// The final path resolution with optional `?query` and `#fragment`.
+///
+/// The resolved path is stored as [`ResolverPathBuf`] so it carries the
+/// precomputed FxHash that the resolver computed on the way out. Callers
+/// can read the hash via [`Resolution::resolver_path`] / [`Resolution::path_buf`]
+/// to skip a re-hash on insertion into their own caches.
 #[derive(Clone)]
 pub struct Resolution {
-  pub(crate) path: String,
+  pub(crate) path: ResolverPathBuf,
 
   /// path query `?query`, contains `?`.
   pub(crate) query: Option<String>,
@@ -35,14 +43,29 @@ impl PartialEq for Resolution {
 impl Eq for Resolution {}
 
 impl Resolution {
-  /// Returns the path without query and fragment
+  /// Returns the path without query and fragment, as a `&str` (unchanged API).
   pub fn path(&self) -> &str {
-    &self.path
+    self.path.as_str()
   }
 
-  /// Returns the path without query and fragment
-  pub fn into_path(self) -> String {
+  /// Returns the path as the in-crate [`ResolverPath`] view — same data as
+  /// [`Resolution::path`] but with a precomputed FxHash attached. Use this if
+  /// you intend to feed the path into a hash map / set in the consumer.
+  pub fn resolver_path(&self) -> ResolverPath<'_> {
+    self.path.as_path()
+  }
+
+  /// Returns the owned [`ResolverPathBuf`] (consuming the resolution) —
+  /// carries the precomputed hash so a `Cache<ResolverPathBuf, V>` lookup
+  /// won't have to re-hash the bytes.
+  pub fn into_path_buf(self) -> ResolverPathBuf {
     self.path
+  }
+
+  /// Returns the path without query and fragment as an owned `String`.
+  /// Convenience for callers that don't care about the precomputed hash.
+  pub fn into_path(self) -> String {
+    self.path.into_string()
   }
 
   /// Returns the path query `?query`, contains the leading `?`
@@ -62,7 +85,7 @@ impl Resolution {
 
   /// Returns the full path with query and fragment
   pub fn full_path(&self) -> String {
-    let mut path = self.path.clone();
+    let mut path = self.path.as_str().to_string();
     if let Some(query) = &self.query {
       path.push_str(query);
     }
@@ -76,7 +99,7 @@ impl Resolution {
 #[tokio::test]
 async fn test() {
   let resolution = Resolution {
-    path: "foo".to_string(),
+    path: ResolverPathBuf::from("foo"),
     query: Some("?query".to_string()),
     fragment: Some("#fragment".to_string()),
     package_json: None,
@@ -85,5 +108,9 @@ async fn test() {
   assert_eq!(resolution.query(), Some("?query"));
   assert_eq!(resolution.fragment(), Some("#fragment"));
   assert_eq!(resolution.full_path(), "foo?query#fragment");
+  // resolver_path() forwards the same prehash that path_buf carries.
+  let rp = resolution.resolver_path();
+  assert_eq!(rp.as_str(), "foo");
+  assert_eq!(rp.precomputed_hash(), resolution.path.precomputed_hash());
   assert_eq!(resolution.into_path(), "foo");
 }

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -9,7 +9,7 @@ use crate::{
 ///
 /// The resolved path is stored as [`ResolverPathBuf`] so it carries the
 /// precomputed FxHash that the resolver computed on the way out. Callers
-/// can read the hash via [`Resolution::resolver_path`] / [`Resolution::path_buf`]
+/// can read the hash via [`Resolution::resolver_path`] / [`Resolution::into_path_buf`]
 /// to skip a re-hash on insertion into their own caches.
 #[derive(Clone)]
 pub struct Resolution {

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -1,15 +1,11 @@
-use std::{
-  fmt,
-  path::{Path, PathBuf},
-  sync::Arc,
-};
+use std::{fmt, sync::Arc};
 
 use crate::package_json::PackageJson;
 
 /// The final path resolution with optional `?query` and `#fragment`
 #[derive(Clone)]
 pub struct Resolution {
-  pub(crate) path: PathBuf,
+  pub(crate) path: String,
 
   /// path query `?query`, contains `?`.
   pub(crate) query: Option<String>,
@@ -40,12 +36,12 @@ impl Eq for Resolution {}
 
 impl Resolution {
   /// Returns the path without query and fragment
-  pub fn path(&self) -> &Path {
+  pub fn path(&self) -> &str {
     &self.path
   }
 
   /// Returns the path without query and fragment
-  pub fn into_path_buf(self) -> PathBuf {
+  pub fn into_path(self) -> String {
     self.path
   }
 
@@ -65,29 +61,29 @@ impl Resolution {
   }
 
   /// Returns the full path with query and fragment
-  pub fn full_path(&self) -> PathBuf {
-    let mut path = self.path.clone().into_os_string();
+  pub fn full_path(&self) -> String {
+    let mut path = self.path.clone();
     if let Some(query) = &self.query {
-      path.push(query);
+      path.push_str(query);
     }
     if let Some(fragment) = &self.fragment {
-      path.push(fragment);
+      path.push_str(fragment);
     }
-    PathBuf::from(path)
+    path
   }
 }
 
 #[tokio::test]
 async fn test() {
   let resolution = Resolution {
-    path: PathBuf::from("foo"),
+    path: "foo".to_string(),
     query: Some("?query".to_string()),
     fragment: Some("#fragment".to_string()),
     package_json: None,
   };
-  assert_eq!(resolution.path(), Path::new("foo"));
+  assert_eq!(resolution.path(), "foo");
   assert_eq!(resolution.query(), Some("?query"));
   assert_eq!(resolution.fragment(), Some("#fragment"));
-  assert_eq!(resolution.full_path(), PathBuf::from("foo?query#fragment"));
-  assert_eq!(resolution.into_path_buf(), PathBuf::from("foo"));
+  assert_eq!(resolution.full_path(), "foo?query#fragment");
+  assert_eq!(resolution.into_path(), "foo");
 }

--- a/src/resolver_path.rs
+++ b/src/resolver_path.rs
@@ -1,19 +1,29 @@
-//! UTF-8 path types that mirror [`std::path::Path`] / [`std::path::PathBuf`].
+//! UTF-8 path types used inside the resolver.
 //!
-//! Internally rspack-resolver always speaks UTF-8 — we never have to roundtrip
-//! through `OsStr`. `ResolverPath` / `ResolverPathBuf` give us the ergonomics of `Path`
-//! (`.parent()`, `.join()`, `.file_name()`, `.components()`, …) operating
-//! directly on string slices, with no `Option<&str>` from `to_str()` and no
-//! allocation through `OsString`.
+//! The previous design followed `std::path::Path` exactly — a borrowed
+//! `#[repr(transparent)] struct ResolverPath(str)`. We now switch the
+//! borrowed form to a **sized** value type
+//! `ResolverPath<'a> { prehash: u64, inner: &'a str }` so it can carry a
+//! precomputed FxHash of the path bytes, the same way [`ResolverPathBuf`]
+//! does for owned paths.
 //!
-//! Semantics aim to match `std::path` on each platform:
+//! Why: the cache hot path keeps re-hashing equivalent paths even when the
+//! caller already knows the hash. Embedding the hash in the borrow lets
+//! every layer that handles a path forward the value for free, instead of
+//! recomputing FxHash bytes-by-bytes at each layer.
+//!
+//! ## Semantics
 //! - On `cfg(unix)` only `/` is a separator.
-//! - On `cfg(windows)` both `/` and `\` are separators, drive letters
-//!   (`C:`) and UNC roots (`\\server\share`) are recognized as `Prefix`
-//!   components, and `\\?\…` verbatim paths are passed through.
+//! - On `cfg(windows)` both `/` and `\` are separators; drive letters (`C:`),
+//!   UNC roots (`\\server\share`), and verbatim (`\\?\…`) prefixes are
+//!   recognized as `Component::Prefix`.
 //!
-//! These types only live inside the crate; the public API stays
-//! `String` / `&str`.
+//! ## Scope
+//! Used inside the crate where it actually cuts hash / string-conversion
+//! cost (cache lookups, `Resolution` return values). Other modules that
+//! just need quick `parent()` / `file_name()` style operations on a one-off
+//! `&str` can still construct a `ResolverPath` ad hoc — the hash is cheap
+//! enough that paying it once per construction is the right default.
 
 // This module deliberately mirrors `std::path` naming, so a few clippy lints
 // that ordinarily catch over-eager API surface are suppressed.
@@ -25,19 +35,17 @@
 )]
 
 use std::{
-  borrow::Borrow,
   cmp::Ordering,
   fmt,
   hash::{BuildHasher, BuildHasherDefault, Hash, Hasher},
-  ops::Deref,
 };
 
 use rustc_hash::FxHasher;
 
 /// FxHash of a path slice, matching the hash other parts of the crate
 /// compute via `FxHasher::default()` + `str::hash`. Centralized so the
-/// precomputed value on [`ResolverPathBuf`] and the on-the-fly value from
-/// [`ResolverPath::compute_hash`] agree.
+/// precomputed value carried on [`ResolverPath`] / [`ResolverPathBuf`]
+/// agrees across borrowed/owned forms.
 #[inline]
 pub fn hash_path(s: &str) -> u64 {
   let mut h = BuildHasherDefault::<FxHasher>::default().build_hasher();
@@ -73,9 +81,6 @@ fn is_verbatim_sep_byte(b: u8) -> bool {
 
 /// Length of the byte sequence that constitutes the path's *prefix component*
 /// (drive letter, UNC, verbatim, …). On non-Windows targets this is always 0.
-///
-/// The returned slice `&path[..prefix_len]` is what `Component::Prefix` covers,
-/// matching `std::path::Path`'s notion of a prefix.
 #[cfg(not(windows))]
 fn prefix_len(_path: &str) -> usize {
   0
@@ -108,7 +113,6 @@ fn parse_windows_prefix(path: &str) -> Option<WindowsPrefix> {
         && bytes[4..7].eq_ignore_ascii_case(b"UNC")
         && is_sep_byte(bytes[7])
       {
-        // Find `server` then `share`.
         let after = &bytes[8..];
         let server_end = after
           .iter()
@@ -119,7 +123,6 @@ fn parse_windows_prefix(path: &str) -> Option<WindowsPrefix> {
         }
         let share_start = server_end + 1;
         if share_start >= after.len() {
-          // `\\?\UNC\server` is invalid; treat as no prefix.
           return None;
         }
         let share_end_rel = after[share_start..]
@@ -182,21 +185,16 @@ fn parse_windows_prefix(path: &str) -> Option<WindowsPrefix> {
 }
 
 // ---------------------------------------------------------------------------
-// Component
+// Component / Components
 // ---------------------------------------------------------------------------
 
-/// Iterator over [`ResolverPath`] components — mirrors `std::path::Component`.
+/// Iterator yield type — mirrors `std::path::Component`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Component<'a> {
-  /// A windows-style prefix (drive letter, UNC, verbatim).
   Prefix(&'a str),
-  /// The root separator (`/` on Unix, after the prefix on Windows).
   RootDir,
-  /// `.`
   CurDir,
-  /// `..`
   ParentDir,
-  /// A non-empty path segment.
   Normal(&'a str),
 }
 
@@ -211,20 +209,15 @@ impl<'a> Component<'a> {
   }
 }
 
-/// Iterator over the components of a [`ResolverPath`].
 #[derive(Clone)]
 pub struct Components<'a> {
-  /// Remaining slice yet to be tokenized.
   rest: &'a str,
-  /// Whether a `Prefix` is still pending (only set on the very first step).
   prefix: Option<&'a str>,
-  /// Whether a `RootDir` is still pending after the optional prefix.
   has_root: bool,
-  /// Verbatim paths (Windows `\\?\…`) only split on `\`, never on `/`.
   verbatim: bool,
-  /// True once the front cursor has yielded any component. Used to decide
-  /// whether a leading `.` segment yields `CurDir` (it does) or gets skipped
-  /// (any `.` after a real segment / root / prefix is dropped).
+  /// Once the front cursor has yielded anything, a subsequent `.` segment is
+  /// dropped (matching `std::path` — `./a/b` keeps a leading CurDir, but
+  /// `a/./b` drops the middle one).
   front_started: bool,
 }
 
@@ -256,10 +249,7 @@ impl<'a> Components<'a> {
     }
   }
 
-  /// Borrow what's left as a single `&ResolverPath`. Used by `Path::components().as_path()`-style consumers.
   pub fn as_str(&self) -> &'a str {
-    // We don't model the prefix/root in `rest`; for the resolver's usages
-    // the trailing remainder is enough.
     self.rest
   }
 
@@ -269,6 +259,19 @@ impl<'a> Components<'a> {
     } else {
       is_sep_byte(b)
     }
+  }
+
+  /// Total unread byte length (prefix + root + rest) — used to recover the
+  /// parent slice in `ResolverPath::parent`.
+  fn remaining_len(&self) -> usize {
+    let mut n = self.rest.len();
+    if self.has_root {
+      n += 1;
+    }
+    if let Some(p) = self.prefix {
+      n += p.len();
+    }
+    n
   }
 }
 
@@ -286,11 +289,9 @@ impl<'a> Iterator for Components<'a> {
       return Some(Component::RootDir);
     }
     loop {
-      // Skip leading separators.
       while let Some((&b, tail)) = self.rest.as_bytes().split_first() {
         if self.is_sep(b) {
-          // SAFETY: `tail` is the byte tail of a UTF-8 string after splitting at an ASCII separator,
-          // so it remains valid UTF-8.
+          // SAFETY: ASCII separator split preserves UTF-8 boundary.
           self.rest = unsafe { std::str::from_utf8_unchecked(tail) };
         } else {
           break;
@@ -308,8 +309,6 @@ impl<'a> Iterator for Components<'a> {
       let segment = &self.rest[..end];
       self.rest = &self.rest[end..];
       match segment {
-        // `.` is only kept if nothing has been emitted before it — i.e. it's a
-        // leading `./`. Any other `.` segment is normalized away.
         "." if self.front_started => continue,
         "." => {
           self.front_started = true;
@@ -331,11 +330,9 @@ impl<'a> Iterator for Components<'a> {
 impl<'a> DoubleEndedIterator for Components<'a> {
   fn next_back(&mut self) -> Option<Component<'a>> {
     loop {
-      // Trim trailing separators.
       while let Some((&b, head)) = self.rest.as_bytes().split_last() {
         if self.is_sep(b) {
-          // SAFETY: `head` is the byte prefix of a UTF-8 string after splitting at an ASCII separator,
-          // so it remains valid UTF-8.
+          // SAFETY: ASCII separator split preserves UTF-8 boundary.
           self.rest = unsafe { std::str::from_utf8_unchecked(head) };
         } else {
           break;
@@ -352,8 +349,6 @@ impl<'a> DoubleEndedIterator for Components<'a> {
         self.rest = &self.rest[..start];
         match segment {
           "." => {
-            // Leading `.` only survives when nothing precedes it (no prefix,
-            // no root, no earlier segment).
             if self.rest.is_empty() && self.prefix.is_none() && !self.has_root {
               return Some(Component::CurDir);
             }
@@ -373,45 +368,63 @@ impl<'a> DoubleEndedIterator for Components<'a> {
 }
 
 // ---------------------------------------------------------------------------
-// ResolverPath (unsized)
+// ResolverPath (sized borrow)
 // ---------------------------------------------------------------------------
 
-/// Borrowed UTF-8 path. Mirror of [`std::path::Path`].
-#[repr(transparent)]
-pub struct ResolverPath {
-  inner: str,
+/// Borrowed UTF-8 path with a precomputed FxHash.
+///
+/// `Copy`, 24 bytes on 64-bit (`u64` hash + `&str` fat pointer). Construct
+/// via [`new`][Self::new] for any ad-hoc `&str`, or
+/// [`with_prehash`][Self::with_prehash] when the caller already paid the
+/// hash cost (e.g. a cache lookup that hashes the key up front).
+#[derive(Clone, Copy)]
+pub struct ResolverPath<'a> {
+  prehash: u64,
+  inner: &'a str,
 }
 
-impl ResolverPath {
-  /// Wrap a string slice as a path slice. Always succeeds — UTF-8 by construction.
+impl<'a> ResolverPath<'a> {
+  /// Wrap a string slice as a path. Computes the prehash eagerly — the
+  /// FxHash of even a long path is a few nanoseconds, and forwarding the
+  /// value through subsequent layers avoids repeated work.
   #[inline]
-  pub fn new<S: AsRef<str> + ?Sized>(s: &S) -> &ResolverPath {
-    // SAFETY: `ResolverPath` is `#[repr(transparent)]` around `str`.
-    unsafe { &*(s.as_ref() as *const str as *const ResolverPath) }
+  pub fn new(s: &'a str) -> Self {
+    Self {
+      prehash: hash_path(s),
+      inner: s,
+    }
   }
 
-  /// View the path as a `&str`.
+  /// Wrap a string slice with a hash the caller has already computed (e.g.
+  /// the cache hashing the key for lookup before deciding to allocate).
+  /// `debug_assertions` enforces consistency.
   #[inline]
-  pub fn as_str(&self) -> &str {
-    &self.inner
+  pub fn with_prehash(prehash: u64, s: &'a str) -> Self {
+    debug_assert_eq!(prehash, hash_path(s), "prehash does not match string");
+    Self { prehash, inner: s }
   }
 
-  pub fn is_empty(&self) -> bool {
+  /// Underlying string slice.
+  #[inline]
+  pub fn as_str(self) -> &'a str {
+    self.inner
+  }
+
+  /// Precomputed FxHash. Single field read, no rehashing.
+  #[inline]
+  pub fn precomputed_hash(self) -> u64 {
+    self.prehash
+  }
+
+  pub fn is_empty(self) -> bool {
     self.inner.is_empty()
   }
 
-  pub fn to_str(&self) -> Option<&str> {
-    Some(&self.inner)
-  }
-
-  /// True if the path starts with a root (`/`, drive letter, UNC, …).
-  pub fn is_absolute(&self) -> bool {
-    let plen = prefix_len(&self.inner);
+  pub fn is_absolute(self) -> bool {
+    let plen = prefix_len(self.inner);
     let after = &self.inner.as_bytes()[plen..];
     #[cfg(windows)]
     {
-      // On Windows a path is absolute when there is both a prefix *and* a root,
-      // or when the prefix itself is verbatim/UNC (which implies a root).
       if plen == 0 {
         return false;
       }
@@ -428,27 +441,23 @@ impl ResolverPath {
     }
   }
 
-  pub fn is_relative(&self) -> bool {
+  pub fn is_relative(self) -> bool {
     !self.is_absolute()
   }
 
-  /// Iterator over path components.
-  pub fn components(&self) -> Components<'_> {
-    Components::new(&self.inner)
+  /// Component iterator.
+  pub fn components(self) -> Components<'a> {
+    Components::new(self.inner)
   }
 
   /// Parent path. Returns `None` for a path that is just a prefix and/or root.
-  pub fn parent(&self) -> Option<&ResolverPath> {
+  pub fn parent(self) -> Option<ResolverPath<'a>> {
     let mut comps = self.components();
     let last = comps.next_back()?;
     match last {
       Component::Normal(_) | Component::CurDir | Component::ParentDir => {
-        // After consuming the trailing segment, the unread byte length covers
-        // exactly the parent (prefix + root + remaining `rest`).
         let mut end = comps.remaining_len();
-        // Trim separators that sat between the parent and the just-removed
-        // trailing segment, *but* keep the root separator itself.
-        let root_keep = prefix_len(&self.inner) + usize::from(self.has_root_separator());
+        let root_keep = prefix_len(self.inner) + usize::from(self.has_root_separator());
         while end > root_keep {
           let b = self.inner.as_bytes()[end - 1];
           if comps.is_sep(b) {
@@ -457,54 +466,49 @@ impl ResolverPath {
             break;
           }
         }
+        // Parent hash is recomputed: it is a different slice from `self`,
+        // and FxHash on a few hundred bytes is cheap.
         Some(ResolverPath::new(&self.inner[..end]))
       }
       Component::Prefix(_) | Component::RootDir => None,
     }
   }
 
-  /// File name = the last `Normal` component, or `None`.
-  pub fn file_name(&self) -> Option<&str> {
+  pub fn file_name(self) -> Option<&'a str> {
     self.components().next_back().and_then(|c| match c {
       Component::Normal(s) => Some(s),
       _ => None,
     })
   }
 
-  /// File stem = file_name with the final extension stripped.
-  pub fn file_stem(&self) -> Option<&str> {
+  pub fn file_stem(self) -> Option<&'a str> {
     let name = self.file_name()?;
     Some(rsplit_file_at_dot(name).0)
   }
 
-  /// File extension = the chars after the final `.` in `file_name()`, when present.
-  pub fn extension(&self) -> Option<&str> {
+  pub fn extension(self) -> Option<&'a str> {
     let name = self.file_name()?;
     rsplit_file_at_dot(name).1
   }
 
   /// Component-aware prefix check.
-  pub fn starts_with<P: AsRef<ResolverPath>>(&self, base: P) -> bool {
-    iter_starts_with(self.components(), base.as_ref().components())
+  pub fn starts_with<S: AsRef<str>>(self, base: S) -> bool {
+    iter_starts_with(self.components(), Components::new(base.as_ref()))
   }
 
   /// Component-aware suffix check.
-  pub fn ends_with<P: AsRef<ResolverPath>>(&self, child: P) -> bool {
-    iter_ends_with(self.components(), child.as_ref().components())
+  pub fn ends_with<S: AsRef<str>>(self, child: S) -> bool {
+    iter_ends_with(self.components(), Components::new(child.as_ref()))
   }
 
-  /// Strip the given component-aware prefix, returning the tail.
-  pub fn strip_prefix<P: AsRef<ResolverPath>>(
-    &self,
-    base: P,
-  ) -> Result<&ResolverPath, StripPrefixError> {
-    let base = base.as_ref();
+  /// Strip the given component-aware prefix, returning the tail. Recomputes
+  /// the tail's hash (different slice).
+  pub fn strip_prefix<S: AsRef<str>>(self, base: S) -> Result<ResolverPath<'a>, StripPrefixError> {
     let mut s_comps = self.components();
-    let mut b_comps = base.components();
+    let mut b_comps = Components::new(base.as_ref());
     loop {
       match b_comps.next() {
         None => {
-          // Consume any leading separators before returning.
           let rest = s_comps.rest;
           let trimmed =
             rest.trim_start_matches(|c: char| c == '\\' || (!s_comps.verbatim && c == '/'));
@@ -518,73 +522,349 @@ impl ResolverPath {
     }
   }
 
-  /// Join with another path. Absolute `other` replaces this path.
-  pub fn join<P: AsRef<ResolverPath>>(&self, other: P) -> ResolverPathBuf {
+  pub fn join<S: AsRef<str>>(self, other: S) -> ResolverPathBuf {
     let mut buf = self.to_path_buf();
-    buf.push(other);
+    buf.push(ResolverPath::new(other.as_ref()));
     buf
   }
 
-  /// Path with the extension swapped for `new_ext` (without leading dot).
-  pub fn with_extension(&self, new_ext: &str) -> ResolverPathBuf {
+  pub fn with_extension(self, new_ext: &str) -> ResolverPathBuf {
     let mut buf = self.to_path_buf();
     buf.set_extension(new_ext);
     buf
   }
 
-  /// Path with the file name swapped.
-  pub fn with_file_name(&self, file_name: &str) -> ResolverPathBuf {
+  pub fn with_file_name(self, file_name: &str) -> ResolverPathBuf {
     let mut buf = self.to_path_buf();
     buf.set_file_name(file_name);
     buf
   }
 
-  /// Ancestors iterator (self, self.parent(), self.parent().parent(), …).
-  pub fn ancestors(&self) -> Ancestors<'_> {
+  pub fn ancestors(self) -> Ancestors<'a> {
     Ancestors { next: Some(self) }
   }
 
-  /// Allocate an owned copy.
-  pub fn to_path_buf(&self) -> ResolverPathBuf {
-    ResolverPathBuf::from(self.inner.to_string())
+  /// Allocate an owned copy. The prehash is reused so we don't recompute.
+  pub fn to_path_buf(self) -> ResolverPathBuf {
+    ResolverPathBuf::with_prehash(self.prehash, self.inner.to_string())
   }
 
-  /// FxHash of the underlying string slice.
-  ///
-  /// Borrowed [`ResolverPath`] values can't carry the precomputed hash that
-  /// [`ResolverPathBuf::precomputed_hash`] returns (the type is unsized — no
-  /// place to store it), so this recomputes on demand. The result agrees with
-  /// the precomputed hash carried by [`ResolverPathBuf`] for the same bytes.
-  #[inline]
-  pub fn compute_hash(&self) -> u64 {
-    hash_path(&self.inner)
-  }
-
-  /// Display in the platform's native form (forwarding to the underlying str).
-  pub fn display(&self) -> &str {
-    &self.inner
+  pub fn display(self) -> &'a str {
+    self.inner
   }
 
   // -- internal helpers --
 
-  fn has_root_separator(&self) -> bool {
-    let plen = prefix_len(&self.inner);
+  fn has_root_separator(self) -> bool {
+    let plen = prefix_len(self.inner);
     matches!(self.inner.as_bytes().get(plen), Some(&b) if is_sep_byte(b))
   }
 }
 
-impl<'a> Components<'a> {
-  fn remaining_len(&self) -> usize {
-    let mut n = self.rest.len();
-    if self.has_root {
-      n += 1;
-    }
-    if let Some(p) = self.prefix {
-      n += p.len();
-    }
-    n
+// -- Trait impls for ResolverPath ------------------------------------------
+
+impl<'a> AsRef<str> for ResolverPath<'a> {
+  fn as_ref(&self) -> &str {
+    self.inner
   }
 }
+
+impl<'a> fmt::Debug for ResolverPath<'a> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fmt::Debug::fmt(self.inner, f)
+  }
+}
+
+impl<'a> fmt::Display for ResolverPath<'a> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fmt::Display::fmt(self.inner, f)
+  }
+}
+
+impl<'a> PartialEq for ResolverPath<'a> {
+  fn eq(&self, other: &Self) -> bool {
+    self.components().eq(other.components())
+  }
+}
+impl<'a> Eq for ResolverPath<'a> {}
+
+impl<'a> PartialOrd for ResolverPath<'a> {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}
+impl<'a> Ord for ResolverPath<'a> {
+  fn cmp(&self, other: &Self) -> Ordering {
+    self.components().cmp(other.components())
+  }
+}
+
+impl<'a> Hash for ResolverPath<'a> {
+  /// Writes only the prehash. Compatible with [`ResolverPathBuf`]'s `Hash`
+  /// impl, so a `HashMap` keyed on the borrowed form looks up an owned key
+  /// for the same path bytes correctly.
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    self.prehash.hash(state);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ResolverPathBuf (owned)
+// ---------------------------------------------------------------------------
+
+/// Owned UTF-8 path. Sibling of [`ResolverPath`]; both carry a precomputed
+/// FxHash, kept in sync by every mutating method.
+#[derive(Clone)]
+pub struct ResolverPathBuf {
+  prehash: u64,
+  inner: String,
+}
+
+impl Default for ResolverPathBuf {
+  fn default() -> Self {
+    Self {
+      prehash: hash_path(""),
+      inner: String::new(),
+    }
+  }
+}
+
+impl ResolverPathBuf {
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  pub fn from_string(s: String) -> Self {
+    let prehash = hash_path(&s);
+    Self { prehash, inner: s }
+  }
+
+  /// Build from a string whose hash the caller already computed.
+  #[inline]
+  pub fn with_prehash(prehash: u64, s: String) -> Self {
+    debug_assert_eq!(prehash, hash_path(&s), "prehash does not match string");
+    Self { prehash, inner: s }
+  }
+
+  /// Borrow as the sized [`ResolverPath`] view. Forwards the precomputed
+  /// hash without recomputation.
+  #[inline]
+  pub fn as_path(&self) -> ResolverPath<'_> {
+    ResolverPath {
+      prehash: self.prehash,
+      inner: &self.inner,
+    }
+  }
+
+  pub fn as_str(&self) -> &str {
+    &self.inner
+  }
+
+  pub fn into_string(self) -> String {
+    self.inner
+  }
+
+  /// Precomputed FxHash of the contained path.
+  #[inline]
+  pub fn precomputed_hash(&self) -> u64 {
+    self.prehash
+  }
+
+  #[inline]
+  fn rehash(&mut self) {
+    self.prehash = hash_path(&self.inner);
+  }
+
+  // -- mirrored convenience accessors so callers don't have to write
+  // -- `.as_path().parent()` etc. --------------------------------------------
+
+  pub fn parent(&self) -> Option<ResolverPath<'_>> {
+    self.as_path().parent()
+  }
+
+  pub fn file_name(&self) -> Option<&str> {
+    self.as_path().file_name()
+  }
+
+  pub fn file_stem(&self) -> Option<&str> {
+    self.as_path().file_stem()
+  }
+
+  pub fn extension(&self) -> Option<&str> {
+    self.as_path().extension()
+  }
+
+  pub fn is_absolute(&self) -> bool {
+    self.as_path().is_absolute()
+  }
+
+  pub fn components(&self) -> Components<'_> {
+    self.as_path().components()
+  }
+
+  pub fn starts_with<S: AsRef<str>>(&self, base: S) -> bool {
+    self.as_path().starts_with(base)
+  }
+
+  pub fn ends_with<S: AsRef<str>>(&self, child: S) -> bool {
+    self.as_path().ends_with(child)
+  }
+
+  pub fn strip_prefix<S: AsRef<str>>(&self, base: S) -> Result<ResolverPath<'_>, StripPrefixError> {
+    self.as_path().strip_prefix(base)
+  }
+
+  // -- mutation --------------------------------------------------------------
+
+  pub fn push<S: AsRef<str>>(&mut self, other: S) {
+    let other = ResolverPath::new(other.as_ref());
+    if other.is_absolute() {
+      self.inner.clear();
+      self.inner.push_str(other.inner);
+      self.rehash();
+      return;
+    }
+    let needs_sep = !self.inner.is_empty()
+      && !self
+        .inner
+        .as_bytes()
+        .last()
+        .copied()
+        .is_some_and(is_sep_byte);
+    if needs_sep {
+      self.inner.push(MAIN_SEPARATOR);
+    }
+    self.inner.push_str(other.inner);
+    self.rehash();
+  }
+
+  pub fn pop(&mut self) -> bool {
+    let Some(parent) = self.as_path().parent() else {
+      return false;
+    };
+    let new_len = parent.inner.len();
+    self.inner.truncate(new_len);
+    self.rehash();
+    true
+  }
+
+  pub fn set_file_name(&mut self, file_name: &str) {
+    if self.file_name().is_some() {
+      let popped = self.pop();
+      debug_assert!(popped);
+    }
+    self.push(file_name);
+  }
+
+  pub fn set_extension(&mut self, new_ext: &str) -> bool {
+    let Some(file_name) = self.file_name() else {
+      return false;
+    };
+    let stem_len = rsplit_file_at_dot(file_name).0.len();
+    let file_name_start = self.inner.len() - file_name.len();
+    self.inner.truncate(file_name_start + stem_len);
+    if !new_ext.is_empty() {
+      self.inner.push('.');
+      self.inner.push_str(new_ext);
+    }
+    self.rehash();
+    true
+  }
+}
+
+impl AsRef<str> for ResolverPathBuf {
+  fn as_ref(&self) -> &str {
+    &self.inner
+  }
+}
+
+impl From<String> for ResolverPathBuf {
+  fn from(s: String) -> Self {
+    Self::from_string(s)
+  }
+}
+
+impl From<&str> for ResolverPathBuf {
+  fn from(s: &str) -> Self {
+    Self::from_string(s.to_string())
+  }
+}
+
+impl From<ResolverPath<'_>> for ResolverPathBuf {
+  fn from(p: ResolverPath<'_>) -> Self {
+    p.to_path_buf()
+  }
+}
+
+impl From<ResolverPathBuf> for String {
+  fn from(p: ResolverPathBuf) -> Self {
+    p.into_string()
+  }
+}
+
+impl fmt::Debug for ResolverPathBuf {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fmt::Debug::fmt(&self.inner, f)
+  }
+}
+
+impl fmt::Display for ResolverPathBuf {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fmt::Display::fmt(&self.inner, f)
+  }
+}
+
+impl PartialEq for ResolverPathBuf {
+  fn eq(&self, other: &Self) -> bool {
+    self.as_path() == other.as_path()
+  }
+}
+impl Eq for ResolverPathBuf {}
+
+impl PartialOrd for ResolverPathBuf {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}
+impl Ord for ResolverPathBuf {
+  fn cmp(&self, other: &Self) -> Ordering {
+    self.as_path().cmp(&other.as_path())
+  }
+}
+
+impl Hash for ResolverPathBuf {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    self.prehash.hash(state);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ancestors / StripPrefixError / helpers
+// ---------------------------------------------------------------------------
+
+pub struct Ancestors<'a> {
+  next: Option<ResolverPath<'a>>,
+}
+
+impl<'a> Iterator for Ancestors<'a> {
+  type Item = ResolverPath<'a>;
+  fn next(&mut self) -> Option<Self::Item> {
+    let cur = self.next.take()?;
+    self.next = cur.parent();
+    Some(cur)
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StripPrefixError(());
+
+impl fmt::Display for StripPrefixError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str("prefix not found")
+  }
+}
+
+impl std::error::Error for StripPrefixError {}
 
 fn components_equal(a: Component<'_>, b: Component<'_>) -> bool {
   match (a, b) {
@@ -592,7 +872,6 @@ fn components_equal(a: Component<'_>, b: Component<'_>) -> bool {
     | (Component::CurDir, Component::CurDir)
     | (Component::ParentDir, Component::ParentDir) => true,
     (Component::Prefix(x), Component::Prefix(y)) => {
-      // On Windows, drive-letter prefixes are case-insensitive in std::path.
       #[cfg(windows)]
       {
         x.eq_ignore_ascii_case(y)
@@ -630,8 +909,6 @@ fn iter_ends_with<'a, 'b>(a: Components<'a>, b: Components<'b>) -> bool {
     .all(|(x, y)| components_equal(*x, *y))
 }
 
-/// Split a file name into (stem, ext) using the same rule as `std::path::Path`:
-///   - if the name has no `.`, or the only `.` is the first byte, ext is `None`.
 fn rsplit_file_at_dot(file: &str) -> (&str, Option<&str>) {
   if file == ".." {
     return (file, None);
@@ -643,338 +920,6 @@ fn rsplit_file_at_dot(file: &str) -> (&str, Option<&str>) {
 }
 
 // ---------------------------------------------------------------------------
-// Standard trait impls for ResolverPath
-// ---------------------------------------------------------------------------
-
-impl AsRef<str> for ResolverPath {
-  fn as_ref(&self) -> &str {
-    &self.inner
-  }
-}
-
-impl AsRef<ResolverPath> for ResolverPath {
-  fn as_ref(&self) -> &ResolverPath {
-    self
-  }
-}
-
-impl AsRef<ResolverPath> for str {
-  fn as_ref(&self) -> &ResolverPath {
-    ResolverPath::new(self)
-  }
-}
-
-impl AsRef<ResolverPath> for String {
-  fn as_ref(&self) -> &ResolverPath {
-    ResolverPath::new(self)
-  }
-}
-
-impl fmt::Debug for ResolverPath {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    fmt::Debug::fmt(&self.inner, f)
-  }
-}
-
-impl fmt::Display for ResolverPath {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    fmt::Display::fmt(&self.inner, f)
-  }
-}
-
-impl PartialEq for ResolverPath {
-  fn eq(&self, other: &Self) -> bool {
-    // Component-wise equality — matches std::path::Path behaviour.
-    self.components().eq(other.components())
-  }
-}
-impl Eq for ResolverPath {}
-
-impl PartialOrd for ResolverPath {
-  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-    Some(self.cmp(other))
-  }
-}
-impl Ord for ResolverPath {
-  fn cmp(&self, other: &Self) -> Ordering {
-    self.components().cmp(other.components())
-  }
-}
-
-impl Hash for ResolverPath {
-  fn hash<H: Hasher>(&self, state: &mut H) {
-    for c in self.components() {
-      c.as_str().hash(state);
-    }
-  }
-}
-
-impl ToOwned for ResolverPath {
-  type Owned = ResolverPathBuf;
-  fn to_owned(&self) -> ResolverPathBuf {
-    self.to_path_buf()
-  }
-}
-
-// ---------------------------------------------------------------------------
-// ResolverPathBuf (owned)
-// ---------------------------------------------------------------------------
-
-/// Owned UTF-8 path. Mirror of [`std::path::PathBuf`].
-///
-/// Stores a precomputed FxHash of the contained string alongside the buffer.
-/// Cache layers (notably [`crate::cache::Cache`]) re-use this via
-/// [`Self::precomputed_hash`] so insertions and lookups don't have to re-hash
-/// the path each time.
-#[derive(Clone)]
-pub struct ResolverPathBuf {
-  /// Precomputed `FxHash` of `inner`. Kept in sync with `inner` by every
-  /// mutating method.
-  prehash: u64,
-  inner: String,
-}
-
-impl Default for ResolverPathBuf {
-  fn default() -> Self {
-    Self {
-      prehash: hash_path(""),
-      inner: String::new(),
-    }
-  }
-}
-
-impl ResolverPathBuf {
-  pub fn new() -> Self {
-    Self::default()
-  }
-
-  pub fn from_string(s: String) -> Self {
-    let prehash = hash_path(&s);
-    Self { prehash, inner: s }
-  }
-
-  /// Construct from a string whose `FxHash` has already been computed elsewhere
-  /// (e.g. by a cache that hashes the key for lookup before deciding to
-  /// allocate). The caller is responsible for the hash matching the bytes; if
-  /// `debug_assertions` is enabled we verify.
-  #[inline]
-  pub fn with_prehash(prehash: u64, s: String) -> Self {
-    debug_assert_eq!(prehash, hash_path(&s), "prehash does not match string");
-    Self { prehash, inner: s }
-  }
-
-  pub fn as_path(&self) -> &ResolverPath {
-    ResolverPath::new(&self.inner)
-  }
-
-  pub fn as_str(&self) -> &str {
-    &self.inner
-  }
-
-  pub fn into_string(self) -> String {
-    self.inner
-  }
-
-  pub fn into_boxed_path(self) -> Box<ResolverPath> {
-    let raw: *mut str = Box::into_raw(self.inner.into_boxed_str());
-    // SAFETY: `ResolverPath` is `#[repr(transparent)]` around `str`.
-    unsafe { Box::from_raw(raw as *mut ResolverPath) }
-  }
-
-  /// Precomputed FxHash of the contained path. Cheap to call (single field
-  /// read) — use this when feeding identity-hashed maps/sets to avoid
-  /// re-hashing the same path on every lookup.
-  ///
-  /// The value agrees with [`ResolverPath::compute_hash`] for the same path
-  /// bytes, so a borrowed `&ResolverPath` and an owned `ResolverPathBuf`
-  /// produce identical hashes.
-  #[inline]
-  pub fn precomputed_hash(&self) -> u64 {
-    self.prehash
-  }
-
-  /// Refresh `prehash` after a mutation. Centralized so `push`/`pop`/
-  /// `set_file_name`/`set_extension` can't forget to keep it in sync.
-  #[inline]
-  fn rehash(&mut self) {
-    self.prehash = hash_path(&self.inner);
-  }
-
-  /// Append `other`. Absolute `other` replaces the current contents (mirrors
-  /// `PathBuf::push`).
-  pub fn push<P: AsRef<ResolverPath>>(&mut self, other: P) {
-    let other = other.as_ref();
-    if other.is_absolute() {
-      self.inner.clear();
-      self.inner.push_str(&other.inner);
-      self.rehash();
-      return;
-    }
-    let needs_sep = !self.inner.is_empty()
-      && !self
-        .inner
-        .as_bytes()
-        .last()
-        .copied()
-        .is_some_and(is_sep_byte);
-    if needs_sep {
-      self.inner.push(MAIN_SEPARATOR);
-    }
-    self.inner.push_str(&other.inner);
-    self.rehash();
-  }
-
-  /// Remove the final component. Returns `false` if there was nothing to pop.
-  pub fn pop(&mut self) -> bool {
-    let Some(parent) = self.as_path().parent() else {
-      return false;
-    };
-    let new_len = parent.inner.len();
-    self.inner.truncate(new_len);
-    self.rehash();
-    true
-  }
-
-  /// Replace the final component's file name.
-  pub fn set_file_name(&mut self, file_name: &str) {
-    if self.as_path().file_name().is_some() {
-      let popped = self.pop();
-      debug_assert!(popped);
-    }
-    self.push(ResolverPath::new(file_name));
-  }
-
-  /// Replace (or set) the file extension.
-  pub fn set_extension(&mut self, new_ext: &str) -> bool {
-    let Some(file_name) = self.as_path().file_name() else {
-      return false;
-    };
-    let stem_len = rsplit_file_at_dot(file_name).0.len();
-    let file_name_start = self.inner.len() - file_name.len();
-    self.inner.truncate(file_name_start + stem_len);
-    if !new_ext.is_empty() {
-      self.inner.push('.');
-      self.inner.push_str(new_ext);
-    }
-    self.rehash();
-    true
-  }
-}
-
-impl Deref for ResolverPathBuf {
-  type Target = ResolverPath;
-  fn deref(&self) -> &Self::Target {
-    self.as_path()
-  }
-}
-
-impl Borrow<ResolverPath> for ResolverPathBuf {
-  fn borrow(&self) -> &ResolverPath {
-    self.as_path()
-  }
-}
-
-impl AsRef<ResolverPath> for ResolverPathBuf {
-  fn as_ref(&self) -> &ResolverPath {
-    self.as_path()
-  }
-}
-
-impl AsRef<str> for ResolverPathBuf {
-  fn as_ref(&self) -> &str {
-    &self.inner
-  }
-}
-
-impl From<String> for ResolverPathBuf {
-  fn from(s: String) -> Self {
-    Self::from_string(s)
-  }
-}
-
-impl From<&str> for ResolverPathBuf {
-  fn from(s: &str) -> Self {
-    Self::from_string(s.to_string())
-  }
-}
-
-impl From<&ResolverPath> for ResolverPathBuf {
-  fn from(p: &ResolverPath) -> Self {
-    p.to_path_buf()
-  }
-}
-
-impl From<ResolverPathBuf> for String {
-  fn from(p: ResolverPathBuf) -> Self {
-    p.into_string()
-  }
-}
-
-impl fmt::Debug for ResolverPathBuf {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    fmt::Debug::fmt(&self.inner, f)
-  }
-}
-
-impl fmt::Display for ResolverPathBuf {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    fmt::Display::fmt(&self.inner, f)
-  }
-}
-
-impl PartialEq for ResolverPathBuf {
-  fn eq(&self, other: &Self) -> bool {
-    self.as_path() == other.as_path()
-  }
-}
-impl Eq for ResolverPathBuf {}
-
-impl PartialOrd for ResolverPathBuf {
-  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-    Some(self.cmp(other))
-  }
-}
-impl Ord for ResolverPathBuf {
-  fn cmp(&self, other: &Self) -> Ordering {
-    self.as_path().cmp(other.as_path())
-  }
-}
-
-impl Hash for ResolverPathBuf {
-  fn hash<H: Hasher>(&self, state: &mut H) {
-    self.as_path().hash(state);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Ancestors / StripPrefixError
-// ---------------------------------------------------------------------------
-
-pub struct Ancestors<'a> {
-  next: Option<&'a ResolverPath>,
-}
-
-impl<'a> Iterator for Ancestors<'a> {
-  type Item = &'a ResolverPath;
-  fn next(&mut self) -> Option<Self::Item> {
-    let cur = self.next.take()?;
-    self.next = cur.parent();
-    Some(cur)
-  }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct StripPrefixError(());
-
-impl fmt::Display for StripPrefixError {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    f.write_str("prefix not found")
-  }
-}
-
-impl std::error::Error for StripPrefixError {}
-
-// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -984,16 +929,15 @@ mod tests {
 
   use super::*;
 
-  fn p(s: &str) -> &ResolverPath {
+  fn p(s: &str) -> ResolverPath<'_> {
     ResolverPath::new(s)
   }
 
-  /// Assert that two paths agree on a set of properties with `std::path::Path`.
   fn agrees_with_std(s: &str) {
     let our = p(s);
     let std_p = Path::new(s);
     assert_eq!(
-      our.parent().map(ResolverPath::as_str),
+      our.parent().map(|p| p.as_str()),
       std_p.parent().and_then(|p| p.to_str()),
       "parent mismatch for {s:?}",
     );
@@ -1068,11 +1012,8 @@ mod tests {
       p("/foo").join("bar").as_str(),
       &format!("/foo{MAIN_SEPARATOR}bar")
     );
-    // Trailing separator preserved (no double separator).
     assert_eq!(p("/foo/").join("bar").as_str(), "/foo/bar");
-    // Absolute `other` replaces base.
     assert_eq!(p("/foo").join("/bar").as_str(), "/bar");
-    // Empty base.
     assert_eq!(p("").join("bar").as_str(), "bar");
   }
 
@@ -1110,29 +1051,18 @@ mod tests {
 
   #[test]
   fn ancestors_walk_up() {
-    let chain: Vec<&str> = p("/foo/bar/baz")
-      .ancestors()
-      .map(ResolverPath::as_str)
-      .collect();
+    let chain: Vec<&str> = p("/foo/bar/baz").ancestors().map(|a| a.as_str()).collect();
     assert_eq!(chain, vec!["/foo/bar/baz", "/foo/bar", "/foo", "/"]);
   }
 
   #[test]
-  fn box_path_roundtrip() {
-    let buf = ResolverPathBuf::from("/foo/bar");
-    let boxed: Box<ResolverPath> = buf.into_boxed_path();
-    assert_eq!(boxed.as_str(), "/foo/bar");
-  }
-
-  #[test]
-  fn prehash_matches_borrowed_compute_hash() {
+  fn prehash_consistent_borrow_vs_owned() {
     for s in ["", "/", "/foo", "/foo/bar/baz.js", "C:\\Users\\rust"] {
       let buf = ResolverPathBuf::from(s);
-      assert_eq!(
-        buf.precomputed_hash(),
-        ResolverPath::new(s).compute_hash(),
-        "hashes disagree for {s:?}"
-      );
+      let borrow = ResolverPath::new(s);
+      assert_eq!(buf.precomputed_hash(), borrow.precomputed_hash(), "{s:?}");
+      // as_path() forwards the prehash without recomputing.
+      assert_eq!(buf.as_path().precomputed_hash(), buf.precomputed_hash());
     }
   }
 
@@ -1140,10 +1070,10 @@ mod tests {
   fn prehash_updates_with_mutation() {
     let mut buf = ResolverPathBuf::from("/foo");
     let h1 = buf.precomputed_hash();
-    buf.push(ResolverPath::new("bar"));
+    buf.push("bar");
     let h2 = buf.precomputed_hash();
     assert_ne!(h1, h2);
-    assert_eq!(h2, ResolverPath::new(buf.as_str()).compute_hash());
+    assert_eq!(h2, hash_path(buf.as_str()));
 
     buf.pop();
     assert_eq!(buf.precomputed_hash(), h1);

--- a/src/resolver_path.rs
+++ b/src/resolver_path.rs
@@ -1,7 +1,7 @@
 //! UTF-8 path types that mirror [`std::path::Path`] / [`std::path::PathBuf`].
 //!
 //! Internally rspack-resolver always speaks UTF-8 — we never have to roundtrip
-//! through `OsStr`. `StrPath` / `StrPathBuf` give us the ergonomics of `Path`
+//! through `OsStr`. `ResolverPath` / `ResolverPathBuf` give us the ergonomics of `Path`
 //! (`.parent()`, `.join()`, `.file_name()`, `.components()`, …) operating
 //! directly on string slices, with no `Option<&str>` from `to_str()` and no
 //! allocation through `OsString`.
@@ -28,9 +28,22 @@ use std::{
   borrow::Borrow,
   cmp::Ordering,
   fmt,
-  hash::{Hash, Hasher},
+  hash::{BuildHasher, BuildHasherDefault, Hash, Hasher},
   ops::Deref,
 };
+
+use rustc_hash::FxHasher;
+
+/// FxHash of a path slice, matching the hash other parts of the crate
+/// compute via `FxHasher::default()` + `str::hash`. Centralized so the
+/// precomputed value on [`ResolverPathBuf`] and the on-the-fly value from
+/// [`ResolverPath::compute_hash`] agree.
+#[inline]
+pub fn hash_path(s: &str) -> u64 {
+  let mut h = BuildHasherDefault::<FxHasher>::default().build_hasher();
+  s.hash(&mut h);
+  h.finish()
+}
 
 // ---------------------------------------------------------------------------
 // Separator + platform helpers
@@ -172,7 +185,7 @@ fn parse_windows_prefix(path: &str) -> Option<WindowsPrefix> {
 // Component
 // ---------------------------------------------------------------------------
 
-/// Iterator over [`StrPath`] components — mirrors `std::path::Component`.
+/// Iterator over [`ResolverPath`] components — mirrors `std::path::Component`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Component<'a> {
   /// A windows-style prefix (drive letter, UNC, verbatim).
@@ -198,7 +211,7 @@ impl<'a> Component<'a> {
   }
 }
 
-/// Iterator over the components of a [`StrPath`].
+/// Iterator over the components of a [`ResolverPath`].
 #[derive(Clone)]
 pub struct Components<'a> {
   /// Remaining slice yet to be tokenized.
@@ -243,7 +256,7 @@ impl<'a> Components<'a> {
     }
   }
 
-  /// Borrow what's left as a single `&StrPath`. Used by `Path::components().as_path()`-style consumers.
+  /// Borrow what's left as a single `&ResolverPath`. Used by `Path::components().as_path()`-style consumers.
   pub fn as_str(&self) -> &'a str {
     // We don't model the prefix/root in `rest`; for the resolver's usages
     // the trailing remainder is enough.
@@ -360,21 +373,21 @@ impl<'a> DoubleEndedIterator for Components<'a> {
 }
 
 // ---------------------------------------------------------------------------
-// StrPath (unsized)
+// ResolverPath (unsized)
 // ---------------------------------------------------------------------------
 
 /// Borrowed UTF-8 path. Mirror of [`std::path::Path`].
 #[repr(transparent)]
-pub struct StrPath {
+pub struct ResolverPath {
   inner: str,
 }
 
-impl StrPath {
+impl ResolverPath {
   /// Wrap a string slice as a path slice. Always succeeds — UTF-8 by construction.
   #[inline]
-  pub fn new<S: AsRef<str> + ?Sized>(s: &S) -> &StrPath {
-    // SAFETY: `StrPath` is `#[repr(transparent)]` around `str`.
-    unsafe { &*(s.as_ref() as *const str as *const StrPath) }
+  pub fn new<S: AsRef<str> + ?Sized>(s: &S) -> &ResolverPath {
+    // SAFETY: `ResolverPath` is `#[repr(transparent)]` around `str`.
+    unsafe { &*(s.as_ref() as *const str as *const ResolverPath) }
   }
 
   /// View the path as a `&str`.
@@ -425,7 +438,7 @@ impl StrPath {
   }
 
   /// Parent path. Returns `None` for a path that is just a prefix and/or root.
-  pub fn parent(&self) -> Option<&StrPath> {
+  pub fn parent(&self) -> Option<&ResolverPath> {
     let mut comps = self.components();
     let last = comps.next_back()?;
     match last {
@@ -444,7 +457,7 @@ impl StrPath {
             break;
           }
         }
-        Some(StrPath::new(&self.inner[..end]))
+        Some(ResolverPath::new(&self.inner[..end]))
       }
       Component::Prefix(_) | Component::RootDir => None,
     }
@@ -471,17 +484,20 @@ impl StrPath {
   }
 
   /// Component-aware prefix check.
-  pub fn starts_with<P: AsRef<StrPath>>(&self, base: P) -> bool {
+  pub fn starts_with<P: AsRef<ResolverPath>>(&self, base: P) -> bool {
     iter_starts_with(self.components(), base.as_ref().components())
   }
 
   /// Component-aware suffix check.
-  pub fn ends_with<P: AsRef<StrPath>>(&self, child: P) -> bool {
+  pub fn ends_with<P: AsRef<ResolverPath>>(&self, child: P) -> bool {
     iter_ends_with(self.components(), child.as_ref().components())
   }
 
   /// Strip the given component-aware prefix, returning the tail.
-  pub fn strip_prefix<P: AsRef<StrPath>>(&self, base: P) -> Result<&StrPath, StripPrefixError> {
+  pub fn strip_prefix<P: AsRef<ResolverPath>>(
+    &self,
+    base: P,
+  ) -> Result<&ResolverPath, StripPrefixError> {
     let base = base.as_ref();
     let mut s_comps = self.components();
     let mut b_comps = base.components();
@@ -492,7 +508,7 @@ impl StrPath {
           let rest = s_comps.rest;
           let trimmed =
             rest.trim_start_matches(|c: char| c == '\\' || (!s_comps.verbatim && c == '/'));
-          return Ok(StrPath::new(trimmed));
+          return Ok(ResolverPath::new(trimmed));
         }
         Some(b) => match s_comps.next() {
           Some(s) if components_equal(s, b) => continue,
@@ -503,21 +519,21 @@ impl StrPath {
   }
 
   /// Join with another path. Absolute `other` replaces this path.
-  pub fn join<P: AsRef<StrPath>>(&self, other: P) -> StrPathBuf {
+  pub fn join<P: AsRef<ResolverPath>>(&self, other: P) -> ResolverPathBuf {
     let mut buf = self.to_path_buf();
     buf.push(other);
     buf
   }
 
   /// Path with the extension swapped for `new_ext` (without leading dot).
-  pub fn with_extension(&self, new_ext: &str) -> StrPathBuf {
+  pub fn with_extension(&self, new_ext: &str) -> ResolverPathBuf {
     let mut buf = self.to_path_buf();
     buf.set_extension(new_ext);
     buf
   }
 
   /// Path with the file name swapped.
-  pub fn with_file_name(&self, file_name: &str) -> StrPathBuf {
+  pub fn with_file_name(&self, file_name: &str) -> ResolverPathBuf {
     let mut buf = self.to_path_buf();
     buf.set_file_name(file_name);
     buf
@@ -529,8 +545,19 @@ impl StrPath {
   }
 
   /// Allocate an owned copy.
-  pub fn to_path_buf(&self) -> StrPathBuf {
-    StrPathBuf::from(self.inner.to_string())
+  pub fn to_path_buf(&self) -> ResolverPathBuf {
+    ResolverPathBuf::from(self.inner.to_string())
+  }
+
+  /// FxHash of the underlying string slice.
+  ///
+  /// Borrowed [`ResolverPath`] values can't carry the precomputed hash that
+  /// [`ResolverPathBuf::precomputed_hash`] returns (the type is unsized — no
+  /// place to store it), so this recomputes on demand. The result agrees with
+  /// the precomputed hash carried by [`ResolverPathBuf`] for the same bytes.
+  #[inline]
+  pub fn compute_hash(&self) -> u64 {
+    hash_path(&self.inner)
   }
 
   /// Display in the platform's native form (forwarding to the underlying str).
@@ -616,65 +643,65 @@ fn rsplit_file_at_dot(file: &str) -> (&str, Option<&str>) {
 }
 
 // ---------------------------------------------------------------------------
-// Standard trait impls for StrPath
+// Standard trait impls for ResolverPath
 // ---------------------------------------------------------------------------
 
-impl AsRef<str> for StrPath {
+impl AsRef<str> for ResolverPath {
   fn as_ref(&self) -> &str {
     &self.inner
   }
 }
 
-impl AsRef<StrPath> for StrPath {
-  fn as_ref(&self) -> &StrPath {
+impl AsRef<ResolverPath> for ResolverPath {
+  fn as_ref(&self) -> &ResolverPath {
     self
   }
 }
 
-impl AsRef<StrPath> for str {
-  fn as_ref(&self) -> &StrPath {
-    StrPath::new(self)
+impl AsRef<ResolverPath> for str {
+  fn as_ref(&self) -> &ResolverPath {
+    ResolverPath::new(self)
   }
 }
 
-impl AsRef<StrPath> for String {
-  fn as_ref(&self) -> &StrPath {
-    StrPath::new(self)
+impl AsRef<ResolverPath> for String {
+  fn as_ref(&self) -> &ResolverPath {
+    ResolverPath::new(self)
   }
 }
 
-impl fmt::Debug for StrPath {
+impl fmt::Debug for ResolverPath {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     fmt::Debug::fmt(&self.inner, f)
   }
 }
 
-impl fmt::Display for StrPath {
+impl fmt::Display for ResolverPath {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     fmt::Display::fmt(&self.inner, f)
   }
 }
 
-impl PartialEq for StrPath {
+impl PartialEq for ResolverPath {
   fn eq(&self, other: &Self) -> bool {
     // Component-wise equality — matches std::path::Path behaviour.
     self.components().eq(other.components())
   }
 }
-impl Eq for StrPath {}
+impl Eq for ResolverPath {}
 
-impl PartialOrd for StrPath {
+impl PartialOrd for ResolverPath {
   fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
     Some(self.cmp(other))
   }
 }
-impl Ord for StrPath {
+impl Ord for ResolverPath {
   fn cmp(&self, other: &Self) -> Ordering {
     self.components().cmp(other.components())
   }
 }
 
-impl Hash for StrPath {
+impl Hash for ResolverPath {
   fn hash<H: Hasher>(&self, state: &mut H) {
     for c in self.components() {
       c.as_str().hash(state);
@@ -682,34 +709,62 @@ impl Hash for StrPath {
   }
 }
 
-impl ToOwned for StrPath {
-  type Owned = StrPathBuf;
-  fn to_owned(&self) -> StrPathBuf {
+impl ToOwned for ResolverPath {
+  type Owned = ResolverPathBuf;
+  fn to_owned(&self) -> ResolverPathBuf {
     self.to_path_buf()
   }
 }
 
 // ---------------------------------------------------------------------------
-// StrPathBuf (owned)
+// ResolverPathBuf (owned)
 // ---------------------------------------------------------------------------
 
 /// Owned UTF-8 path. Mirror of [`std::path::PathBuf`].
-#[derive(Clone, Default)]
-pub struct StrPathBuf {
+///
+/// Stores a precomputed FxHash of the contained string alongside the buffer.
+/// Cache layers (notably [`crate::cache::Cache`]) re-use this via
+/// [`Self::precomputed_hash`] so insertions and lookups don't have to re-hash
+/// the path each time.
+#[derive(Clone)]
+pub struct ResolverPathBuf {
+  /// Precomputed `FxHash` of `inner`. Kept in sync with `inner` by every
+  /// mutating method.
+  prehash: u64,
   inner: String,
 }
 
-impl StrPathBuf {
+impl Default for ResolverPathBuf {
+  fn default() -> Self {
+    Self {
+      prehash: hash_path(""),
+      inner: String::new(),
+    }
+  }
+}
+
+impl ResolverPathBuf {
   pub fn new() -> Self {
     Self::default()
   }
 
   pub fn from_string(s: String) -> Self {
-    Self { inner: s }
+    let prehash = hash_path(&s);
+    Self { prehash, inner: s }
   }
 
-  pub fn as_path(&self) -> &StrPath {
-    StrPath::new(&self.inner)
+  /// Construct from a string whose `FxHash` has already been computed elsewhere
+  /// (e.g. by a cache that hashes the key for lookup before deciding to
+  /// allocate). The caller is responsible for the hash matching the bytes; if
+  /// `debug_assertions` is enabled we verify.
+  #[inline]
+  pub fn with_prehash(prehash: u64, s: String) -> Self {
+    debug_assert_eq!(prehash, hash_path(&s), "prehash does not match string");
+    Self { prehash, inner: s }
+  }
+
+  pub fn as_path(&self) -> &ResolverPath {
+    ResolverPath::new(&self.inner)
   }
 
   pub fn as_str(&self) -> &str {
@@ -720,19 +775,39 @@ impl StrPathBuf {
     self.inner
   }
 
-  pub fn into_boxed_path(self) -> Box<StrPath> {
+  pub fn into_boxed_path(self) -> Box<ResolverPath> {
     let raw: *mut str = Box::into_raw(self.inner.into_boxed_str());
-    // SAFETY: `StrPath` is `#[repr(transparent)]` around `str`.
-    unsafe { Box::from_raw(raw as *mut StrPath) }
+    // SAFETY: `ResolverPath` is `#[repr(transparent)]` around `str`.
+    unsafe { Box::from_raw(raw as *mut ResolverPath) }
+  }
+
+  /// Precomputed FxHash of the contained path. Cheap to call (single field
+  /// read) — use this when feeding identity-hashed maps/sets to avoid
+  /// re-hashing the same path on every lookup.
+  ///
+  /// The value agrees with [`ResolverPath::compute_hash`] for the same path
+  /// bytes, so a borrowed `&ResolverPath` and an owned `ResolverPathBuf`
+  /// produce identical hashes.
+  #[inline]
+  pub fn precomputed_hash(&self) -> u64 {
+    self.prehash
+  }
+
+  /// Refresh `prehash` after a mutation. Centralized so `push`/`pop`/
+  /// `set_file_name`/`set_extension` can't forget to keep it in sync.
+  #[inline]
+  fn rehash(&mut self) {
+    self.prehash = hash_path(&self.inner);
   }
 
   /// Append `other`. Absolute `other` replaces the current contents (mirrors
   /// `PathBuf::push`).
-  pub fn push<P: AsRef<StrPath>>(&mut self, other: P) {
+  pub fn push<P: AsRef<ResolverPath>>(&mut self, other: P) {
     let other = other.as_ref();
     if other.is_absolute() {
       self.inner.clear();
       self.inner.push_str(&other.inner);
+      self.rehash();
       return;
     }
     let needs_sep = !self.inner.is_empty()
@@ -746,6 +821,7 @@ impl StrPathBuf {
       self.inner.push(MAIN_SEPARATOR);
     }
     self.inner.push_str(&other.inner);
+    self.rehash();
   }
 
   /// Remove the final component. Returns `false` if there was nothing to pop.
@@ -755,6 +831,7 @@ impl StrPathBuf {
     };
     let new_len = parent.inner.len();
     self.inner.truncate(new_len);
+    self.rehash();
     true
   }
 
@@ -764,7 +841,7 @@ impl StrPathBuf {
       let popped = self.pop();
       debug_assert!(popped);
     }
-    self.push(StrPath::new(file_name));
+    self.push(ResolverPath::new(file_name));
   }
 
   /// Replace (or set) the file extension.
@@ -779,90 +856,91 @@ impl StrPathBuf {
       self.inner.push('.');
       self.inner.push_str(new_ext);
     }
+    self.rehash();
     true
   }
 }
 
-impl Deref for StrPathBuf {
-  type Target = StrPath;
+impl Deref for ResolverPathBuf {
+  type Target = ResolverPath;
   fn deref(&self) -> &Self::Target {
     self.as_path()
   }
 }
 
-impl Borrow<StrPath> for StrPathBuf {
-  fn borrow(&self) -> &StrPath {
+impl Borrow<ResolverPath> for ResolverPathBuf {
+  fn borrow(&self) -> &ResolverPath {
     self.as_path()
   }
 }
 
-impl AsRef<StrPath> for StrPathBuf {
-  fn as_ref(&self) -> &StrPath {
+impl AsRef<ResolverPath> for ResolverPathBuf {
+  fn as_ref(&self) -> &ResolverPath {
     self.as_path()
   }
 }
 
-impl AsRef<str> for StrPathBuf {
+impl AsRef<str> for ResolverPathBuf {
   fn as_ref(&self) -> &str {
     &self.inner
   }
 }
 
-impl From<String> for StrPathBuf {
+impl From<String> for ResolverPathBuf {
   fn from(s: String) -> Self {
     Self::from_string(s)
   }
 }
 
-impl From<&str> for StrPathBuf {
+impl From<&str> for ResolverPathBuf {
   fn from(s: &str) -> Self {
     Self::from_string(s.to_string())
   }
 }
 
-impl From<&StrPath> for StrPathBuf {
-  fn from(p: &StrPath) -> Self {
+impl From<&ResolverPath> for ResolverPathBuf {
+  fn from(p: &ResolverPath) -> Self {
     p.to_path_buf()
   }
 }
 
-impl From<StrPathBuf> for String {
-  fn from(p: StrPathBuf) -> Self {
+impl From<ResolverPathBuf> for String {
+  fn from(p: ResolverPathBuf) -> Self {
     p.into_string()
   }
 }
 
-impl fmt::Debug for StrPathBuf {
+impl fmt::Debug for ResolverPathBuf {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     fmt::Debug::fmt(&self.inner, f)
   }
 }
 
-impl fmt::Display for StrPathBuf {
+impl fmt::Display for ResolverPathBuf {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     fmt::Display::fmt(&self.inner, f)
   }
 }
 
-impl PartialEq for StrPathBuf {
+impl PartialEq for ResolverPathBuf {
   fn eq(&self, other: &Self) -> bool {
     self.as_path() == other.as_path()
   }
 }
-impl Eq for StrPathBuf {}
+impl Eq for ResolverPathBuf {}
 
-impl PartialOrd for StrPathBuf {
+impl PartialOrd for ResolverPathBuf {
   fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
     Some(self.cmp(other))
   }
 }
-impl Ord for StrPathBuf {
+impl Ord for ResolverPathBuf {
   fn cmp(&self, other: &Self) -> Ordering {
     self.as_path().cmp(other.as_path())
   }
 }
 
-impl Hash for StrPathBuf {
+impl Hash for ResolverPathBuf {
   fn hash<H: Hasher>(&self, state: &mut H) {
     self.as_path().hash(state);
   }
@@ -873,11 +951,11 @@ impl Hash for StrPathBuf {
 // ---------------------------------------------------------------------------
 
 pub struct Ancestors<'a> {
-  next: Option<&'a StrPath>,
+  next: Option<&'a ResolverPath>,
 }
 
 impl<'a> Iterator for Ancestors<'a> {
-  type Item = &'a StrPath;
+  type Item = &'a ResolverPath;
   fn next(&mut self) -> Option<Self::Item> {
     let cur = self.next.take()?;
     self.next = cur.parent();
@@ -906,8 +984,8 @@ mod tests {
 
   use super::*;
 
-  fn p(s: &str) -> &StrPath {
-    StrPath::new(s)
+  fn p(s: &str) -> &ResolverPath {
+    ResolverPath::new(s)
   }
 
   /// Assert that two paths agree on a set of properties with `std::path::Path`.
@@ -915,7 +993,7 @@ mod tests {
     let our = p(s);
     let std_p = Path::new(s);
     assert_eq!(
-      our.parent().map(StrPath::as_str),
+      our.parent().map(ResolverPath::as_str),
       std_p.parent().and_then(|p| p.to_str()),
       "parent mismatch for {s:?}",
     );
@@ -1000,7 +1078,7 @@ mod tests {
 
   #[test]
   fn pop_and_parent() {
-    let mut buf = StrPathBuf::from("/foo/bar");
+    let mut buf = ResolverPathBuf::from("/foo/bar");
     assert!(buf.pop());
     assert_eq!(buf.as_str(), "/foo");
     assert!(buf.pop());
@@ -1023,7 +1101,7 @@ mod tests {
 
   #[test]
   fn set_extension_works() {
-    let mut buf = StrPathBuf::from("/foo/bar.js");
+    let mut buf = ResolverPathBuf::from("/foo/bar.js");
     assert!(buf.set_extension("ts"));
     assert_eq!(buf.as_str(), "/foo/bar.ts");
     assert!(buf.set_extension(""));
@@ -1032,14 +1110,49 @@ mod tests {
 
   #[test]
   fn ancestors_walk_up() {
-    let chain: Vec<&str> = p("/foo/bar/baz").ancestors().map(StrPath::as_str).collect();
+    let chain: Vec<&str> = p("/foo/bar/baz")
+      .ancestors()
+      .map(ResolverPath::as_str)
+      .collect();
     assert_eq!(chain, vec!["/foo/bar/baz", "/foo/bar", "/foo", "/"]);
   }
 
   #[test]
   fn box_path_roundtrip() {
-    let buf = StrPathBuf::from("/foo/bar");
-    let boxed: Box<StrPath> = buf.into_boxed_path();
+    let buf = ResolverPathBuf::from("/foo/bar");
+    let boxed: Box<ResolverPath> = buf.into_boxed_path();
     assert_eq!(boxed.as_str(), "/foo/bar");
+  }
+
+  #[test]
+  fn prehash_matches_borrowed_compute_hash() {
+    for s in ["", "/", "/foo", "/foo/bar/baz.js", "C:\\Users\\rust"] {
+      let buf = ResolverPathBuf::from(s);
+      assert_eq!(
+        buf.precomputed_hash(),
+        ResolverPath::new(s).compute_hash(),
+        "hashes disagree for {s:?}"
+      );
+    }
+  }
+
+  #[test]
+  fn prehash_updates_with_mutation() {
+    let mut buf = ResolverPathBuf::from("/foo");
+    let h1 = buf.precomputed_hash();
+    buf.push(ResolverPath::new("bar"));
+    let h2 = buf.precomputed_hash();
+    assert_ne!(h1, h2);
+    assert_eq!(h2, ResolverPath::new(buf.as_str()).compute_hash());
+
+    buf.pop();
+    assert_eq!(buf.precomputed_hash(), h1);
+
+    let mut buf = ResolverPathBuf::from("/foo/bar.js");
+    let before = buf.precomputed_hash();
+    buf.set_extension("ts");
+    assert_ne!(before, buf.precomputed_hash());
+    assert_eq!(buf.as_str(), "/foo/bar.ts");
+    assert_eq!(buf.precomputed_hash(), hash_path("/foo/bar.ts"));
   }
 }

--- a/src/resolver_path.rs
+++ b/src/resolver_path.rs
@@ -727,6 +727,21 @@ impl ResolverPathBuf {
       self.rehash();
       return;
     }
+    // Mirror `std::path::PathBuf::push`: a path that has a root but no
+    // prefix (e.g. `\windows`, `/foo`) keeps `self`'s prefix and replaces
+    // everything after it. On Unix this collapses to `is_absolute`; on
+    // Windows it lets `C:foo.push("\\bar")` produce `C:\\bar`.
+    #[cfg(windows)]
+    {
+      let other_bytes = other.inner.as_bytes();
+      if prefix_len(other.inner) == 0 && matches!(other_bytes.first(), Some(&b) if is_sep_byte(b)) {
+        let self_plen = prefix_len(&self.inner);
+        self.inner.truncate(self_plen);
+        self.inner.push_str(other.inner);
+        self.rehash();
+        return;
+      }
+    }
     let needs_sep = !self.inner.is_empty()
       && !self
         .inner
@@ -739,6 +754,30 @@ impl ResolverPathBuf {
     }
     self.inner.push_str(other.inner);
     self.rehash();
+  }
+
+  /// Append a single separator character to the buffer without any segment.
+  /// Used by `normalize_path` to anchor a root that has no prefix attached
+  /// (`/foo` style). Idempotent: no-op when the tail is already a separator.
+  /// The character must be a path separator (`/`, or `\\` on Windows).
+  pub fn push_separator_char(&mut self, sep: char) {
+    debug_assert!(is_sep_byte(sep as u8));
+    if self
+      .inner
+      .as_bytes()
+      .last()
+      .copied()
+      .is_some_and(is_sep_byte)
+    {
+      return;
+    }
+    self.inner.push(sep);
+    self.rehash();
+  }
+
+  /// Convenience: appends [`MAIN_SEPARATOR`].
+  pub fn push_separator(&mut self) {
+    self.push_separator_char(MAIN_SEPARATOR);
   }
 
   pub fn pop(&mut self) -> bool {

--- a/src/resolver_path.rs
+++ b/src/resolver_path.rs
@@ -223,18 +223,12 @@ pub struct Components<'a> {
 
 impl<'a> Components<'a> {
   fn new(path: &'a str) -> Self {
-    let plen = prefix_len(path);
+    #[cfg(windows)]
+    let (plen, verbatim) =
+      parse_windows_prefix(path).map_or((0usize, false), |p| (p.len, p.verbatim));
+    #[cfg(not(windows))]
+    let (plen, verbatim) = (0usize, false);
     let prefix = if plen > 0 { Some(&path[..plen]) } else { None };
-    let verbatim = {
-      #[cfg(windows)]
-      {
-        prefix.is_some() && path.starts_with(r"\\?")
-      }
-      #[cfg(not(windows))]
-      {
-        false
-      }
-    };
     let after_prefix = &path[plen..];
     let (has_root, rest) = match after_prefix.as_bytes().first() {
       Some(&b) if is_sep_byte(b) => (true, &after_prefix[1..]),
@@ -503,6 +497,10 @@ impl<'a> ResolverPath<'a> {
 
   /// Strip the given component-aware prefix, returning the tail. Recomputes
   /// the tail's hash (different slice).
+  ///
+  /// # Errors
+  /// Returns [`StripPrefixError`] if `base` is not a component-wise prefix
+  /// of `self` (mirroring [`std::path::Path::strip_prefix`]).
   pub fn strip_prefix<S: AsRef<str>>(self, base: S) -> Result<ResolverPath<'a>, StripPrefixError> {
     let mut s_comps = self.components();
     let mut b_comps = Components::new(base.as_ref());
@@ -710,6 +708,11 @@ impl ResolverPathBuf {
     self.as_path().ends_with(child)
   }
 
+  /// See [`ResolverPath::strip_prefix`].
+  ///
+  /// # Errors
+  /// Returns [`StripPrefixError`] if `base` is not a component-wise prefix
+  /// of `self`.
   pub fn strip_prefix<S: AsRef<str>>(&self, base: S) -> Result<ResolverPath<'_>, StripPrefixError> {
     self.as_path().strip_prefix(base)
   }

--- a/src/str_path.rs
+++ b/src/str_path.rs
@@ -1,0 +1,1045 @@
+//! UTF-8 path types that mirror [`std::path::Path`] / [`std::path::PathBuf`].
+//!
+//! Internally rspack-resolver always speaks UTF-8 — we never have to roundtrip
+//! through `OsStr`. `StrPath` / `StrPathBuf` give us the ergonomics of `Path`
+//! (`.parent()`, `.join()`, `.file_name()`, `.components()`, …) operating
+//! directly on string slices, with no `Option<&str>` from `to_str()` and no
+//! allocation through `OsString`.
+//!
+//! Semantics aim to match `std::path` on each platform:
+//! - On `cfg(unix)` only `/` is a separator.
+//! - On `cfg(windows)` both `/` and `\` are separators, drive letters
+//!   (`C:`) and UNC roots (`\\server\share`) are recognized as `Prefix`
+//!   components, and `\\?\…` verbatim paths are passed through.
+//!
+//! These types only live inside the crate; the public API stays
+//! `String` / `&str`.
+
+// This module deliberately mirrors `std::path` naming, so a few clippy lints
+// that ordinarily catch over-eager API surface are suppressed.
+#![allow(
+  clippy::use_self,
+  clippy::unnecessary_wraps,
+  clippy::elidable_lifetime_names,
+  clippy::needless_continue
+)]
+
+use std::{
+  borrow::Borrow,
+  cmp::Ordering,
+  fmt,
+  hash::{Hash, Hasher},
+  ops::Deref,
+};
+
+// ---------------------------------------------------------------------------
+// Separator + platform helpers
+// ---------------------------------------------------------------------------
+
+/// Native separator pushed when joining components.
+#[cfg(windows)]
+pub const MAIN_SEPARATOR: char = '\\';
+#[cfg(not(windows))]
+pub const MAIN_SEPARATOR: char = '/';
+
+#[cfg(windows)]
+#[inline]
+const fn is_sep_byte(b: u8) -> bool {
+  b == b'/' || b == b'\\'
+}
+#[cfg(not(windows))]
+#[inline]
+const fn is_sep_byte(b: u8) -> bool {
+  b == b'/'
+}
+
+#[inline]
+fn is_verbatim_sep_byte(b: u8) -> bool {
+  b == b'\\'
+}
+
+/// Length of the byte sequence that constitutes the path's *prefix component*
+/// (drive letter, UNC, verbatim, …). On non-Windows targets this is always 0.
+///
+/// The returned slice `&path[..prefix_len]` is what `Component::Prefix` covers,
+/// matching `std::path::Path`'s notion of a prefix.
+#[cfg(not(windows))]
+fn prefix_len(_path: &str) -> usize {
+  0
+}
+
+#[cfg(windows)]
+fn prefix_len(path: &str) -> usize {
+  parse_windows_prefix(path).map_or(0, |p| p.len)
+}
+
+#[cfg(windows)]
+#[derive(Clone, Copy)]
+struct WindowsPrefix {
+  len: usize,
+  /// Verbatim prefixes (`\\?\…`) disable forward-slash separators.
+  verbatim: bool,
+}
+
+#[cfg(windows)]
+fn parse_windows_prefix(path: &str) -> Option<WindowsPrefix> {
+  let bytes = path.as_bytes();
+  // `\\?\…` verbatim, `\\.\…` device, or `\\server\share` UNC
+  if bytes.len() >= 2 && is_sep_byte(bytes[0]) && is_sep_byte(bytes[1]) {
+    // verbatim or device
+    if bytes.len() >= 4 && (bytes[2] == b'?' || bytes[2] == b'.') && is_sep_byte(bytes[3]) {
+      let verbatim = bytes[2] == b'?';
+      // `\\?\UNC\server\share`
+      if verbatim
+        && bytes.len() >= 8
+        && bytes[4..7].eq_ignore_ascii_case(b"UNC")
+        && is_sep_byte(bytes[7])
+      {
+        // Find `server` then `share`.
+        let after = &bytes[8..];
+        let server_end = after
+          .iter()
+          .position(|&b| is_verbatim_sep_byte(b))
+          .unwrap_or(after.len());
+        if server_end == 0 {
+          return None;
+        }
+        let share_start = server_end + 1;
+        if share_start >= after.len() {
+          // `\\?\UNC\server` is invalid; treat as no prefix.
+          return None;
+        }
+        let share_end_rel = after[share_start..]
+          .iter()
+          .position(|&b| is_verbatim_sep_byte(b))
+          .unwrap_or(after.len() - share_start);
+        return Some(WindowsPrefix {
+          len: 8 + share_start + share_end_rel,
+          verbatim: true,
+        });
+      }
+      // `\\?\C:` verbatim disk
+      if verbatim && bytes.len() >= 6 && bytes[4].is_ascii_alphabetic() && bytes[5] == b':' {
+        return Some(WindowsPrefix {
+          len: 6,
+          verbatim: true,
+        });
+      }
+      // Generic verbatim `\\?\foo` or device `\\.\foo` — single segment.
+      let rest = &bytes[4..];
+      let end = rest
+        .iter()
+        .position(|&b| is_verbatim_sep_byte(b))
+        .unwrap_or(rest.len());
+      return Some(WindowsPrefix {
+        len: 4 + end,
+        verbatim,
+      });
+    }
+    // `\\server\share` UNC
+    let after = &bytes[2..];
+    let server_end = after
+      .iter()
+      .position(|&b| is_sep_byte(b))
+      .unwrap_or(after.len());
+    if server_end == 0 {
+      return None;
+    }
+    let share_start = server_end + 1;
+    if share_start >= after.len() {
+      return None;
+    }
+    let share_end_rel = after[share_start..]
+      .iter()
+      .position(|&b| is_sep_byte(b))
+      .unwrap_or(after.len() - share_start);
+    return Some(WindowsPrefix {
+      len: 2 + share_start + share_end_rel,
+      verbatim: false,
+    });
+  }
+  // `C:` drive prefix
+  if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+    return Some(WindowsPrefix {
+      len: 2,
+      verbatim: false,
+    });
+  }
+  None
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/// Iterator over [`StrPath`] components — mirrors `std::path::Component`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Component<'a> {
+  /// A windows-style prefix (drive letter, UNC, verbatim).
+  Prefix(&'a str),
+  /// The root separator (`/` on Unix, after the prefix on Windows).
+  RootDir,
+  /// `.`
+  CurDir,
+  /// `..`
+  ParentDir,
+  /// A non-empty path segment.
+  Normal(&'a str),
+}
+
+impl<'a> Component<'a> {
+  pub fn as_str(self) -> &'a str {
+    match self {
+      Self::Prefix(s) | Self::Normal(s) => s,
+      Self::RootDir => "/",
+      Self::CurDir => ".",
+      Self::ParentDir => "..",
+    }
+  }
+}
+
+/// Iterator over the components of a [`StrPath`].
+#[derive(Clone)]
+pub struct Components<'a> {
+  /// Remaining slice yet to be tokenized.
+  rest: &'a str,
+  /// Whether a `Prefix` is still pending (only set on the very first step).
+  prefix: Option<&'a str>,
+  /// Whether a `RootDir` is still pending after the optional prefix.
+  has_root: bool,
+  /// Verbatim paths (Windows `\\?\…`) only split on `\`, never on `/`.
+  verbatim: bool,
+  /// True once the front cursor has yielded any component. Used to decide
+  /// whether a leading `.` segment yields `CurDir` (it does) or gets skipped
+  /// (any `.` after a real segment / root / prefix is dropped).
+  front_started: bool,
+}
+
+impl<'a> Components<'a> {
+  fn new(path: &'a str) -> Self {
+    let plen = prefix_len(path);
+    let prefix = if plen > 0 { Some(&path[..plen]) } else { None };
+    let verbatim = {
+      #[cfg(windows)]
+      {
+        prefix.is_some() && path.starts_with(r"\\?")
+      }
+      #[cfg(not(windows))]
+      {
+        false
+      }
+    };
+    let after_prefix = &path[plen..];
+    let (has_root, rest) = match after_prefix.as_bytes().first() {
+      Some(&b) if is_sep_byte(b) => (true, &after_prefix[1..]),
+      _ => (false, after_prefix),
+    };
+    Self {
+      rest,
+      prefix,
+      has_root,
+      verbatim,
+      front_started: false,
+    }
+  }
+
+  /// Borrow what's left as a single `&StrPath`. Used by `Path::components().as_path()`-style consumers.
+  pub fn as_str(&self) -> &'a str {
+    // We don't model the prefix/root in `rest`; for the resolver's usages
+    // the trailing remainder is enough.
+    self.rest
+  }
+
+  fn is_sep(&self, b: u8) -> bool {
+    if self.verbatim {
+      is_verbatim_sep_byte(b)
+    } else {
+      is_sep_byte(b)
+    }
+  }
+}
+
+impl<'a> Iterator for Components<'a> {
+  type Item = Component<'a>;
+
+  fn next(&mut self) -> Option<Component<'a>> {
+    if let Some(p) = self.prefix.take() {
+      self.front_started = true;
+      return Some(Component::Prefix(p));
+    }
+    if self.has_root {
+      self.has_root = false;
+      self.front_started = true;
+      return Some(Component::RootDir);
+    }
+    loop {
+      // Skip leading separators.
+      while let Some((&b, tail)) = self.rest.as_bytes().split_first() {
+        if self.is_sep(b) {
+          // SAFETY: `tail` is the byte tail of a UTF-8 string after splitting at an ASCII separator,
+          // so it remains valid UTF-8.
+          self.rest = unsafe { std::str::from_utf8_unchecked(tail) };
+        } else {
+          break;
+        }
+      }
+      if self.rest.is_empty() {
+        return None;
+      }
+      let end = self
+        .rest
+        .as_bytes()
+        .iter()
+        .position(|&b| self.is_sep(b))
+        .unwrap_or(self.rest.len());
+      let segment = &self.rest[..end];
+      self.rest = &self.rest[end..];
+      match segment {
+        // `.` is only kept if nothing has been emitted before it — i.e. it's a
+        // leading `./`. Any other `.` segment is normalized away.
+        "." if self.front_started => continue,
+        "." => {
+          self.front_started = true;
+          return Some(Component::CurDir);
+        }
+        ".." => {
+          self.front_started = true;
+          return Some(Component::ParentDir);
+        }
+        other => {
+          self.front_started = true;
+          return Some(Component::Normal(other));
+        }
+      }
+    }
+  }
+}
+
+impl<'a> DoubleEndedIterator for Components<'a> {
+  fn next_back(&mut self) -> Option<Component<'a>> {
+    loop {
+      // Trim trailing separators.
+      while let Some((&b, head)) = self.rest.as_bytes().split_last() {
+        if self.is_sep(b) {
+          // SAFETY: `head` is the byte prefix of a UTF-8 string after splitting at an ASCII separator,
+          // so it remains valid UTF-8.
+          self.rest = unsafe { std::str::from_utf8_unchecked(head) };
+        } else {
+          break;
+        }
+      }
+      if !self.rest.is_empty() {
+        let start = self
+          .rest
+          .as_bytes()
+          .iter()
+          .rposition(|&b| self.is_sep(b))
+          .map_or(0, |i| i + 1);
+        let segment = &self.rest[start..];
+        self.rest = &self.rest[..start];
+        match segment {
+          "." => {
+            // Leading `.` only survives when nothing precedes it (no prefix,
+            // no root, no earlier segment).
+            if self.rest.is_empty() && self.prefix.is_none() && !self.has_root {
+              return Some(Component::CurDir);
+            }
+            continue;
+          }
+          ".." => return Some(Component::ParentDir),
+          other => return Some(Component::Normal(other)),
+        }
+      }
+      if self.has_root {
+        self.has_root = false;
+        return Some(Component::RootDir);
+      }
+      return self.prefix.take().map(Component::Prefix);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// StrPath (unsized)
+// ---------------------------------------------------------------------------
+
+/// Borrowed UTF-8 path. Mirror of [`std::path::Path`].
+#[repr(transparent)]
+pub struct StrPath {
+  inner: str,
+}
+
+impl StrPath {
+  /// Wrap a string slice as a path slice. Always succeeds — UTF-8 by construction.
+  #[inline]
+  pub fn new<S: AsRef<str> + ?Sized>(s: &S) -> &StrPath {
+    // SAFETY: `StrPath` is `#[repr(transparent)]` around `str`.
+    unsafe { &*(s.as_ref() as *const str as *const StrPath) }
+  }
+
+  /// View the path as a `&str`.
+  #[inline]
+  pub fn as_str(&self) -> &str {
+    &self.inner
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.inner.is_empty()
+  }
+
+  pub fn to_str(&self) -> Option<&str> {
+    Some(&self.inner)
+  }
+
+  /// True if the path starts with a root (`/`, drive letter, UNC, …).
+  pub fn is_absolute(&self) -> bool {
+    let plen = prefix_len(&self.inner);
+    let after = &self.inner.as_bytes()[plen..];
+    #[cfg(windows)]
+    {
+      // On Windows a path is absolute when there is both a prefix *and* a root,
+      // or when the prefix itself is verbatim/UNC (which implies a root).
+      if plen == 0 {
+        return false;
+      }
+      if matches!(after.first(), Some(&b) if is_sep_byte(b)) {
+        return true;
+      }
+      let bytes = self.inner.as_bytes();
+      bytes.starts_with(b"\\\\") || bytes.starts_with(b"//")
+    }
+    #[cfg(not(windows))]
+    {
+      let _ = plen;
+      matches!(after.first(), Some(&b) if is_sep_byte(b))
+    }
+  }
+
+  pub fn is_relative(&self) -> bool {
+    !self.is_absolute()
+  }
+
+  /// Iterator over path components.
+  pub fn components(&self) -> Components<'_> {
+    Components::new(&self.inner)
+  }
+
+  /// Parent path. Returns `None` for a path that is just a prefix and/or root.
+  pub fn parent(&self) -> Option<&StrPath> {
+    let mut comps = self.components();
+    let last = comps.next_back()?;
+    match last {
+      Component::Normal(_) | Component::CurDir | Component::ParentDir => {
+        // After consuming the trailing segment, the unread byte length covers
+        // exactly the parent (prefix + root + remaining `rest`).
+        let mut end = comps.remaining_len();
+        // Trim separators that sat between the parent and the just-removed
+        // trailing segment, *but* keep the root separator itself.
+        let root_keep = prefix_len(&self.inner) + usize::from(self.has_root_separator());
+        while end > root_keep {
+          let b = self.inner.as_bytes()[end - 1];
+          if comps.is_sep(b) {
+            end -= 1;
+          } else {
+            break;
+          }
+        }
+        Some(StrPath::new(&self.inner[..end]))
+      }
+      Component::Prefix(_) | Component::RootDir => None,
+    }
+  }
+
+  /// File name = the last `Normal` component, or `None`.
+  pub fn file_name(&self) -> Option<&str> {
+    self.components().next_back().and_then(|c| match c {
+      Component::Normal(s) => Some(s),
+      _ => None,
+    })
+  }
+
+  /// File stem = file_name with the final extension stripped.
+  pub fn file_stem(&self) -> Option<&str> {
+    let name = self.file_name()?;
+    Some(rsplit_file_at_dot(name).0)
+  }
+
+  /// File extension = the chars after the final `.` in `file_name()`, when present.
+  pub fn extension(&self) -> Option<&str> {
+    let name = self.file_name()?;
+    rsplit_file_at_dot(name).1
+  }
+
+  /// Component-aware prefix check.
+  pub fn starts_with<P: AsRef<StrPath>>(&self, base: P) -> bool {
+    iter_starts_with(self.components(), base.as_ref().components())
+  }
+
+  /// Component-aware suffix check.
+  pub fn ends_with<P: AsRef<StrPath>>(&self, child: P) -> bool {
+    iter_ends_with(self.components(), child.as_ref().components())
+  }
+
+  /// Strip the given component-aware prefix, returning the tail.
+  pub fn strip_prefix<P: AsRef<StrPath>>(&self, base: P) -> Result<&StrPath, StripPrefixError> {
+    let base = base.as_ref();
+    let mut s_comps = self.components();
+    let mut b_comps = base.components();
+    loop {
+      match b_comps.next() {
+        None => {
+          // Consume any leading separators before returning.
+          let rest = s_comps.rest;
+          let trimmed =
+            rest.trim_start_matches(|c: char| c == '\\' || (!s_comps.verbatim && c == '/'));
+          return Ok(StrPath::new(trimmed));
+        }
+        Some(b) => match s_comps.next() {
+          Some(s) if components_equal(s, b) => continue,
+          _ => return Err(StripPrefixError(())),
+        },
+      }
+    }
+  }
+
+  /// Join with another path. Absolute `other` replaces this path.
+  pub fn join<P: AsRef<StrPath>>(&self, other: P) -> StrPathBuf {
+    let mut buf = self.to_path_buf();
+    buf.push(other);
+    buf
+  }
+
+  /// Path with the extension swapped for `new_ext` (without leading dot).
+  pub fn with_extension(&self, new_ext: &str) -> StrPathBuf {
+    let mut buf = self.to_path_buf();
+    buf.set_extension(new_ext);
+    buf
+  }
+
+  /// Path with the file name swapped.
+  pub fn with_file_name(&self, file_name: &str) -> StrPathBuf {
+    let mut buf = self.to_path_buf();
+    buf.set_file_name(file_name);
+    buf
+  }
+
+  /// Ancestors iterator (self, self.parent(), self.parent().parent(), …).
+  pub fn ancestors(&self) -> Ancestors<'_> {
+    Ancestors { next: Some(self) }
+  }
+
+  /// Allocate an owned copy.
+  pub fn to_path_buf(&self) -> StrPathBuf {
+    StrPathBuf::from(self.inner.to_string())
+  }
+
+  /// Display in the platform's native form (forwarding to the underlying str).
+  pub fn display(&self) -> &str {
+    &self.inner
+  }
+
+  // -- internal helpers --
+
+  fn has_root_separator(&self) -> bool {
+    let plen = prefix_len(&self.inner);
+    matches!(self.inner.as_bytes().get(plen), Some(&b) if is_sep_byte(b))
+  }
+}
+
+impl<'a> Components<'a> {
+  fn remaining_len(&self) -> usize {
+    let mut n = self.rest.len();
+    if self.has_root {
+      n += 1;
+    }
+    if let Some(p) = self.prefix {
+      n += p.len();
+    }
+    n
+  }
+}
+
+fn components_equal(a: Component<'_>, b: Component<'_>) -> bool {
+  match (a, b) {
+    (Component::RootDir, Component::RootDir)
+    | (Component::CurDir, Component::CurDir)
+    | (Component::ParentDir, Component::ParentDir) => true,
+    (Component::Prefix(x), Component::Prefix(y)) => {
+      // On Windows, drive-letter prefixes are case-insensitive in std::path.
+      #[cfg(windows)]
+      {
+        x.eq_ignore_ascii_case(y)
+      }
+      #[cfg(not(windows))]
+      {
+        x == y
+      }
+    }
+    (Component::Normal(x), Component::Normal(y)) => x == y,
+    _ => false,
+  }
+}
+
+fn iter_starts_with<'a, 'b>(mut a: Components<'a>, mut b: Components<'b>) -> bool {
+  loop {
+    match (a.next(), b.next()) {
+      (_, None) => return true,
+      (Some(x), Some(y)) if components_equal(x, y) => continue,
+      _ => return false,
+    }
+  }
+}
+
+fn iter_ends_with<'a, 'b>(a: Components<'a>, b: Components<'b>) -> bool {
+  let a: Vec<_> = a.collect();
+  let b: Vec<_> = b.collect();
+  if b.len() > a.len() {
+    return false;
+  }
+  let start = a.len() - b.len();
+  a[start..]
+    .iter()
+    .zip(b.iter())
+    .all(|(x, y)| components_equal(*x, *y))
+}
+
+/// Split a file name into (stem, ext) using the same rule as `std::path::Path`:
+///   - if the name has no `.`, or the only `.` is the first byte, ext is `None`.
+fn rsplit_file_at_dot(file: &str) -> (&str, Option<&str>) {
+  if file == ".." {
+    return (file, None);
+  }
+  match file.rfind('.') {
+    Some(0) | None => (file, None),
+    Some(i) => (&file[..i], Some(&file[i + 1..])),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Standard trait impls for StrPath
+// ---------------------------------------------------------------------------
+
+impl AsRef<str> for StrPath {
+  fn as_ref(&self) -> &str {
+    &self.inner
+  }
+}
+
+impl AsRef<StrPath> for StrPath {
+  fn as_ref(&self) -> &StrPath {
+    self
+  }
+}
+
+impl AsRef<StrPath> for str {
+  fn as_ref(&self) -> &StrPath {
+    StrPath::new(self)
+  }
+}
+
+impl AsRef<StrPath> for String {
+  fn as_ref(&self) -> &StrPath {
+    StrPath::new(self)
+  }
+}
+
+impl fmt::Debug for StrPath {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fmt::Debug::fmt(&self.inner, f)
+  }
+}
+
+impl fmt::Display for StrPath {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fmt::Display::fmt(&self.inner, f)
+  }
+}
+
+impl PartialEq for StrPath {
+  fn eq(&self, other: &Self) -> bool {
+    // Component-wise equality — matches std::path::Path behaviour.
+    self.components().eq(other.components())
+  }
+}
+impl Eq for StrPath {}
+
+impl PartialOrd for StrPath {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}
+impl Ord for StrPath {
+  fn cmp(&self, other: &Self) -> Ordering {
+    self.components().cmp(other.components())
+  }
+}
+
+impl Hash for StrPath {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    for c in self.components() {
+      c.as_str().hash(state);
+    }
+  }
+}
+
+impl ToOwned for StrPath {
+  type Owned = StrPathBuf;
+  fn to_owned(&self) -> StrPathBuf {
+    self.to_path_buf()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// StrPathBuf (owned)
+// ---------------------------------------------------------------------------
+
+/// Owned UTF-8 path. Mirror of [`std::path::PathBuf`].
+#[derive(Clone, Default)]
+pub struct StrPathBuf {
+  inner: String,
+}
+
+impl StrPathBuf {
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  pub fn from_string(s: String) -> Self {
+    Self { inner: s }
+  }
+
+  pub fn as_path(&self) -> &StrPath {
+    StrPath::new(&self.inner)
+  }
+
+  pub fn as_str(&self) -> &str {
+    &self.inner
+  }
+
+  pub fn into_string(self) -> String {
+    self.inner
+  }
+
+  pub fn into_boxed_path(self) -> Box<StrPath> {
+    let raw: *mut str = Box::into_raw(self.inner.into_boxed_str());
+    // SAFETY: `StrPath` is `#[repr(transparent)]` around `str`.
+    unsafe { Box::from_raw(raw as *mut StrPath) }
+  }
+
+  /// Append `other`. Absolute `other` replaces the current contents (mirrors
+  /// `PathBuf::push`).
+  pub fn push<P: AsRef<StrPath>>(&mut self, other: P) {
+    let other = other.as_ref();
+    if other.is_absolute() {
+      self.inner.clear();
+      self.inner.push_str(&other.inner);
+      return;
+    }
+    let needs_sep = !self.inner.is_empty()
+      && !self
+        .inner
+        .as_bytes()
+        .last()
+        .copied()
+        .is_some_and(is_sep_byte);
+    if needs_sep {
+      self.inner.push(MAIN_SEPARATOR);
+    }
+    self.inner.push_str(&other.inner);
+  }
+
+  /// Remove the final component. Returns `false` if there was nothing to pop.
+  pub fn pop(&mut self) -> bool {
+    let Some(parent) = self.as_path().parent() else {
+      return false;
+    };
+    let new_len = parent.inner.len();
+    self.inner.truncate(new_len);
+    true
+  }
+
+  /// Replace the final component's file name.
+  pub fn set_file_name(&mut self, file_name: &str) {
+    if self.as_path().file_name().is_some() {
+      let popped = self.pop();
+      debug_assert!(popped);
+    }
+    self.push(StrPath::new(file_name));
+  }
+
+  /// Replace (or set) the file extension.
+  pub fn set_extension(&mut self, new_ext: &str) -> bool {
+    let Some(file_name) = self.as_path().file_name() else {
+      return false;
+    };
+    let stem_len = rsplit_file_at_dot(file_name).0.len();
+    let file_name_start = self.inner.len() - file_name.len();
+    self.inner.truncate(file_name_start + stem_len);
+    if !new_ext.is_empty() {
+      self.inner.push('.');
+      self.inner.push_str(new_ext);
+    }
+    true
+  }
+}
+
+impl Deref for StrPathBuf {
+  type Target = StrPath;
+  fn deref(&self) -> &Self::Target {
+    self.as_path()
+  }
+}
+
+impl Borrow<StrPath> for StrPathBuf {
+  fn borrow(&self) -> &StrPath {
+    self.as_path()
+  }
+}
+
+impl AsRef<StrPath> for StrPathBuf {
+  fn as_ref(&self) -> &StrPath {
+    self.as_path()
+  }
+}
+
+impl AsRef<str> for StrPathBuf {
+  fn as_ref(&self) -> &str {
+    &self.inner
+  }
+}
+
+impl From<String> for StrPathBuf {
+  fn from(s: String) -> Self {
+    Self::from_string(s)
+  }
+}
+
+impl From<&str> for StrPathBuf {
+  fn from(s: &str) -> Self {
+    Self::from_string(s.to_string())
+  }
+}
+
+impl From<&StrPath> for StrPathBuf {
+  fn from(p: &StrPath) -> Self {
+    p.to_path_buf()
+  }
+}
+
+impl From<StrPathBuf> for String {
+  fn from(p: StrPathBuf) -> Self {
+    p.into_string()
+  }
+}
+
+impl fmt::Debug for StrPathBuf {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fmt::Debug::fmt(&self.inner, f)
+  }
+}
+
+impl fmt::Display for StrPathBuf {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fmt::Display::fmt(&self.inner, f)
+  }
+}
+
+impl PartialEq for StrPathBuf {
+  fn eq(&self, other: &Self) -> bool {
+    self.as_path() == other.as_path()
+  }
+}
+impl Eq for StrPathBuf {}
+
+impl PartialOrd for StrPathBuf {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}
+impl Ord for StrPathBuf {
+  fn cmp(&self, other: &Self) -> Ordering {
+    self.as_path().cmp(other.as_path())
+  }
+}
+
+impl Hash for StrPathBuf {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    self.as_path().hash(state);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ancestors / StripPrefixError
+// ---------------------------------------------------------------------------
+
+pub struct Ancestors<'a> {
+  next: Option<&'a StrPath>,
+}
+
+impl<'a> Iterator for Ancestors<'a> {
+  type Item = &'a StrPath;
+  fn next(&mut self) -> Option<Self::Item> {
+    let cur = self.next.take()?;
+    self.next = cur.parent();
+    Some(cur)
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StripPrefixError(());
+
+impl fmt::Display for StripPrefixError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str("prefix not found")
+  }
+}
+
+impl std::error::Error for StripPrefixError {}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use std::path::Path;
+
+  use super::*;
+
+  fn p(s: &str) -> &StrPath {
+    StrPath::new(s)
+  }
+
+  /// Assert that two paths agree on a set of properties with `std::path::Path`.
+  fn agrees_with_std(s: &str) {
+    let our = p(s);
+    let std_p = Path::new(s);
+    assert_eq!(
+      our.parent().map(StrPath::as_str),
+      std_p.parent().and_then(|p| p.to_str()),
+      "parent mismatch for {s:?}",
+    );
+    assert_eq!(
+      our.file_name(),
+      std_p.file_name().and_then(|n| n.to_str()),
+      "file_name mismatch for {s:?}",
+    );
+    assert_eq!(
+      our.file_stem(),
+      std_p.file_stem().and_then(|n| n.to_str()),
+      "file_stem mismatch for {s:?}",
+    );
+    assert_eq!(
+      our.extension(),
+      std_p.extension().and_then(|n| n.to_str()),
+      "extension mismatch for {s:?}",
+    );
+    assert_eq!(
+      our.is_absolute(),
+      std_p.is_absolute(),
+      "is_absolute mismatch for {s:?}",
+    );
+  }
+
+  #[test]
+  fn matches_std_path_basics() {
+    let inputs = [
+      "/",
+      "/foo",
+      "/foo/bar",
+      "/foo/bar.js",
+      "/foo/bar.d.ts",
+      "/foo/.hidden",
+      "/foo/..",
+      "/foo/.",
+      "/foo/bar/",
+      "foo",
+      "foo/bar",
+      "./foo",
+      "../foo",
+      "",
+      ".",
+      "..",
+    ];
+    for s in inputs {
+      agrees_with_std(s);
+    }
+  }
+
+  #[test]
+  #[cfg(windows)]
+  fn matches_std_path_windows() {
+    let inputs = [
+      r"C:",
+      r"C:\",
+      r"C:\foo",
+      r"C:\foo\bar.js",
+      r"C:/foo/bar.js",
+      r"\\server\share",
+      r"\\server\share\path\file.js",
+      r"\\?\C:\foo\bar",
+    ];
+    for s in inputs {
+      agrees_with_std(s);
+    }
+  }
+
+  #[test]
+  fn join_basic() {
+    assert_eq!(
+      p("/foo").join("bar").as_str(),
+      &format!("/foo{MAIN_SEPARATOR}bar")
+    );
+    // Trailing separator preserved (no double separator).
+    assert_eq!(p("/foo/").join("bar").as_str(), "/foo/bar");
+    // Absolute `other` replaces base.
+    assert_eq!(p("/foo").join("/bar").as_str(), "/bar");
+    // Empty base.
+    assert_eq!(p("").join("bar").as_str(), "bar");
+  }
+
+  #[test]
+  fn pop_and_parent() {
+    let mut buf = StrPathBuf::from("/foo/bar");
+    assert!(buf.pop());
+    assert_eq!(buf.as_str(), "/foo");
+    assert!(buf.pop());
+    assert_eq!(buf.as_str(), "/");
+    assert!(!buf.pop());
+  }
+
+  #[test]
+  fn starts_with_component_aware() {
+    assert!(p("/foo/bar").starts_with("/foo"));
+    assert!(!p("/foobar").starts_with("/foo"));
+    assert!(p("/foo/bar/baz").starts_with("/foo/bar"));
+  }
+
+  #[test]
+  fn strip_prefix_returns_tail() {
+    let tail = p("/foo/bar/baz").strip_prefix("/foo").unwrap();
+    assert_eq!(tail.as_str(), "bar/baz");
+  }
+
+  #[test]
+  fn set_extension_works() {
+    let mut buf = StrPathBuf::from("/foo/bar.js");
+    assert!(buf.set_extension("ts"));
+    assert_eq!(buf.as_str(), "/foo/bar.ts");
+    assert!(buf.set_extension(""));
+    assert_eq!(buf.as_str(), "/foo/bar");
+  }
+
+  #[test]
+  fn ancestors_walk_up() {
+    let chain: Vec<&str> = p("/foo/bar/baz").ancestors().map(StrPath::as_str).collect();
+    assert_eq!(chain, vec!["/foo/bar/baz", "/foo/bar", "/foo", "/"]);
+  }
+
+  #[test]
+  fn box_path_roundtrip() {
+    let buf = StrPathBuf::from("/foo/bar");
+    let boxed: Box<StrPath> = buf.into_boxed_path();
+    assert_eq!(boxed.as_str(), "/foo/bar");
+  }
+}

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -1,5 +1,7 @@
 //! <https://github.com/webpack/enhanced-resolve/blob/main/test/alias.test.js>
 
+use std::path::PathBuf;
+
 use super::JoinExt;
 use crate::{AliasValue, Resolution, ResolveContext, ResolveError, ResolveOptions, Resolver};
 
@@ -300,8 +302,18 @@ async fn alias_fragment() {
       )],
       ..ResolveOptions::default()
     });
-    let resolved_path = resolver.resolve(&f, "foo").await.map(|r| r.full_path());
-    assert_eq!(resolved_path, Ok(expected), "{comment} {request}");
+    // PathBuf comparison: `expected` is hand-formatted with `/` while the
+    // resolver emits `\\` at boundaries on Windows; component-wise eq
+    // matches what `PathBuf::eq` did pre-refactor.
+    let resolved_path = resolver
+      .resolve(&f, "foo")
+      .await
+      .map(|r| PathBuf::from(r.full_path()));
+    assert_eq!(
+      resolved_path,
+      Ok(PathBuf::from(expected)),
+      "{comment} {request}"
+    );
   }
 }
 

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -1,20 +1,15 @@
 //! <https://github.com/webpack/enhanced-resolve/blob/main/test/alias.test.js>
 
-use std::path::Path;
-
-use normalize_path::NormalizePath;
-
+use super::JoinExt;
 use crate::{AliasValue, Resolution, ResolveContext, ResolveError, ResolveOptions, Resolver};
 
 #[tokio::test]
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 async fn alias() {
-  use std::path::{Path, PathBuf};
-
   use super::memory_fs::MemoryFS;
   use crate::ResolverGeneric;
 
-  let f = Path::new("/");
+  let f = "/";
 
   let file_system = MemoryFS::new(&[
     ("/a/index", ""),
@@ -120,14 +115,14 @@ async fn alias() {
     let resolved_path = resolver.resolve(f, request).await.map(|r| r.full_path());
     assert_eq!(
       resolved_path,
-      Ok(PathBuf::from(expected)),
+      Ok(expected.to_string()),
       "{comment} {request}"
     );
   }
 
   #[rustfmt::skip]
     let ignore = [
-        ("should resolve an ignore module", "ignored", ResolveError::Ignored(f.join("ignored")))
+        ("should resolve an ignore module", "ignored", ResolveError::Ignored(f.path_join("ignored")))
     ];
 
   for (comment, request, expected) in ignore {
@@ -151,17 +146,16 @@ async fn infinite_recursion() {
   assert_eq!(resolution, Err(ResolveError::Recursion));
 }
 
-fn check_slash(path: &Path) {
-  let s = path.to_str().expect("path should be UTF-8").to_string();
+fn check_slash(path: &str) {
   #[cfg(target_os = "windows")]
   {
-    assert!(!s.contains('/'), "{s}");
-    assert!(s.contains('\\'), "{s}");
+    assert!(!path.contains('/'), "{path}");
+    assert!(path.contains('\\'), "{path}");
   }
   #[cfg(not(target_os = "windows"))]
   {
-    assert!(s.contains('/'), "{s}");
-    assert!(!s.contains('\\'), "{s}");
+    assert!(path.contains('/'), "{path}");
+    assert!(!path.contains('\\'), "{path}");
   }
 }
 
@@ -169,15 +163,12 @@ fn check_slash(path: &Path) {
 async fn absolute_path() {
   let f = super::fixture();
   let resolver = Resolver::new(ResolveOptions {
-    alias: vec![(
-      f.join("foo").to_str().unwrap().to_string(),
-      vec![AliasValue::Ignore],
-    )],
-    modules: vec![f.clone().to_str().unwrap().to_string()],
+    alias: vec![(f.path_join("foo"), vec![AliasValue::Ignore])],
+    modules: vec![f.clone()],
     ..ResolveOptions::default()
   });
   let resolution = resolver.resolve(&f, "foo/index").await;
-  assert_eq!(resolution, Err(ResolveError::Ignored(f.join("foo"))));
+  assert_eq!(resolution, Err(ResolveError::Ignored(f.path_join("foo"))));
 }
 
 #[tokio::test]
@@ -186,9 +177,7 @@ async fn system_path() {
   let resolver = Resolver::new(ResolveOptions {
     alias: vec![(
       "@app".into(),
-      vec![AliasValue::from(
-        f.join("alias").to_str().expect("path should be UTF-8"),
-      )],
+      vec![AliasValue::from(f.path_join("alias").as_str())],
     )],
     ..ResolveOptions::default()
   });
@@ -199,21 +188,24 @@ async fn system_path() {
     let path = resolver
       .resolve(&f, specifier)
       .await
-      .map(Resolution::into_path_buf)
+      .map(Resolution::into_path)
       .unwrap();
-    assert_eq!(path, f.join("alias/files/a.js"));
+    assert_eq!(path, f.path_join("alias/files/a.js"));
     check_slash(&path);
   }
 }
 
 #[tokio::test]
 async fn alias_is_full_path() {
+  use std::path::Path;
+
+  use normalize_path::NormalizePath;
+
   let f = super::fixture();
-  let dir = f.join("foo");
-  let dir_str = dir.to_str().expect("path should be UTF-8").to_string();
+  let dir = f.path_join("foo");
 
   let resolver = Resolver::new(ResolveOptions {
-    alias: vec![("@".into(), vec![AliasValue::Path(dir_str.clone())])],
+    alias: vec![("@".into(), vec![AliasValue::Path(dir.clone())])],
     ..ResolveOptions::default()
   });
 
@@ -225,27 +217,29 @@ async fn alias_is_full_path() {
     // specifier has multiple `/` for reasons we'll never know
     "@////index".to_string(),
     // specifier is a full path
-    dir_str,
+    dir.clone(),
   ];
 
   for specifier in specifiers {
     let resolution = resolver.resolve_with_context(&f, &specifier, &mut ctx);
     assert_eq!(
       resolution.await.map(|r| r.full_path()),
-      Ok(dir.join("index.js"))
+      Ok(dir.path_join("index.js"))
     );
   }
 
   for path in ctx.file_dependencies {
-    assert_eq!(path, path.normalize(), "{path:?}");
+    let as_path = Path::new(&path);
+    assert_eq!(as_path, as_path.normalize(), "{path:?}");
     check_slash(&path);
   }
 
   for path in ctx.missing_dependencies {
-    assert_eq!(path, path.normalize(), "{path:?}");
+    let as_path = Path::new(&path);
+    assert_eq!(as_path, as_path.normalize(), "{path:?}");
     check_slash(&path);
-    if let Some(path) = path.parent() {
-      assert!(!path.is_file(), "{path:?} must not be a file");
+    if let Some(parent) = as_path.parent() {
+      assert!(!parent.is_file(), "{parent:?} must not be a file");
     }
   }
 }
@@ -258,11 +252,7 @@ async fn all_alias_values_are_not_found() {
     alias: vec![(
       "m1".to_string(),
       vec![AliasValue::Path(
-        f.join("node_modules")
-          .join("m2")
-          .to_str()
-          .expect("path should be UTF-8")
-          .to_string(),
+        f.path_join("node_modules").path_join("m2"),
       )],
     )],
     ..ResolveOptions::default()
@@ -288,17 +278,17 @@ async fn alias_fragment() {
     (
       "handle fragment edge case (no fragment)",
       "./no#fragment/#/#",
-      f.join("no#fragment/#/#.js"),
+      f.path_join("no#fragment/#/#.js"),
     ),
     (
       "handle fragment edge case (fragment)",
       "./no#fragment/#/",
-      f.join("no.js#fragment/#/"),
+      format!("{}/no.js#fragment/#/", f),
     ),
     (
       "handle fragment escaping",
       "./no\0#fragment/\0#/\0##fragment",
-      f.join("no#fragment/#/#.js#fragment"),
+      f.path_join("no#fragment/#/#.js#fragment"),
     ),
   ];
 
@@ -319,17 +309,9 @@ async fn alias_fragment() {
 async fn alias_try_fragment_as_path() {
   let f = super::fixture();
   let resolver = Resolver::new(ResolveOptions {
-    alias: vec![(
-      "#".to_string(),
-      vec![AliasValue::Path(
-        f.join("#")
-          .to_str()
-          .expect("path should be UTF-8")
-          .to_string(),
-      )],
-    )],
+    alias: vec![("#".to_string(), vec![AliasValue::Path(f.path_join("#"))])],
     ..ResolveOptions::default()
   });
   let resolution = resolver.resolve(&f, "#/a").await.map(|r| r.full_path());
-  assert_eq!(resolution, Ok(f.join("#").join("a.js")));
+  assert_eq!(resolution, Ok(f.path_join("#").path_join("a.js")));
 }

--- a/src/tests/browser_field.rs
+++ b/src/tests/browser_field.rs
@@ -1,10 +1,11 @@
 //! <https://github.com/webpack/enhanced-resolve/blob/main/test/browserField.test.js>
 
+use super::JoinExt;
 use crate::{AliasValue, ResolveError, ResolveOptions, Resolver};
 
 #[tokio::test]
 async fn ignore() {
-  let f = super::fixture().join("browser-module");
+  let f = super::fixture().path_join("browser-module");
 
   let resolver = Resolver::new(ResolveOptions {
     alias_fields: vec![
@@ -18,10 +19,10 @@ async fn ignore() {
 
   #[rustfmt::skip]
     let data = [
-        (f.clone(), "./lib/ignore", f.join("lib/ignore.js")),
-        (f.clone(), "./lib/ignore.js", f.join("lib/ignore.js")),
-        (f.join("lib"), "./ignore", f.join("lib/ignore.js")),
-        (f.join("lib"), "./ignore.js", f.join("lib/ignore.js")),
+        (f.clone(), "./lib/ignore", f.path_join("lib/ignore.js")),
+        (f.clone(), "./lib/ignore.js", f.path_join("lib/ignore.js")),
+        (f.path_join("lib"), "./ignore", f.path_join("lib/ignore.js")),
+        (f.path_join("lib"), "./ignore.js", f.path_join("lib/ignore.js")),
     ];
 
   for (path, request, expected) in data {
@@ -33,7 +34,7 @@ async fn ignore() {
 
 #[tokio::test]
 async fn shared_resolvers() {
-  let f = super::fixture().join("browser-module");
+  let f = super::fixture().path_join("browser-module");
 
   let resolver1 = Resolver::new(ResolveOptions {
     alias_fields: vec![vec![
@@ -47,7 +48,7 @@ async fn shared_resolvers() {
     .resolve(&f, "./lib/main1.js")
     .await
     .map(|r| r.full_path());
-  assert_eq!(resolved_path, Ok(f.join("lib/main.js")));
+  assert_eq!(resolved_path, Ok(f.path_join("lib/main.js")));
 
   let resolver2 = resolver1.clone_with_options(ResolveOptions {
     alias_fields: vec![vec!["innerBrowser2".into(), "browser".into()]],
@@ -57,12 +58,12 @@ async fn shared_resolvers() {
     .resolve(&f, "./lib/main2.js")
     .await
     .map(|r| r.full_path());
-  assert_eq!(resolved_path, Ok(f.join("./lib/replaced.js")));
+  assert_eq!(resolved_path, Ok(f.path_join("./lib/replaced.js")));
 }
 
 #[tokio::test]
 async fn replace_file() {
-  let f = super::fixture().join("browser-module");
+  let f = super::fixture().path_join("browser-module");
 
   let resolver = Resolver::new(ResolveOptions {
     alias_fields: vec![
@@ -78,21 +79,21 @@ async fn replace_file() {
 
   #[rustfmt::skip]
     let data = [
-        ("should replace a file 1", f.clone(), "./lib/replaced", f.join("lib/browser.js")),
-        ("should replace a file 2", f.clone(), "./lib/replaced.js", f.join("lib/browser.js")),
-        ("should replace a file 3", f.join("lib"), "./replaced", f.join("lib/browser.js")),
-        ("should replace a file 4", f.join("lib"), "./replaced.js", f.join("lib/browser.js")),
-        ("should replace a module with a file 1", f.clone(), "module-a", f.join("browser/module-a.js")),
-        ("should replace a module with a file 2", f.join("lib"), "module-a", f.join("browser/module-a.js")),
-        ("should replace a module with a module 1", f.clone(), "module-b", f.join("node_modules/module-c.js")),
-        ("should replace a module with a module 2", f.join("lib"), "module-b", f.join("node_modules/module-c.js")),
-        ("should resolve in nested property 1", f.clone(), "./lib/main1.js", f.join("lib/main.js")),
-        ("should resolve in nested property 2", f.clone(), "./lib/main2.js", f.join("lib/browser.js")),
-        ("should check only alias field properties", f.clone(), "./toString", f.join("lib/toString.js")),
+        ("should replace a file 1", f.clone(), "./lib/replaced", f.path_join("lib/browser.js")),
+        ("should replace a file 2", f.clone(), "./lib/replaced.js", f.path_join("lib/browser.js")),
+        ("should replace a file 3", f.path_join("lib"), "./replaced", f.path_join("lib/browser.js")),
+        ("should replace a file 4", f.path_join("lib"), "./replaced.js", f.path_join("lib/browser.js")),
+        ("should replace a module with a file 1", f.clone(), "module-a", f.path_join("browser/module-a.js")),
+        ("should replace a module with a file 2", f.path_join("lib"), "module-a", f.path_join("browser/module-a.js")),
+        ("should replace a module with a module 1", f.clone(), "module-b", f.path_join("node_modules/module-c.js")),
+        ("should replace a module with a module 2", f.path_join("lib"), "module-b", f.path_join("node_modules/module-c.js")),
+        ("should resolve in nested property 1", f.clone(), "./lib/main1.js", f.path_join("lib/main.js")),
+        ("should resolve in nested property 2", f.clone(), "./lib/main2.js", f.path_join("lib/browser.js")),
+        ("should check only alias field properties", f.clone(), "./toString", f.path_join("lib/toString.js")),
         // not part of enhanced-resolve
-        ("recursion", f.clone(), "module-c", f.join("node_modules/module-c.js")),
-        ("resolve self 1", f.clone(), "./lib/main.js", f.join("lib/main.js")),
-        ("resolve self 2", f.clone(), "./main.js", f.join("lib/main.js")),
+        ("recursion", f.clone(), "module-c", f.path_join("node_modules/module-c.js")),
+        ("resolve self 1", f.clone(), "./lib/main.js", f.path_join("lib/main.js")),
+        ("resolve self 2", f.clone(), "./main.js", f.path_join("lib/main.js")),
     ];
 
   for (comment, path, request, expected) in data {
@@ -141,8 +142,8 @@ async fn broken() {
   #[rustfmt::skip]
     let data = [
         // The browser field string value should be ignored
-        (f.clone(), "browser-module-broken", Ok(f.join("node_modules/browser-module-broken/main.js"))),
-        (f.join("browser-module"), "./number", Err(ResolveError::NotFound("./number".into()))),
+        (f.clone(), "browser-module-broken", Ok(f.path_join("node_modules/browser-module-broken/main.js"))),
+        (f.path_join("browser-module"), "./number", Err(ResolveError::NotFound("./number".into()))),
     ];
 
   for (path, request, expected) in data {
@@ -162,27 +163,25 @@ async fn crypto_js() {
     alias_fields: vec![vec!["browser".into()]],
     fallback: vec![(
       "crypto".into(),
-      vec![AliasValue::from(
-        f.join("lib.js").to_str().expect("path should be UTF-8"),
-      )],
+      vec![AliasValue::from(f.path_join("lib.js").as_str())],
     )],
     ..ResolveOptions::default()
   });
 
   let resolved_path = resolver
-    .resolve(f.join("crypto-js"), "crypto")
+    .resolve(f.path_join("crypto-js"), "crypto")
     .await
     .map(|r| r.full_path());
   assert_eq!(
     resolved_path,
-    Err(ResolveError::Ignored(f.join("crypto-js")))
+    Err(ResolveError::Ignored(f.path_join("crypto-js")))
   );
 }
 
 // https://github.com/webpack/webpack/blob/87660921808566ef3b8796f8df61bd79fc026108/test/cases/resolving/browser-field/index.js#L40-L43
 #[tokio::test]
 async fn recursive() {
-  let f = super::fixture().join("browser-module");
+  let f = super::fixture().path_join("browser-module");
 
   let resolver = Resolver::new(ResolveOptions {
     alias_fields: vec![vec!["browser".into()]],
@@ -220,7 +219,7 @@ async fn recursive() {
 
 #[tokio::test]
 async fn with_query() {
-  let f = super::fixture().join("browser-module");
+  let f = super::fixture().path_join("browser-module");
 
   let resolver = Resolver::new(ResolveOptions {
     alias_fields: vec![vec!["browser".into()]],
@@ -228,5 +227,8 @@ async fn with_query() {
   });
 
   let resolved_path = resolver.resolve(&f, "./foo").await.map(|r| r.full_path());
-  assert_eq!(resolved_path, Ok(f.join("lib").join("browser.js?query")));
+  assert_eq!(
+    resolved_path,
+    Ok(f.path_join("lib").path_join("browser.js?query"))
+  );
 }

--- a/src/tests/builtins.rs
+++ b/src/tests/builtins.rs
@@ -1,10 +1,9 @@
-use std::path::Path;
-
+use super::JoinExt;
 use crate::{ResolveError, ResolveOptions, Resolver};
 
 #[tokio::test]
 async fn builtins_off() {
-  let f = Path::new("/");
+  let f = "/";
   let resolver = Resolver::default();
   let resolved_path = resolver.resolve(f, "zlib").await.map(|r| r.full_path());
   assert_eq!(resolved_path, Err(ResolveError::NotFound("zlib".into())));
@@ -12,7 +11,7 @@ async fn builtins_off() {
 
 #[tokio::test]
 async fn builtins() {
-  let f = Path::new("/");
+  let f = "/";
 
   let resolver = Resolver::new(ResolveOptions::default().with_builtin_modules(true));
 
@@ -96,7 +95,7 @@ async fn builtins() {
 
 #[tokio::test]
 async fn fail() {
-  let f = Path::new("/");
+  let f = "/";
   let resolver = Resolver::new(ResolveOptions::default().with_builtin_modules(true));
   let request = "xxx";
   let resolved_path = resolver.resolve(f, request).await;
@@ -106,7 +105,7 @@ async fn fail() {
 
 #[tokio::test]
 async fn imports() {
-  let f = super::fixture().join("builtins");
+  let f = super::fixture().path_join("builtins");
   let resolver = Resolver::new(ResolveOptions {
     builtin_modules: true,
     condition_names: vec!["node".into()],

--- a/src/tests/dependencies.rs
+++ b/src/tests/dependencies.rs
@@ -2,8 +2,6 @@
 
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 mod windows {
-  use std::path::PathBuf;
-
   use rustc_hash::FxHashSet;
 
   use super::super::memory_fs::MemoryFS;
@@ -98,15 +96,14 @@ mod windows {
 
     for (name, context, request, result, file_dependencies, missing_dependencies) in data {
       let mut ctx = ResolveContext::default();
-      let path = PathBuf::from(context);
       let resolved = resolver
-        .resolve_with_context(path, request, &mut ctx)
+        .resolve_with_context(context, request, &mut ctx)
         .await
         .map(|r| r.full_path());
-      assert_eq!(resolved, Ok(PathBuf::from(result)));
-      let file_dependencies = FxHashSet::from_iter(file_dependencies.iter().map(PathBuf::from));
+      assert_eq!(resolved, Ok(result.to_string()));
+      let file_dependencies = FxHashSet::from_iter(file_dependencies.iter().map(|s| s.to_string()));
       let missing_dependencies =
-        FxHashSet::from_iter(missing_dependencies.iter().map(PathBuf::from));
+        FxHashSet::from_iter(missing_dependencies.iter().map(|s| s.to_string()));
       assert_eq!(ctx.file_dependencies, file_dependencies, "{name}");
       assert_eq!(ctx.missing_dependencies, missing_dependencies, "{name}");
     }

--- a/src/tests/exports_field.rs
+++ b/src/tests/exports_field.rs
@@ -2,19 +2,18 @@
 //!
 //! The huge exports field test cases are at the bottom of this file.
 
-use std::path::Path;
-
 use simd_json::json;
 
+use super::JoinExt;
 use crate::{package_json, Ctx, PathUtil, ResolveError, ResolveOptions, Resolver};
 
 #[tokio::test]
 async fn test_simple() {
-  let f = super::fixture().join("exports-field");
-  let f2 = super::fixture().join("exports-field2");
-  let f4 = super::fixture().join("exports-field-error");
-  let f5 = super::fixture().join("imports-exports-wildcard");
-  let f6 = super::fixture().join("export-query");
+  let f = super::fixture().path_join("exports-field");
+  let f2 = super::fixture().path_join("exports-field2");
+  let f4 = super::fixture().path_join("exports-field-error");
+  let f5 = super::fixture().path_join("imports-exports-wildcard");
+  let f6 = super::fixture().path_join("export-query");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -25,31 +24,31 @@ async fn test_simple() {
 
   #[rustfmt::skip]
     let pass = [
-        ("resolve root using exports field, not a main field", f.clone(), "exports-field", f.join("node_modules/exports-field/x.js")),
-        ("resolver should respect condition names", f.clone(), "exports-field/dist/main.js", f.join("node_modules/exports-field/lib/lib2/main.js")),
+        ("resolve root using exports field, not a main field", f.clone(), "exports-field", f.path_join("node_modules/exports-field/x.js")),
+        ("resolver should respect condition names", f.clone(), "exports-field/dist/main.js", f.path_join("node_modules/exports-field/lib/lib2/main.js")),
         // enhanced_resolve behaves differently to node.js. enhanced_resolve fallbacks when an
         // array item is unresolved, where as node.js fallbacks when an array has an
         // InvalidPackageTarget error.
-        // ("resolver should respect fallback", f2.clone(), "exports-field/dist/browser.js", f2.join("node_modules/exports-field/lib/browser.js")),
+        // ("resolver should respect fallback", f2.clone(), "exports-field/dist/browser.js", f2.path_join("node_modules/exports-field/lib/browser.js")),
         // The following two tests require fallback from array values, the path is changed here to
         // only test query and fragment.
-        ("resolver should respect query parameters #1", f2.clone(), "exports-field/dist/main.js?foo", f2.join("node_modules/exports-field/lib/lib2/main.js?foo")),
-        ("resolver should respect fragment parameters #1", f2.clone(), "exports-field/dist/main.js#foo", f2.join("node_modules/exports-field/lib/lib2/main.js#foo")),
-        ("relative path should work, if relative path as request is used", f.clone(), "./node_modules/exports-field/lib/main.js", f.join("node_modules/exports-field/lib/main.js")),
-        ("self-resolving root", f.clone(), "@exports-field/core", f.join("a.js")),
-        ("should resolve with wildcard pattern #1", f5.clone(), "m/features/f.js", f5.join("node_modules/m/src/features/f.js")),
-        ("should resolve with wildcard pattern #2", f5.clone(), "m/features/y/y.js", f5.join("node_modules/m/src/features/y/y.js")),
-        ("should resolve with wildcard pattern #3", f5.clone(), "m/features-no-ext/y/y.js", f5.join("node_modules/m/src/features/y/y.js")),
-        ("should resolve with wildcard pattern #4", f5.clone(), "m/middle/nested/f.js", f5.join("node_modules/m/src/middle/nested/f.js")),
-        ("should resolve with wildcard pattern #5", f5.clone(), "m/middle-1/nested/f.js", f5.join("node_modules/m/src/middle-1/nested/f.js")),
-        ("should resolve with wildcard pattern #6", f5.clone(), "m/middle-2/nested/f.js", f5.join("node_modules/m/src/middle-2/nested/f.js")),
-        ("should resolve with wildcard pattern #7", f5.clone(), "m/middle-3/nested/f", f5.join("node_modules/m/src/middle-3/nested/f/nested/f.js")),
-        ("should resolve with wildcard pattern #8", f5.clone(), "m/middle-4/f/nested", f5.join("node_modules/m/src/middle-4/f/f.js")),
-        ("should resolve with wildcard pattern #9", f5.clone(), "m/middle-5/f$/$", f5.join("node_modules/m/src/middle-5/f$/$.js")),
-        ("should resolve with query string #10", f6.clone(), "export-query/add", f6.join("add.js?query1?query2")),
+        ("resolver should respect query parameters #1", f2.clone(), "exports-field/dist/main.js?foo", f2.path_join("node_modules/exports-field/lib/lib2/main.js?foo")),
+        ("resolver should respect fragment parameters #1", f2.clone(), "exports-field/dist/main.js#foo", f2.path_join("node_modules/exports-field/lib/lib2/main.js#foo")),
+        ("relative path should work, if relative path as request is used", f.clone(), "./node_modules/exports-field/lib/main.js", f.path_join("node_modules/exports-field/lib/main.js")),
+        ("self-resolving root", f.clone(), "@exports-field/core", f.path_join("a.js")),
+        ("should resolve with wildcard pattern #1", f5.clone(), "m/features/f.js", f5.path_join("node_modules/m/src/features/f.js")),
+        ("should resolve with wildcard pattern #2", f5.clone(), "m/features/y/y.js", f5.path_join("node_modules/m/src/features/y/y.js")),
+        ("should resolve with wildcard pattern #3", f5.clone(), "m/features-no-ext/y/y.js", f5.path_join("node_modules/m/src/features/y/y.js")),
+        ("should resolve with wildcard pattern #4", f5.clone(), "m/middle/nested/f.js", f5.path_join("node_modules/m/src/middle/nested/f.js")),
+        ("should resolve with wildcard pattern #5", f5.clone(), "m/middle-1/nested/f.js", f5.path_join("node_modules/m/src/middle-1/nested/f.js")),
+        ("should resolve with wildcard pattern #6", f5.clone(), "m/middle-2/nested/f.js", f5.path_join("node_modules/m/src/middle-2/nested/f.js")),
+        ("should resolve with wildcard pattern #7", f5.clone(), "m/middle-3/nested/f", f5.path_join("node_modules/m/src/middle-3/nested/f/nested/f.js")),
+        ("should resolve with wildcard pattern #8", f5.clone(), "m/middle-4/f/nested", f5.path_join("node_modules/m/src/middle-4/f/f.js")),
+        ("should resolve with wildcard pattern #9", f5.clone(), "m/middle-5/f$/$", f5.path_join("node_modules/m/src/middle-5/f$/$.js")),
+        ("should resolve with query string #10", f6.clone(), "export-query/add", f6.path_join("add.js?query1?query2")),
         // Sadly we can not use real `minus.js?query` and `equal.js?query` file due to Windows: invalid path
-        ("should resolve with query string #10", f6.clone(), "export-query/minus", f6.join("minus.js?query?extra")),
-        ("should resolve with query string #10", f6.clone(), "export-query/equal", f6.join("equal.js?query")),
+        ("should resolve with query string #10", f6.clone(), "export-query/minus", f6.path_join("minus.js?query?extra")),
+        ("should resolve with query string #10", f6.clone(), "export-query/equal", f6.path_join("equal.js?query")),
     ];
 
   // Not needed or snapshot:
@@ -63,14 +62,14 @@ async fn test_simple() {
     assert_eq!(resolved_path, Ok(expected), "{comment} {path:?} {request}");
   }
 
-  let p = f.join("node_modules/exports-field/package.json");
-  let p2 = f2.join("node_modules/exports-field/package.json");
-  let p4 = f4.join("node_modules/exports-field/package.json");
-  let p5 = f5.join("node_modules/m/package.json");
+  let p = f.path_join("node_modules/exports-field/package.json");
+  let p2 = f2.path_join("node_modules/exports-field/package.json");
+  let p4 = f4.path_join("node_modules/exports-field/package.json");
+  let p5 = f5.path_join("node_modules/m/package.json");
 
   #[rustfmt::skip]
     let fail = [
-        // ("throw error if extension not provided", f2.clone(), "exports-field/dist/main", ResolveError::NotFound(f2.join("node_modules/exports-field/lib/lib2/main"))),
+        // ("throw error if extension not provided", f2.clone(), "exports-field/dist/main", ResolveError::NotFound(f2.path_join("node_modules/exports-field/lib/lib2/main"))),
         ("resolver should respect query parameters #2. Direct matching", f2.clone(), "exports-field?foo", ResolveError::PackagePathNotExported("./?foo".into(), p2.clone())),
         ("resolver should respect fragment parameters #2. Direct matching", f2, "exports-field#foo", ResolveError::PackagePathNotExported("./#foo".into(), p2)),
         ("relative path should not work with exports field", f.clone(), "./node_modules/exports-field/dist/main.js", ResolveError::NotFound("./node_modules/exports-field/dist/main.js".into())),
@@ -81,7 +80,7 @@ async fn test_simple() {
         ("request ending with slash #2", f.clone(), "exports-field/dist/", ResolveError::PackagePathNotExported("./dist/".to_string(), p.clone())),
         ("request ending with slash #3", f.clone(), "exports-field/lib/", ResolveError::PackagePathNotExported("./lib/".to_string(), p)),
         ("should throw error if target is invalid", f4, "exports-field", ResolveError::InvalidPackageTarget("./a/../b/../../pack1/index.js".to_string(), ".".to_string(), p4)),
-        ("throw error if exports field is invalid", f.clone(), "invalid-exports-field", ResolveError::InvalidPackageConfig(f.join("node_modules/invalid-exports-field/package.json"))),
+        ("throw error if exports field is invalid", f.clone(), "invalid-exports-field", ResolveError::InvalidPackageConfig(f.path_join("node_modules/invalid-exports-field/package.json"))),
         ("should throw error if target is 'null'", f5, "m/features/internal/file.js", ResolveError::PackagePathNotExported("./features/internal/file.js".to_string(), p5)),
     ];
 
@@ -94,7 +93,7 @@ async fn test_simple() {
 // resolve using exports field, not a browser field #1
 #[tokio::test]
 async fn exports_not_browser_field1() {
-  let f = super::fixture().join("exports-field");
+  let f = super::fixture().path_join("exports-field");
 
   let resolver = Resolver::new(ResolveOptions {
     alias_fields: vec![vec!["browser".into()]],
@@ -109,14 +108,14 @@ async fn exports_not_browser_field1() {
     .map(|r| r.full_path());
   assert_eq!(
     resolved_path,
-    Ok(f.join("node_modules/exports-field/lib/lib2/main.js"))
+    Ok(f.path_join("node_modules/exports-field/lib/lib2/main.js"))
   );
 }
 
 // resolve using exports field and a browser alias field #2
 #[tokio::test]
 async fn exports_not_browser_field2() {
-  let f2 = super::fixture().join("exports-field2");
+  let f2 = super::fixture().path_join("exports-field2");
 
   let resolver = Resolver::new(ResolveOptions {
     alias_fields: vec![vec!["browser".into()]],
@@ -131,14 +130,14 @@ async fn exports_not_browser_field2() {
     .map(|r| r.full_path());
   assert_eq!(
     resolved_path,
-    Ok(f2.join("node_modules/exports-field/lib/browser.js"))
+    Ok(f2.path_join("node_modules/exports-field/lib/browser.js"))
   );
 }
 
 // should resolve extension without fullySpecified
 #[tokio::test]
 async fn extension_without_fully_specified() {
-  let f2 = super::fixture().join("exports-field2");
+  let f2 = super::fixture().path_join("exports-field2");
 
   let commonjs_resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -152,14 +151,14 @@ async fn extension_without_fully_specified() {
     .map(|r| r.full_path());
   assert_eq!(
     resolved_path,
-    Ok(f2.join("node_modules/exports-field/lib/lib2/main.js"))
+    Ok(f2.path_join("node_modules/exports-field/lib/lib2/main.js"))
   );
 }
 
 #[tokio::test]
 async fn field_name_path() {
-  let f2 = super::fixture().join("exports-field2");
-  let f3 = super::fixture().join("exports-field3");
+  let f2 = super::fixture().path_join("exports-field2");
+  let f3 = super::fixture().path_join("exports-field3");
 
   // field name path #1 #2 #3
   let exports_fields = [
@@ -187,7 +186,7 @@ async fn field_name_path() {
       .map(|r| r.full_path());
     assert_eq!(
       resolved_path,
-      Ok(f3.join("node_modules/exports-field/main.js"))
+      Ok(f3.path_join("node_modules/exports-field/main.js"))
     );
   }
 
@@ -204,7 +203,7 @@ async fn field_name_path() {
     .map(|r| r.full_path());
   assert_eq!(
     resolved_path,
-    Ok(f2.join("node_modules/exports-field/index.js"))
+    Ok(f2.path_join("node_modules/exports-field/index.js"))
   );
 
   // field name path #5
@@ -223,7 +222,7 @@ async fn field_name_path() {
     .map(|r| r.full_path());
   assert_eq!(
     resolved_path,
-    Ok(f3.join("node_modules/exports-field/index"))
+    Ok(f3.path_join("node_modules/exports-field/index"))
   );
 
   // non-compliant export targeting a directory
@@ -238,13 +237,13 @@ async fn field_name_path() {
     .map(|r| r.full_path());
   assert_eq!(
     resolved_path,
-    Ok(f3.join("node_modules/exports-field/src/index.js"))
+    Ok(f3.path_join("node_modules/exports-field/src/index.js"))
   );
 }
 
 #[tokio::test]
 async fn shared_resolvers() {
-  let f3 = super::fixture().join("exports-field3");
+  let f3 = super::fixture().path_join("exports-field3");
 
   let resolver1 = Resolver::new(ResolveOptions {
     exports_fields: vec![vec!["exportsField".into(), "exports".into()]],
@@ -257,7 +256,7 @@ async fn shared_resolvers() {
     .map(|r| r.full_path());
   assert_eq!(
     resolved_path,
-    Ok(f3.join("node_modules/exports-field/main.js"))
+    Ok(f3.path_join("node_modules/exports-field/main.js"))
   );
 
   let resolver2 = resolver1.clone_with_options(ResolveOptions {
@@ -271,13 +270,13 @@ async fn shared_resolvers() {
     .map(|r| r.full_path());
   assert_eq!(
     resolved_path,
-    Ok(f3.join("node_modules/exports-field/index"))
+    Ok(f3.path_join("node_modules/exports-field/index"))
   );
 }
 
 #[tokio::test]
 async fn extension_alias_1_2() {
-  let f = super::fixture().join("exports-field-and-extension-alias");
+  let f = super::fixture().path_join("exports-field-and-extension-alias");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -289,8 +288,8 @@ async fn extension_alias_1_2() {
 
   #[rustfmt::skip]
     let pass = [
-        ("should resolve with the `extensionAlias` option", f.clone(), "@org/pkg/string.js", f.join("node_modules/@org/pkg/dist/string.js")),
-        ("should resolve with the `extensionAlias` option #2", f.clone(), "pkg/string.js", f.join("node_modules/pkg/dist/string.js")),
+        ("should resolve with the `extensionAlias` option", f.clone(), "@org/pkg/string.js", f.path_join("node_modules/@org/pkg/dist/string.js")),
+        ("should resolve with the `extensionAlias` option #2", f.clone(), "pkg/string.js", f.path_join("node_modules/pkg/dist/string.js")),
     ];
 
   for (comment, path, request, expected) in pass {
@@ -304,7 +303,7 @@ async fn extension_alias_1_2() {
 
 #[tokio::test]
 async fn extension_alias_3() {
-  let f = super::fixture().join("exports-field-and-extension-alias");
+  let f = super::fixture().path_join("exports-field-and-extension-alias");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -325,7 +324,7 @@ async fn extension_alias_3() {
 
   #[rustfmt::skip]
     let pass = [
-        ("should resolve with the `extensionAlias` option #3", f.clone(), "pkg/string.js", f.join("node_modules/pkg/dist/string.js")),
+        ("should resolve with the `extensionAlias` option #3", f.clone(), "pkg/string.js", f.path_join("node_modules/pkg/dist/string.js")),
     ];
 
   for (comment, path, request, expected) in pass {
@@ -339,7 +338,7 @@ async fn extension_alias_3() {
 
 #[tokio::test]
 async fn extension_alias_throw_error() {
-  let f = super::fixture().join("exports-field-and-extension-alias");
+  let f = super::fixture().path_join("exports-field-and-extension-alias");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -353,7 +352,7 @@ async fn extension_alias_throw_error() {
     let fail = [
         // enhanced-resolve has two test cases that are exactly the same here
         // https://github.com/webpack/enhanced-resolve/blob/a998c7d218b7a9ec2461fc4fddd1ad5dd7687485/test/exportsField.test.js#L2976-L3024
-        ("should throw error with the `extensionAlias` option", f.clone(), "pkg/string.js", ResolveError::ExtensionAlias("string.js".into(), "string.ts".into(), f.join("node_modules/pkg/dist"))),
+        ("should throw error with the `extensionAlias` option", f.clone(), "pkg/string.js", ResolveError::ExtensionAlias("string.js".into(), "string.ts".into(), f.path_join("node_modules/pkg/dist"))),
         // TODO: The error is PackagePathNotExported in enhanced-resolve
         // ("should throw error with the `extensionAlias` option", f.clone(), "pkg/string.js", ResolveError::PackagePathNotExported("node_modules/pkg/dist/string.ts".to_string())),
     ];
@@ -2603,14 +2602,9 @@ async fn test_cases() {
         .collect::<Vec<_>>(),
       ..ResolveOptions::default()
     })
-    .package_exports_resolve(
-      Path::new(""),
-      case.request,
-      &case.exports_field,
-      &mut Ctx::default(),
-    )
+    .package_exports_resolve("", case.request, &case.exports_field, &mut Ctx::default())
     .await
-    .map(|p| p.map(|p| p.to_path_buf()));
+    .map(|p| p.map(|p| p.path().to_string()));
     if let Some(expect) = case.expect {
       if expect.is_empty() {
         assert!(
@@ -2621,12 +2615,7 @@ async fn test_cases() {
         );
       } else {
         for expect in expect {
-          assert_eq!(
-            resolved,
-            Ok(Some(Path::new(expect).normalize())),
-            "{}",
-            &case.name
-          );
+          assert_eq!(resolved, Ok(Some(expect.normalize())), "{}", &case.name);
         }
       }
     } else {

--- a/src/tests/extension_alias.rs
+++ b/src/tests/extension_alias.rs
@@ -1,10 +1,11 @@
 //! <https://github.com/webpack/enhanced-resolve/blob/main/test/extension-alias.test.js>
 
+use super::JoinExt;
 use crate::{ResolveError, ResolveOptions, Resolver};
 
 #[tokio::test]
 async fn extension_alias() {
-  let f = super::fixture().join("extension-alias");
+  let f = super::fixture().path_join("extension-alias");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -18,10 +19,10 @@ async fn extension_alias() {
 
   #[rustfmt::skip]
     let pass = [
-        ("should alias fully specified file", f.clone(), "./index.js", f.join("index.ts")),
-        ("should alias fully specified file when there are two alternatives", f.clone(), "./dir/index.js", f.join("dir/index.ts")),
-        ("should also allow the second alternative", f.clone(), "./dir2/index.js", f.join("dir2/index.js")),
-        ("should support alias option without an array", f.clone(), "./dir2/index.mjs", f.join("dir2/index.mts")),
+        ("should alias fully specified file", f.clone(), "./index.js", f.path_join("index.ts")),
+        ("should alias fully specified file when there are two alternatives", f.clone(), "./dir/index.js", f.path_join("dir/index.ts")),
+        ("should also allow the second alternative", f.clone(), "./dir2/index.js", f.path_join("dir2/index.js")),
+        ("should support alias option without an array", f.clone(), "./dir2/index.mjs", f.path_join("dir2/index.mts")),
     ];
 
   for (comment, path, request, expected) in pass {
@@ -41,7 +42,7 @@ async fn extension_alias() {
 // should not apply extension alias to extensions or mainFiles field
 #[tokio::test]
 async fn not_apply_to_extension_nor_main_files() {
-  let f = super::fixture().join("extension-alias");
+  let f = super::fixture().path_join("extension-alias");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -61,7 +62,7 @@ async fn not_apply_to_extension_nor_main_files() {
       .resolve(&path, request)
       .await
       .map(|r| r.full_path());
-    let expected = f.join(expected);
+    let expected = f.path_join(expected);
     assert_eq!(resolved_path, Ok(expected), "{comment} {path:?} {request}");
   }
 }

--- a/src/tests/extensions.rs
+++ b/src/tests/extensions.rs
@@ -2,11 +2,12 @@
 
 use rustc_hash::FxHashSet;
 
+use super::JoinExt;
 use crate::{EnforceExtension, Resolution, ResolveContext, ResolveError, ResolveOptions, Resolver};
 
 #[tokio::test]
 async fn extensions() {
-  let f = super::fixture().join("extensions");
+  let f = super::fixture().path_join("extensions");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".ts".into(), ".js".into()],
@@ -25,7 +26,7 @@ async fn extensions() {
 
   for (comment, request, expected_path) in pass {
     let resolved_path = resolver.resolve(&f, request).await.map(|r| r.full_path());
-    let expected = f.join(expected_path);
+    let expected = f.path_join(expected_path);
     assert_eq!(
       resolved_path,
       Ok(expected),
@@ -48,7 +49,7 @@ async fn extensions() {
 // should default enforceExtension to true when extensions includes an empty string
 #[tokio::test]
 async fn default_enforce_extension() {
-  let f = super::fixture().join("extensions");
+  let f = super::fixture().path_join("extensions");
 
   let mut ctx = ResolveContext::default();
   let resolved = Resolver::new(ResolveOptions {
@@ -59,12 +60,12 @@ async fn default_enforce_extension() {
   .await;
 
   assert_eq!(
-    resolved.map(Resolution::into_path_buf),
-    Ok(f.join("foo.ts"))
+    resolved.map(Resolution::into_path),
+    Ok(f.path_join("foo.ts"))
   );
   assert_eq!(
     ctx.file_dependencies,
-    FxHashSet::from_iter([f.join("foo.ts"), f.join("package.json")])
+    FxHashSet::from_iter([f.path_join("foo.ts"), f.path_join("package.json")])
   );
   assert!(ctx.missing_dependencies.is_empty());
 }
@@ -72,7 +73,7 @@ async fn default_enforce_extension() {
 // should respect enforceExtension when extensions includes an empty string
 #[tokio::test]
 async fn respect_enforce_extension() {
-  let f = super::fixture().join("extensions");
+  let f = super::fixture().path_join("extensions");
 
   let mut ctx = ResolveContext::default();
   let resolved = Resolver::new(ResolveOptions {
@@ -84,22 +85,22 @@ async fn respect_enforce_extension() {
   .await;
 
   assert_eq!(
-    resolved.map(Resolution::into_path_buf),
-    Ok(f.join("foo.ts"))
+    resolved.map(Resolution::into_path),
+    Ok(f.path_join("foo.ts"))
   );
   assert_eq!(
     ctx.file_dependencies,
-    FxHashSet::from_iter([f.join("foo.ts"), f.join("package.json")])
+    FxHashSet::from_iter([f.path_join("foo.ts"), f.path_join("package.json")])
   );
   assert_eq!(
     ctx.missing_dependencies,
-    FxHashSet::from_iter([f.join("foo")])
+    FxHashSet::from_iter([f.path_join("foo")])
   );
 }
 
 #[tokio::test]
 async fn multi_dot_extension() {
-  let f = super::fixture().join("extensions");
+  let f = super::fixture().path_join("extensions");
 
   let resolver = Resolver::new(ResolveOptions {
     // Test for `.d.ts`, not part of enhanced-resolve.
@@ -115,7 +116,7 @@ async fn multi_dot_extension() {
 
   for (comment, request, expected_path) in pass {
     let resolved_path = resolver.resolve(&f, request).await.map(|r| r.full_path());
-    let expected = f.join(expected_path);
+    let expected = f.path_join(expected_path);
     assert_eq!(
       resolved_path,
       Ok(expected),

--- a/src/tests/fallback.rs
+++ b/src/tests/fallback.rs
@@ -1,11 +1,9 @@
 //! https://github.com/webpack/enhanced-resolve/blob/main/test/fallback.test.js
 
-use super::JoinExt;
-
 #[tokio::test]
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 async fn fallback() {
-  use super::memory_fs::MemoryFS;
+  use super::{memory_fs::MemoryFS, JoinExt};
   use crate::{AliasValue, ResolveError, ResolveOptions, ResolverGeneric};
 
   let f = "/";

--- a/src/tests/fallback.rs
+++ b/src/tests/fallback.rs
@@ -1,14 +1,14 @@
 //! https://github.com/webpack/enhanced-resolve/blob/main/test/fallback.test.js
 
+use super::JoinExt;
+
 #[tokio::test]
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 async fn fallback() {
-  use std::path::{Path, PathBuf};
-
   use super::memory_fs::MemoryFS;
   use crate::{AliasValue, ResolveError, ResolveOptions, ResolverGeneric};
 
-  let f = Path::new("/");
+  let f = "/";
 
   let file_system = MemoryFS::new(&[
     ("/a/index", ""),
@@ -93,15 +93,15 @@ async fn fallback() {
     let resolved_path = resolver.resolve(f, request).await.map(|r| r.full_path());
     assert_eq!(
       resolved_path,
-      Ok(PathBuf::from(expected)),
+      Ok(expected.to_string()),
       "{comment} {request}"
     );
   }
 
   #[rustfmt::skip]
     let ignore = [
-        ("should resolve an ignore module", "ignored", ResolveError::Ignored(f.join("ignored"))),
-        ("should resolve node: builtin module", "node:path", ResolveError::Ignored(PathBuf::from("/node:path"))),
+        ("should resolve an ignore module", "ignored", ResolveError::Ignored(f.path_join("ignored"))),
+        ("should resolve node: builtin module", "node:path", ResolveError::Ignored("/node:path".to_string())),
     ];
 
   for (comment, request, expected) in ignore {

--- a/src/tests/full_specified.rs
+++ b/src/tests/full_specified.rs
@@ -2,8 +2,6 @@
 
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 mod windows {
-  use std::path::PathBuf;
-
   use super::super::memory_fs::MemoryFS;
   use crate::{AliasValue, ResolveOptions, ResolverGeneric};
 
@@ -93,11 +91,7 @@ mod windows {
 
     for (comment, request, expected) in successful_resolves {
       let resolution = resolver.resolve("/a", request).await.map(|r| r.full_path());
-      assert_eq!(
-        resolution,
-        Ok(PathBuf::from(expected)),
-        "{comment} {request}"
-      );
+      assert_eq!(resolution, Ok(expected.to_string()), "{comment} {request}");
     }
   }
 
@@ -145,11 +139,7 @@ mod windows {
 
     for (comment, request, expected) in successful_resolves {
       let resolution = resolver.resolve("/a", request).await.map(|r| r.full_path());
-      assert_eq!(
-        resolution,
-        Ok(PathBuf::from(expected)),
-        "{comment} {request}"
-      );
+      assert_eq!(resolution, Ok(expected.to_string()), "{comment} {request}");
     }
   }
 }

--- a/src/tests/imports_field.rs
+++ b/src/tests/imports_field.rs
@@ -2,16 +2,15 @@
 //!
 //! The huge imports field test cases are at the bottom of this file.
 
-use std::path::Path;
-
 use simd_json::{json, prelude::*};
 
+use super::JoinExt;
 use crate::{package_json::JSONValue, Ctx, PathUtil, ResolveError, ResolveOptions, Resolver};
 
 #[tokio::test]
 async fn test_simple() {
-  let f = super::fixture().join("imports-field");
-  let f2 = super::fixture().join("imports-exports-wildcard/node_modules/m/");
+  let f = super::fixture().path_join("imports-field");
+  let f2 = super::fixture().path_join("imports-exports-wildcard/node_modules/m/");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -22,15 +21,15 @@ async fn test_simple() {
 
   #[rustfmt::skip]
     let pass = [
-        ("should resolve using imports field instead of self-referencing", f.clone(), "#imports-field", f.join("b.js")),
-        ("should resolve using imports field instead of self-referencing for a subpath", f.join("dir"), "#imports-field", f.join("b.js")),
-        ("should resolve package #1", f.clone(), "#a/dist/main.js", f.join("node_modules/a/lib/lib2/main.js")),
-        ("should resolve package #3", f.clone(), "#ccc/index.js", f.join("node_modules/c/index.js")),
-        ("should resolve package #4", f.clone(), "#c", f.join("node_modules/c/index.js")),
-        ("should resolve with wildcard pattern", f2.clone(), "#internal/i.js", f2.join("src/internal/i.js")),
+        ("should resolve using imports field instead of self-referencing", f.clone(), "#imports-field", f.path_join("b.js")),
+        ("should resolve using imports field instead of self-referencing for a subpath", f.path_join("dir"), "#imports-field", f.path_join("b.js")),
+        ("should resolve package #1", f.clone(), "#a/dist/main.js", f.path_join("node_modules/a/lib/lib2/main.js")),
+        ("should resolve package #3", f.clone(), "#ccc/index.js", f.path_join("node_modules/c/index.js")),
+        ("should resolve package #4", f.clone(), "#c", f.path_join("node_modules/c/index.js")),
+        ("should resolve with wildcard pattern", f2.clone(), "#internal/i.js", f2.path_join("src/internal/i.js")),
         // https://github.com/web-infra-dev/rspack/issues/13508
         // https://github.com/nodejs/node/pull/60864
-        ("should resolve #/ wildcard imports", f.clone(), "#/foo", f.join("src/foo.js")),
+        ("should resolve #/ wildcard imports", f.clone(), "#/foo", f.path_join("src/foo.js")),
     ];
 
   for (comment, path, request, expected) in pass {
@@ -47,8 +46,8 @@ async fn test_simple() {
 
   #[rustfmt::skip]
     let fail = [
-        ("should disallow resolve out of package scope", f.clone(), "#b", ResolveError::InvalidPackageTarget("../b.js".to_string(), "#b".to_string(), f.join("package.json"))),
-        ("should resolve package #2", f.clone(), "#a", ResolveError::PackageImportNotDefined("#a".to_string(), f.join("package.json"))),
+        ("should disallow resolve out of package scope", f.clone(), "#b", ResolveError::InvalidPackageTarget("../b.js".to_string(), "#b".to_string(), f.path_join("package.json"))),
+        ("should resolve package #2", f.clone(), "#a", ResolveError::PackageImportNotDefined("#a".to_string(), f.path_join("package.json"))),
     ];
 
   for (comment, path, request, error) in fail {
@@ -59,7 +58,7 @@ async fn test_simple() {
 
 #[tokio::test]
 async fn shared_resolvers() {
-  let f = super::fixture().join("imports-field");
+  let f = super::fixture().path_join("imports-field");
 
   // field name #1
   let resolver1 = Resolver::new(ResolveOptions {
@@ -74,7 +73,7 @@ async fn shared_resolvers() {
     .resolve(&f, "#imports-field")
     .await
     .map(|r| r.full_path());
-  assert_eq!(resolved_path, Ok(f.join("b.js")));
+  assert_eq!(resolved_path, Ok(f.path_join("b.js")));
 
   // field name #2
   let resolver2 = resolver1.clone_with_options(ResolveOptions {
@@ -83,7 +82,7 @@ async fn shared_resolvers() {
   });
 
   let resolved_path = resolver2.resolve(&f, "#b").await.map(|r| r.full_path());
-  assert_eq!(resolved_path, Ok(f.join("a.js")));
+  assert_eq!(resolved_path, Ok(f.path_join("a.js")));
 }
 
 // Small script for generating the test cases from enhanced_resolve
@@ -1308,7 +1307,7 @@ async fn test_cases() {
       .package_imports_exports_resolve(
         case.request,
         case.imports_field.as_object().unwrap(),
-        Path::new(""),
+        "",
         true,
         &case
           .condition_names
@@ -1318,7 +1317,7 @@ async fn test_cases() {
         &mut Ctx::default(),
       )
       .await
-      .map(|p| p.map(|p| p.to_path_buf()));
+      .map(|p| p.map(|p| p.path().to_string()));
     if let Some(expect) = case.expect {
       if expect.is_empty() {
         assert!(
@@ -1329,12 +1328,7 @@ async fn test_cases() {
         );
       } else {
         for expect in expect {
-          assert_eq!(
-            resolved,
-            Ok(Some(Path::new(expect).normalize())),
-            "{}",
-            &case.name
-          );
+          assert_eq!(resolved, Ok(Some(expect.normalize())), "{}", &case.name);
         }
       }
     } else {

--- a/src/tests/imports_field.rs
+++ b/src/tests/imports_field.rs
@@ -2,6 +2,8 @@
 //!
 //! The huge imports field test cases are at the bottom of this file.
 
+use std::path::PathBuf;
+
 use simd_json::{json, prelude::*};
 
 use super::JoinExt;
@@ -33,11 +35,18 @@ async fn test_simple() {
     ];
 
   for (comment, path, request, expected) in pass {
+    // PathBuf comparison: the resolver may emit `\\` while `path_join` /
+    // hand-written expected strings carry `/`. Component-wise equality
+    // reproduces pre-refactor `main` behavior (which compared `PathBuf`s).
     let resolved_path = resolver
       .resolve(&path, request)
       .await
-      .map(|r| r.full_path());
-    assert_eq!(resolved_path, Ok(expected), "{comment} {path:?} {request}");
+      .map(|r| PathBuf::from(r.full_path()));
+    assert_eq!(
+      resolved_path,
+      Ok(PathBuf::from(expected)),
+      "{comment} {path:?} {request}"
+    );
   }
 
   // Note added:
@@ -1317,7 +1326,7 @@ async fn test_cases() {
         &mut Ctx::default(),
       )
       .await
-      .map(|p| p.map(|p| p.path().to_string()));
+      .map(|p| p.map(|p| PathBuf::from(p.path().to_string())));
     if let Some(expect) = case.expect {
       if expect.is_empty() {
         assert!(
@@ -1328,7 +1337,12 @@ async fn test_cases() {
         );
       } else {
         for expect in expect {
-          assert_eq!(resolved, Ok(Some(expect.normalize())), "{}", &case.name);
+          assert_eq!(
+            resolved,
+            Ok(Some(PathBuf::from(expect.normalize()))),
+            "{}",
+            &case.name
+          );
         }
       }
     } else {

--- a/src/tests/incorrect_description_file.rs
+++ b/src/tests/incorrect_description_file.rs
@@ -2,18 +2,19 @@
 
 use rustc_hash::FxHashSet;
 
+use super::JoinExt;
 use crate::{JSONError, Resolution, ResolveContext, ResolveError, ResolveOptions, Resolver};
 
 // should not resolve main in incorrect description file #1
 #[tokio::test]
 async fn incorrect_description_file_1() {
-  let f = super::fixture().join("incorrect-package");
+  let f = super::fixture().path_join("incorrect-package");
   let mut ctx = ResolveContext::default();
   let resolution = Resolver::default()
-    .resolve_with_context(f.join("pack1"), ".", &mut ctx)
+    .resolve_with_context(f.path_join("pack1"), ".", &mut ctx)
     .await;
   let _error = ResolveError::JSON(JSONError {
-    path: f.join("pack1/package.json"),
+    path: f.path_join("pack1/package.json"),
     message: String::from("EOF while parsing a value at line 3 column 0"),
     line: 3,
     column: 0,
@@ -23,7 +24,7 @@ async fn incorrect_description_file_1() {
   assert!(matches!(resolution, Err(ResolveError::JSON(_))));
   assert_eq!(
     ctx.file_dependencies,
-    FxHashSet::from_iter([f.join("pack1"), f.join("pack1/package.json")])
+    FxHashSet::from_iter([f.path_join("pack1"), f.path_join("pack1/package.json")])
   );
   assert!(!ctx.missing_dependencies.is_empty());
 }
@@ -31,10 +32,10 @@ async fn incorrect_description_file_1() {
 // should not resolve main in incorrect description file #2
 #[tokio::test]
 async fn incorrect_description_file_2() {
-  let f = super::fixture().join("incorrect-package");
-  let resolution = Resolver::default().resolve(f.join("pack2"), ".").await;
+  let f = super::fixture().path_join("incorrect-package");
+  let resolution = Resolver::default().resolve(f.path_join("pack2"), ".").await;
   let _error = ResolveError::JSON(JSONError {
-    path: f.join("pack2/package.json"),
+    path: f.path_join("pack2/package.json"),
     message: String::from("EOF while parsing a value at line 1 column 0"),
     line: 1,
     column: 0,
@@ -46,24 +47,21 @@ async fn incorrect_description_file_2() {
 // should not resolve main in incorrect description file #3
 #[tokio::test]
 async fn incorrect_description_file_3() {
-  let f = super::fixture().join("incorrect-package");
-  let resolution = Resolver::default().resolve(f.join("pack2"), ".").await;
+  let f = super::fixture().path_join("incorrect-package");
+  let resolution = Resolver::default().resolve(f.path_join("pack2"), ".").await;
   assert!(resolution.is_err());
 }
 
 // `enhanced_resolve` does not have this test case
 #[tokio::test]
 async fn no_description_file() {
-  let f = super::fixture_root().join("enhanced_resolve");
+  let f = super::fixture_root().path_join("enhanced_resolve");
 
   // has description file
   let resolver = Resolver::default();
   assert_eq!(
-    resolver
-      .resolve(&f, ".")
-      .await
-      .map(Resolution::into_path_buf),
-    Ok(f.join("lib/index.js"))
+    resolver.resolve(&f, ".").await.map(Resolution::into_path),
+    Ok(f.path_join("lib/index.js"))
   );
 
   // without description file

--- a/src/tests/main_field.rs
+++ b/src/tests/main_field.rs
@@ -1,10 +1,11 @@
 //! Not part of enhanced_resolve's test suite
 
+use super::JoinExt;
 use crate::{ResolveOptions, Resolver};
 
 #[tokio::test]
 async fn test() {
-  let f = super::fixture().join("restrictions");
+  let f = super::fixture().path_join("restrictions");
 
   let resolver1 = Resolver::new(ResolveOptions {
     main_fields: vec!["style".into()],
@@ -12,7 +13,7 @@ async fn test() {
   });
 
   let resolution = resolver1.resolve(&f, "pck2").await.map(|r| r.full_path());
-  assert_eq!(resolution, Ok(f.join("node_modules/pck2/index.css")));
+  assert_eq!(resolution, Ok(f.path_join("node_modules/pck2/index.css")));
 
   let resolver2 = resolver1.clone_with_options(ResolveOptions {
     main_fields: vec!["module".into(), "main".into()],
@@ -20,12 +21,12 @@ async fn test() {
   });
 
   let resolution = resolver2.resolve(&f, "pck2").await.map(|r| r.full_path());
-  assert_eq!(resolution, Ok(f.join("node_modules/pck2/module.js")));
+  assert_eq!(resolution, Ok(f.path_join("node_modules/pck2/module.js")));
 }
 
 #[tokio::test]
 async fn test_fallback() {
-  let f = super::fixture_root().join("invalid");
+  let f = super::fixture_root().path_join("invalid");
 
   let resolver1 = Resolver::new(ResolveOptions {
     main_fields: vec!["module".into(), "main".into()],
@@ -39,6 +40,6 @@ async fn test_fallback() {
     .map(|r| r.full_path());
   assert_eq!(
     resolution,
-    Ok(f.join("node_modules/main_field_fallback/exist.js"))
+    Ok(f.path_join("node_modules/main_field_fallback/exist.js"))
   );
 }

--- a/src/tests/memory_fs.rs
+++ b/src/tests/memory_fs.rs
@@ -1,13 +1,6 @@
-use std::{
-  io,
-  path::{Path, PathBuf},
-};
+use std::io;
 
 use crate::{FileMetadata, FileSystem};
-
-fn path_to_str(path: &Path) -> &str {
-  path.to_str().expect("path should be UTF-8")
-}
 
 #[derive(Default)]
 pub struct MemoryFS {
@@ -25,60 +18,62 @@ impl MemoryFS {
       fs: vfs::MemoryFS::default(),
     };
     for (path, content) in data {
-      fs.add_file(Path::new(path), content);
+      fs.add_file(path, content);
     }
     fs
   }
 
   #[allow(dead_code)]
-  pub fn add_file(&mut self, path: &Path, content: &str) {
+  pub fn add_file(&mut self, path: &str, content: &str) {
+    use std::path::Path;
+
     use vfs::FileSystem;
     let fs = &mut self.fs;
     // Create all parent directories
-    for path in path.ancestors().collect::<Vec<_>>().iter().rev() {
-      let path = path_to_str(path);
-      if !fs.exists(path).unwrap() {
-        fs.create_dir(path).unwrap();
+    for ancestor in Path::new(path).ancestors().collect::<Vec<_>>().iter().rev() {
+      let ancestor = ancestor.to_str().expect("path should be UTF-8");
+      if !fs.exists(ancestor).unwrap() {
+        fs.create_dir(ancestor).unwrap();
       }
     }
     // Create file
-    let mut file = fs.create_file(path_to_str(path)).unwrap();
+    let mut file = fs.create_file(path).unwrap();
     file.write_all(content.as_bytes()).unwrap();
   }
 }
 #[async_trait::async_trait]
 impl FileSystem for MemoryFS {
-  async fn read_to_string(&self, path: &Path) -> io::Result<String> {
+  async fn read_to_string(&self, path: &str) -> io::Result<String> {
     use vfs::FileSystem;
     let mut file = self
       .fs
-      .open_file(path_to_str(path))
+      .open_file(path)
       .map_err(|err| io::Error::new(io::ErrorKind::NotFound, err))?;
     let mut buffer = String::new();
     file.read_to_string(&mut buffer).unwrap();
     Ok(buffer)
   }
-  async fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
+  async fn read(&self, path: &str) -> io::Result<Vec<u8>> {
     let buf = self.read_to_string(path).await?;
     Ok(buf.into_bytes())
   }
 
-  async fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+  async fn metadata(&self, path: &str) -> io::Result<FileMetadata> {
     use vfs::FileSystem;
     let metadata = self
       .fs
-      .metadata(path_to_str(path))
+      .metadata(path)
       .map_err(|err| io::Error::new(io::ErrorKind::NotFound, err))?;
     let is_file = metadata.file_type == vfs::VfsFileType::File;
     let is_dir = metadata.file_type == vfs::VfsFileType::Directory;
     Ok(FileMetadata::new(is_file, is_dir, false))
   }
 
-  async fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+  async fn symlink_metadata(&self, path: &str) -> io::Result<FileMetadata> {
     self.metadata(path).await
   }
 
-  async fn canonicalize(&self, _path: &Path) -> io::Result<PathBuf> {
+  async fn canonicalize(&self, _path: &str) -> io::Result<String> {
     Err(io::Error::new(io::ErrorKind::NotFound, "not a symlink"))
   }
 }

--- a/src/tests/missing.rs
+++ b/src/tests/missing.rs
@@ -1,8 +1,9 @@
 //! https://github.com/webpack/enhanced-resolve/blob/main/test/missing.test.js
 
-use normalize_path::NormalizePath;
+use std::path::Path;
 
-use crate::{AliasValue, ResolveContext, ResolveOptions, Resolver};
+use super::JoinExt;
+use crate::{path::PathUtil, AliasValue, ResolveContext, ResolveOptions, Resolver};
 
 #[tokio::test]
 async fn test() {
@@ -12,44 +13,44 @@ async fn test() {
     (
       "./missing-file",
       vec![
-        f.join("missing-file"),
-        f.join("missing-file.js"),
-        f.join("missing-file.node"),
+        f.path_join("missing-file"),
+        f.path_join("missing-file.js"),
+        f.path_join("missing-file.node"),
       ],
     ),
     (
       "missing-module",
       vec![
-        f.join("node_modules/missing-module"),
-        f.parent().unwrap().join("node_modules"), // enhanced-resolve is "node_modules/missing-module"
+        f.path_join("node_modules/missing-module"),
+        Path::new(&f).parent().unwrap().path_join("node_modules"), // enhanced-resolve is "node_modules/missing-module"
       ],
     ),
     (
       "missing-module/missing-file",
       vec![
-        f.join("node_modules/missing-module"),
-        // f.parent().unwrap().join("node_modules/missing-module"), // we don't report this
+        f.path_join("node_modules/missing-module"),
+        // f.parent().unwrap().path_join("node_modules/missing-module"), // we don't report this
       ],
     ),
     (
       "m1/missing-file",
       vec![
-        f.join("node_modules/m1/missing-file"),
-        f.join("node_modules/m1/missing-file.js"),
-        f.join("node_modules/m1/missing-file.node"),
-        // f.parent().unwrap().join("node_modules/m1"), // we don't report this
+        f.path_join("node_modules/m1/missing-file"),
+        f.path_join("node_modules/m1/missing-file.js"),
+        f.path_join("node_modules/m1/missing-file.node"),
+        // f.parent().unwrap().path_join("node_modules/m1"), // we don't report this
       ],
     ),
     (
       "m1/",
       vec![
-        f.join("node_modules/m1/index"),
-        f.join("node_modules/m1/index.js"),
-        f.join("node_modules/m1/index.json"),
-        f.join("node_modules/m1/index.node"),
+        f.path_join("node_modules/m1/index"),
+        f.path_join("node_modules/m1/index.js"),
+        f.path_join("node_modules/m1/index.json"),
+        f.path_join("node_modules/m1/index.node"),
       ],
     ),
-    ("m1/a", vec![f.join("node_modules/m1/a")]),
+    ("m1/a", vec![f.path_join("node_modules/m1/a")]),
   ];
 
   let resolver = Resolver::default();
@@ -58,8 +59,8 @@ async fn test() {
     let mut ctx = ResolveContext::default();
     let _ = resolver.resolve_with_context(&f, specifier, &mut ctx).await;
 
-    for path in ctx.file_dependencies {
-      assert_eq!(path, path.normalize(), "{path:?}");
+    for path in &ctx.file_dependencies {
+      assert_eq!(*path, path.normalize(), "{path:?}");
     }
 
     for path in missing_dependencies {
@@ -81,21 +82,11 @@ async fn alias_and_extensions() {
     alias: vec![
       (
         "@scope-js/package-name/dir$".into(),
-        vec![AliasValue::Path(
-          f.join("foo/index.js")
-            .to_str()
-            .expect("path should be UTF-8")
-            .to_string(),
-        )],
+        vec![AliasValue::Path(f.path_join("foo/index.js"))],
       ),
       (
         "react-dom".into(),
-        vec![AliasValue::Path(
-          f.join("foo/index.js")
-            .to_str()
-            .expect("path should be UTF-8")
-            .to_string(),
-        )],
+        vec![AliasValue::Path(f.path_join("foo/index.js"))],
       ),
     ],
     extensions: vec![".server.ts".into()],
@@ -107,14 +98,14 @@ async fn alias_and_extensions() {
   let _ = resolver.resolve_with_context(&f, "@scope-js/package-name/dir/router", &mut ctx);
   let _ = resolver.resolve_with_context(&f, "react-dom/client", &mut ctx);
 
-  for path in ctx.file_dependencies {
-    assert_eq!(path, path.normalize(), "{path:?}");
+  for path in &ctx.file_dependencies {
+    assert_eq!(*path, path.normalize(), "{path:?}");
   }
 
-  for path in ctx.missing_dependencies {
-    assert_eq!(path, path.normalize(), "{path:?}");
-    if let Some(path) = path.parent() {
-      assert!(!path.is_file(), "{path:?} must not be a file");
+  for path in &ctx.missing_dependencies {
+    assert_eq!(*path, path.normalize(), "{path:?}");
+    if let Some(parent) = Path::new(path).parent() {
+      assert!(!parent.is_file(), "{parent:?} must not be a file");
     }
   }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -42,9 +42,19 @@ pub fn fixture_root() -> String {
 }
 
 pub fn fixture() -> String {
-  let mut p = fixture_root();
-  p.push_str("/enhanced_resolve/test/fixtures");
-  p
+  // Mirror `main`'s `PathBuf`-based builder so the result uses platform-native
+  // separators end-to-end (all `\\` on Windows, all `/` on Unix). Without this,
+  // `env::current_dir()` yields `\\`-separated bytes on Windows while the
+  // literal suffix here would contribute `/`, producing a mixed string that
+  // diverges byte-wise from what the resolver actually emits — the previous
+  // `PathBuf::eq` was component-aware and absorbed this; `String::eq` is not.
+  std::path::PathBuf::from(fixture_root())
+    .join("enhanced_resolve")
+    .join("test")
+    .join("fixtures")
+    .to_str()
+    .unwrap()
+    .to_string()
 }
 
 /// Test helper: join a `&str` path with a subpath using OS separator.

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -28,24 +28,76 @@ mod tsconfig_project_references;
 #[cfg(windows)]
 mod windows;
 
-use std::{env, path::PathBuf, sync::Arc, thread};
+use std::{env, sync::Arc, thread};
 
 use crate::Resolver;
 
-pub fn fixture_root() -> PathBuf {
-  env::current_dir().unwrap().join("fixtures")
+pub fn fixture_root() -> String {
+  env::current_dir()
+    .unwrap()
+    .join("fixtures")
+    .to_str()
+    .unwrap()
+    .to_string()
 }
 
-pub fn fixture() -> PathBuf {
-  fixture_root()
-    .join("enhanced_resolve")
-    .join("test")
-    .join("fixtures")
+pub fn fixture() -> String {
+  let mut p = fixture_root();
+  p.push_str("/enhanced_resolve/test/fixtures");
+  p
+}
+
+/// Test helper: join a `&str` path with a subpath using OS separator.
+///
+/// Lets tests keep the ergonomic `f.join("a/b")` style while operating on `String`.
+/// Normalizes `./` and `..` in the result (so leading `./` is dropped — matching the
+/// resolver's internal normalization), but preserves any trailing separator on `sub`
+/// the way `Path` component-equality used to swallow.
+pub fn p(base: &str, sub: &str) -> String {
+  use crate::path::PathUtil;
+  let trailing = sub.ends_with('/') || sub.ends_with('\\');
+  let mut result = base.normalize_with(sub);
+  if trailing && !(result.ends_with('/') || result.ends_with('\\')) {
+    result.push('/');
+  }
+  result
+}
+
+/// Path-like join extension for `String`/`&str` so test code can write `f.path_join("a")`.
+///
+/// Mirrors `Path::join` semantics: absolute `sub` replaces `base`; otherwise components
+/// are appended with the platform separator.
+pub trait JoinExt {
+  fn path_join(&self, sub: &str) -> String;
+}
+
+impl JoinExt for str {
+  fn path_join(&self, sub: &str) -> String {
+    p(self, sub)
+  }
+}
+
+impl JoinExt for String {
+  fn path_join(&self, sub: &str) -> String {
+    p(self.as_str(), sub)
+  }
+}
+
+impl JoinExt for std::path::Path {
+  fn path_join(&self, sub: &str) -> String {
+    p(self.to_str().expect("path should be UTF-8"), sub)
+  }
+}
+
+impl JoinExt for std::path::PathBuf {
+  fn path_join(&self, sub: &str) -> String {
+    p(self.to_str().expect("path should be UTF-8"), sub)
+  }
 }
 
 #[tokio::test]
 async fn threaded_environment() {
-  let cwd = env::current_dir().unwrap();
+  let cwd = env::current_dir().unwrap().to_str().unwrap().to_string();
   let resolver = Arc::new(Resolver::default());
   for _ in 0..2 {
     _ = thread::spawn({

--- a/src/tests/node_path.rs
+++ b/src/tests/node_path.rs
@@ -1,10 +1,8 @@
-use std::path::{Path, PathBuf};
-
 use super::memory_fs::MemoryFS;
 use crate::{ResolveOptions, ResolverGeneric};
 
 fn new_resolver(
-  node_path_dirs: Vec<PathBuf>,
+  node_path_dirs: Vec<String>,
   data: &[(&'static str, &'static str)],
 ) -> ResolverGeneric<MemoryFS> {
   ResolverGeneric::<MemoryFS>::new_with_file_system(
@@ -24,23 +22,23 @@ mod posix {
   #[tokio::test]
   async fn basic() {
     let resolver = new_resolver(
-      vec![PathBuf::from("/global/lib")],
+      vec!["/global/lib".to_string()],
       &[
         ("/global/lib/foo/package.json", r#"{"main":"index.js"}"#),
         ("/global/lib/foo/index.js", ""),
       ],
     );
-    let result = resolver.resolve(Path::new("/project/src"), "foo").await;
+    let result = resolver.resolve("/project/src", "foo").await;
     assert_eq!(
       result.map(|r| r.full_path()),
-      Ok(PathBuf::from("/global/lib/foo/index.js"))
+      Ok("/global/lib/foo/index.js".to_string())
     );
   }
 
   #[tokio::test]
   async fn node_modules_takes_priority_over_node_path() {
     let resolver = new_resolver(
-      vec![PathBuf::from("/global/lib")],
+      vec!["/global/lib".to_string()],
       &[
         (
           "/project/node_modules/foo/package.json",
@@ -51,17 +49,17 @@ mod posix {
         ("/global/lib/foo/index.js", ""),
       ],
     );
-    let result = resolver.resolve(Path::new("/project/src"), "foo").await;
+    let result = resolver.resolve("/project/src", "foo").await;
     assert_eq!(
       result.map(|r| r.full_path()),
-      Ok(PathBuf::from("/project/node_modules/foo/index.js")),
+      Ok("/project/node_modules/foo/index.js".to_string()),
     );
   }
 
   #[tokio::test]
   async fn multiple_node_path_dirs() {
     let resolver = new_resolver(
-      vec![PathBuf::from("/first/lib"), PathBuf::from("/second/lib")],
+      vec!["/first/lib".to_string(), "/second/lib".to_string()],
       &[
         ("/first/lib/foo/package.json", r#"{"main":"index.js"}"#),
         ("/first/lib/foo/index.js", ""),
@@ -69,23 +67,23 @@ mod posix {
         ("/second/lib/bar/index.js", ""),
       ],
     );
-    let result = resolver.resolve(Path::new("/project"), "foo").await;
+    let result = resolver.resolve("/project", "foo").await;
     assert_eq!(
       result.map(|r| r.full_path()),
-      Ok(PathBuf::from("/first/lib/foo/index.js"))
+      Ok("/first/lib/foo/index.js".to_string())
     );
 
-    let result = resolver.resolve(Path::new("/project"), "bar").await;
+    let result = resolver.resolve("/project", "bar").await;
     assert_eq!(
       result.map(|r| r.full_path()),
-      Ok(PathBuf::from("/second/lib/bar/index.js"))
+      Ok("/second/lib/bar/index.js".to_string())
     );
   }
 
   #[tokio::test]
   async fn first_node_path_dir_takes_priority() {
     let resolver = new_resolver(
-      vec![PathBuf::from("/first/lib"), PathBuf::from("/second/lib")],
+      vec!["/first/lib".to_string(), "/second/lib".to_string()],
       &[
         ("/first/lib/foo/package.json", r#"{"main":"a.js"}"#),
         ("/first/lib/foo/a.js", ""),
@@ -93,33 +91,33 @@ mod posix {
         ("/second/lib/foo/b.js", ""),
       ],
     );
-    let result = resolver.resolve(Path::new("/project"), "foo").await;
+    let result = resolver.resolve("/project", "foo").await;
     assert_eq!(
       result.map(|r| r.full_path()),
-      Ok(PathBuf::from("/first/lib/foo/a.js"))
+      Ok("/first/lib/foo/a.js".to_string())
     );
   }
 
   #[tokio::test]
   async fn nonexistent_node_path_dir_skipped() {
     let resolver = new_resolver(
-      vec![PathBuf::from("/nonexistent"), PathBuf::from("/global/lib")],
+      vec!["/nonexistent".to_string(), "/global/lib".to_string()],
       &[
         ("/global/lib/foo/package.json", r#"{"main":"index.js"}"#),
         ("/global/lib/foo/index.js", ""),
       ],
     );
-    let result = resolver.resolve(Path::new("/project"), "foo").await;
+    let result = resolver.resolve("/project", "foo").await;
     assert_eq!(
       result.map(|r| r.full_path()),
-      Ok(PathBuf::from("/global/lib/foo/index.js"))
+      Ok("/global/lib/foo/index.js".to_string())
     );
   }
 
   #[tokio::test]
   async fn scoped_package() {
     let resolver = new_resolver(
-      vec![PathBuf::from("/global/lib")],
+      vec!["/global/lib".to_string()],
       &[
         (
           "/global/lib/@scope/pkg/package.json",
@@ -128,29 +126,27 @@ mod posix {
         ("/global/lib/@scope/pkg/index.js", ""),
       ],
     );
-    let result = resolver.resolve(Path::new("/project"), "@scope/pkg").await;
+    let result = resolver.resolve("/project", "@scope/pkg").await;
     assert_eq!(
       result.map(|r| r.full_path()),
-      Ok(PathBuf::from("/global/lib/@scope/pkg/index.js"))
+      Ok("/global/lib/@scope/pkg/index.js".to_string())
     );
   }
 
   #[tokio::test]
   async fn subpath_import() {
     let resolver = new_resolver(
-      vec![PathBuf::from("/global/lib")],
+      vec!["/global/lib".to_string()],
       &[
         ("/global/lib/foo/package.json", r#"{"main":"index.js"}"#),
         ("/global/lib/foo/index.js", ""),
         ("/global/lib/foo/lib/utils.js", ""),
       ],
     );
-    let result = resolver
-      .resolve(Path::new("/project"), "foo/lib/utils")
-      .await;
+    let result = resolver.resolve("/project", "foo/lib/utils").await;
     assert_eq!(
       result.map(|r| r.full_path()),
-      Ok(PathBuf::from("/global/lib/foo/lib/utils.js"))
+      Ok("/global/lib/foo/lib/utils.js".to_string())
     );
   }
 
@@ -166,33 +162,33 @@ mod posix {
         ..ResolveOptions::default()
       },
     );
-    let result = resolver.resolve(Path::new("/project"), "foo").await;
+    let result = resolver.resolve("/project", "foo").await;
     assert!(result.is_err());
   }
 
   #[tokio::test]
   async fn not_found_in_node_path() {
     let resolver = new_resolver(
-      vec![PathBuf::from("/global/lib")],
+      vec!["/global/lib".to_string()],
       &[
         ("/global/lib/bar/package.json", r#"{"main":"index.js"}"#),
         ("/global/lib/bar/index.js", ""),
       ],
     );
-    let result = resolver.resolve(Path::new("/project"), "foo").await;
+    let result = resolver.resolve("/project", "foo").await;
     assert!(result.is_err());
   }
 
   #[tokio::test]
   async fn file_without_package_json() {
     let resolver = new_resolver(
-      vec![PathBuf::from("/global/lib")],
+      vec!["/global/lib".to_string()],
       &[("/global/lib/foo.js", "")],
     );
-    let result = resolver.resolve(Path::new("/project"), "foo").await;
+    let result = resolver.resolve("/project", "foo").await;
     assert_eq!(
       result.map(|r| r.full_path()),
-      Ok(PathBuf::from("/global/lib/foo.js"))
+      Ok("/global/lib/foo.js".to_string())
     );
   }
 
@@ -206,24 +202,24 @@ mod posix {
         ..ResolveOptions::default()
       },
     )
-    .with_node_path_dirs(vec![PathBuf::from("/global/lib")]);
-    let result = resolver.resolve(Path::new("/project"), "foo").await;
+    .with_node_path_dirs(vec!["/global/lib".to_string()]);
+    let result = resolver.resolve("/project", "foo").await;
     assert_eq!(
       result.map(|r| r.full_path()),
-      Ok(PathBuf::from("/global/lib/foo.json"))
+      Ok("/global/lib/foo.json".to_string())
     );
   }
 
   #[tokio::test]
   async fn index_file_resolution() {
     let resolver = new_resolver(
-      vec![PathBuf::from("/global/lib")],
+      vec!["/global/lib".to_string()],
       &[("/global/lib/foo/index.js", "")],
     );
-    let result = resolver.resolve(Path::new("/project"), "foo").await;
+    let result = resolver.resolve("/project", "foo").await;
     assert_eq!(
       result.map(|r| r.full_path()),
-      Ok(PathBuf::from("/global/lib/foo/index.js"))
+      Ok("/global/lib/foo/index.js".to_string())
     );
   }
 }

--- a/src/tests/package_json.rs
+++ b/src/tests/package_json.rs
@@ -1,12 +1,10 @@
 #[cfg(test)]
 mod tests {
-  use std::path::PathBuf;
-
   use crate::{package_json::ParseError, PackageJson};
 
   #[tokio::test]
   async fn test_json_with_bom() {
-    let mock_path = PathBuf::from("package.json");
+    let mock_path = "package.json".to_string();
     let json_with_bom = b"\xEF\xBB\xBF{\"name\": \"example-package\"}".to_vec();
 
     let result = PackageJson::parse(mock_path.clone(), mock_path.clone(), json_with_bom).err();
@@ -22,7 +20,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_normal_json() {
-    let mock_path = PathBuf::from("package.json");
+    let mock_path = "package.json".to_string();
     let json_with_bom = r##"{"name": "example-package"}"##.as_bytes().to_vec();
 
     let parsed = PackageJson::parse(mock_path.clone(), mock_path.clone(), json_with_bom).unwrap();
@@ -32,7 +30,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_broken_json() {
-    let mock_path = PathBuf::from("package.json");
+    let mock_path = "package.json".to_string();
     let json_with_bom = r##"{"broken":"string"##.as_bytes().to_vec();
 
     let parsed_err = PackageJson::parse(mock_path.clone(), mock_path.clone(), json_with_bom).err();
@@ -49,7 +47,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_empty_string() {
-    let mock_path = PathBuf::from("package.json");
+    let mock_path = "package.json".to_string();
     let json_with_bom = "    ".as_bytes().to_vec();
 
     let parse_error = PackageJson::parse(mock_path.clone(), mock_path.clone(), json_with_bom)

--- a/src/tests/pnp.rs
+++ b/src/tests/pnp.rs
@@ -3,11 +3,14 @@
 //! enhanced_resolve's test <https://github.com/webpack/enhanced-resolve/blob/main/test/pnp.test.js>
 //! cannot be ported over because it uses mocks on `pnpApi` provided by the runtime.
 
+use std::path::Path;
+
+use super::JoinExt;
 use crate::{path::PathUtil, ResolveContext, ResolveError::NotFound, ResolveOptions, Resolver};
 
 #[tokio::test]
 async fn pnp1() {
-  let fixture = super::fixture_root().join("pnp");
+  let fixture = super::fixture_root().path_join("pnp");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -20,7 +23,7 @@ async fn pnp1() {
       .resolve(&fixture, "is-even")
       .await
       .map(|r| r.full_path()),
-    Ok(fixture.join(
+    Ok(fixture.path_join(
       ".yarn/cache/is-even-npm-1.0.0-9f726520dc-2728cc2f39.zip/node_modules/is-even/index.js"
     ))
   );
@@ -30,7 +33,7 @@ async fn pnp1() {
       .resolve(&fixture, "lodash.zip")
       .await
       .map(|r| r.full_path()),
-    Ok(fixture.join(
+    Ok(fixture.path_join(
       ".yarn/cache/lodash.zip-npm-4.2.0-5299417ec8-e596da80a6.zip/node_modules/lodash.zip/index.js"
     ))
   );
@@ -38,17 +41,16 @@ async fn pnp1() {
   assert_eq!(
     resolver
       .resolve(
-        fixture
-          .join(".yarn/cache/is-even-npm-1.0.0-9f726520dc-2728cc2f39.zip/node_modules/is-even"),
+        fixture.path_join(
+          ".yarn/cache/is-even-npm-1.0.0-9f726520dc-2728cc2f39.zip/node_modules/is-even"
+        ),
         "is-odd"
       )
       .await
       .map(|r| r.full_path()),
-    Ok(
-      fixture.join(
-        ".yarn/cache/is-odd-npm-0.1.2-9d980a9da8-7dc6c6fd00.zip/node_modules/is-odd/index.js"
-      )
-    ),
+    Ok(fixture.path_join(
+      ".yarn/cache/is-odd-npm-0.1.2-9d980a9da8-7dc6c6fd00.zip/node_modules/is-odd/index.js"
+    )),
   );
 
   assert_eq!(
@@ -56,23 +58,21 @@ async fn pnp1() {
       .resolve(&fixture, "is-odd")
       .await
       .map(|r| r.full_path()),
-    Ok(
-      fixture.join(
-        ".yarn/cache/is-odd-npm-3.0.1-93c3c3f41b-89ee2e353c.zip/node_modules/is-odd/index.js"
-      )
-    ),
+    Ok(fixture.path_join(
+      ".yarn/cache/is-odd-npm-3.0.1-93c3c3f41b-89ee2e353c.zip/node_modules/is-odd/index.js"
+    )),
   );
 
   assert_eq!(
         resolver.resolve(&fixture, "preact").await.map(|r| r.full_path()),
-        Ok(fixture.join(
+        Ok(fixture.path_join(
             ".yarn/cache/preact-npm-10.25.4-2dd2c0aa44-33a009d614.zip/node_modules/preact/dist/preact.mjs"
         )),
     );
 
   assert_eq!(
         resolver.resolve(&fixture, "preact/devtools").await.map(|r| r.full_path()),
-        Ok(fixture.join(
+        Ok(fixture.path_join(
             ".yarn/cache/preact-npm-10.25.4-2dd2c0aa44-33a009d614.zip/node_modules/preact/devtools/dist/devtools.mjs"
         )),
     );
@@ -80,7 +80,7 @@ async fn pnp1() {
 
 #[tokio::test]
 async fn pnp_file_dependencies() {
-  let fixture = super::fixture_root().join("pnp");
+  let fixture = super::fixture_root().path_join("pnp");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -94,7 +94,9 @@ async fn pnp_file_dependencies() {
     .await;
   assert!(result.is_ok());
   assert!(
-    ctx.file_dependencies.contains(&fixture.join(".pnp.cjs")),
+    ctx
+      .file_dependencies
+      .contains(&fixture.path_join(".pnp.cjs")),
     ".pnp.cjs should be in file_dependencies, got: {:?}",
     ctx.file_dependencies
   );
@@ -105,7 +107,7 @@ async fn pnp_file_dependencies() {
 // so that the `main` field value (e.g. "index" without extension) can be resolved.
 #[tokio::test]
 async fn pnp_bare_specifier_fully_specified() {
-  let fixture = super::fixture_root().join("pnp");
+  let fixture = super::fixture_root().path_join("pnp");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -125,7 +127,7 @@ async fn pnp_bare_specifier_fully_specified() {
 
 #[tokio::test]
 async fn pnp_resolve_description_file() {
-  let fixture = super::fixture_root().join("pnp");
+  let fixture = super::fixture_root().path_join("pnp");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -133,36 +135,24 @@ async fn pnp_resolve_description_file() {
     ..ResolveOptions::default()
   });
 
-  let full_path = fixture
-    .join(
-      ".yarn/cache/preact-npm-10.25.4-2dd2c0aa44-33a009d614.zip/node_modules/preact/dist/preact.js",
-    )
-    .to_str()
-    .expect("path should be UTF-8")
-    .to_string();
+  let full_path = fixture.path_join(
+    ".yarn/cache/preact-npm-10.25.4-2dd2c0aa44-33a009d614.zip/node_modules/preact/dist/preact.js",
+  );
 
   let r = resolver.resolve(&fixture, &full_path).await.unwrap();
 
   assert_eq!(
-    r.package_json
-      .unwrap()
-      .path
-      .to_str()
-      .expect("path should be UTF-8")
-      .to_string(),
+    r.package_json.unwrap().path,
     fixture
-      .join(".yarn/cache/preact-npm-10.25.4-2dd2c0aa44-33a009d614.zip/node_modules/preact")
-      .join("package.json")
+      .path_join(".yarn/cache/preact-npm-10.25.4-2dd2c0aa44-33a009d614.zip/node_modules/preact")
+      .path_join("package.json")
       .normalize()
-      .to_str()
-      .expect("path should be UTF-8")
-      .to_string()
   );
 }
 
 #[tokio::test]
 async fn resolve_in_pnp_linked_folder() {
-  let fixture = super::fixture_root().join("pnp");
+  let fixture = super::fixture_root().path_join("pnp");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -175,13 +165,13 @@ async fn resolve_in_pnp_linked_folder() {
       .resolve(&fixture, "lib/lib.js")
       .await
       .map(|r| r.full_path()),
-    Ok(fixture.join("shared/lib.js"))
+    Ok(fixture.path_join("shared/lib.js"))
   );
 }
 
 #[tokio::test]
 async fn resolve_pnp_pkg_should_failed_while_disable_pnp_mode() {
-  let fixture = super::fixture_root().join("pnp");
+  let fixture = super::fixture_root().path_join("pnp");
 
   let resolver = Resolver::new(ResolveOptions {
     enable_pnp: false,
@@ -200,7 +190,7 @@ async fn resolve_pnp_pkg_should_failed_while_disable_pnp_mode() {
 #[cfg(target_os = "windows")]
 #[tokio::test]
 async fn resolve_pnp_with_global_cache_enabled_windows() {
-  let fixture = super::fixture_root().join("pnp-global-cache-enabled");
+  let fixture = super::fixture_root().path_join("pnp-global-cache-enabled");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -214,7 +204,7 @@ async fn resolve_pnp_with_global_cache_enabled_windows() {
     .map(|r| r.full_path())
     .unwrap();
 
-  let module_root = resolved.parent().unwrap();
+  let module_root = Path::new(&resolved).parent().unwrap();
   let module_root_str = module_root
     .to_str()
     .expect("path should be UTF-8")
@@ -224,16 +214,14 @@ async fn resolve_pnp_with_global_cache_enabled_windows() {
     "Expected global cache path, got: {module_root_str}"
   );
 
+  let module_root_string = module_root
+    .to_str()
+    .expect("path should be UTF-8")
+    .to_string();
   let resolved_from_cache = resolver
-    .resolve(module_root, "./index.js")
+    .resolve(&module_root_string, "./index.js")
     .await
-    .map(|r| {
-      r.full_path()
-        .to_str()
-        .expect("path should be UTF-8")
-        .replace('\\', "/")
-        .to_string()
-    })
+    .map(|r| r.full_path().replace('\\', "/"))
     .unwrap();
   assert!(
     resolved_from_cache.contains("/Yarn/Berry/cache/path-to-regexp"),
@@ -244,7 +232,7 @@ async fn resolve_pnp_with_global_cache_enabled_windows() {
 #[cfg(not(target_os = "windows"))]
 #[tokio::test]
 async fn resolve_pnp_with_global_cache_enabled_unix() {
-  let fixture = super::fixture_root().join("pnp-global-cache-enabled");
+  let fixture = super::fixture_root().path_join("pnp-global-cache-enabled");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -258,28 +246,28 @@ async fn resolve_pnp_with_global_cache_enabled_unix() {
     .map(|r| r.full_path())
     .unwrap();
 
-  let module_root = resolved.parent().unwrap();
+  let module_root = Path::new(&resolved).parent().unwrap();
   let module_root_str = module_root.to_str().expect("path should be UTF-8");
   assert!(
     module_root_str.contains("/.yarn/berry/cache/path-to-regexp"),
     "Expected global cache path, got: {module_root_str}"
   );
 
+  let module_root_string = module_root_str.to_string();
   let resolved_from_cache = resolver
-    .resolve(module_root, "./index.js")
+    .resolve(&module_root_string, "./index.js")
     .await
     .map(|r| r.full_path())
     .unwrap();
-  let resolved_str = resolved_from_cache.to_str().expect("path should be UTF-8");
   assert!(
-    resolved_str.contains("/.yarn/berry/cache/path-to-regexp"),
-    "Expected global cache path, got: {resolved_str}"
+    resolved_from_cache.contains("/.yarn/berry/cache/path-to-regexp"),
+    "Expected global cache path, got: {resolved_from_cache}"
   );
 }
 
 #[tokio::test]
 async fn resolve_pnp_transitive_dep_from_global_cache() {
-  let fixture = super::fixture_root().join("pnp-global-cache-enabled");
+  let fixture = super::fixture_root().path_join("pnp-global-cache-enabled");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -293,19 +281,16 @@ async fn resolve_pnp_transitive_dep_from_global_cache() {
     .map(|r| r.full_path())
     .unwrap();
 
-  let module_root = path_to_regexp.parent().unwrap();
+  let module_root = Path::new(&path_to_regexp).parent().unwrap();
+  let module_root_string = module_root
+    .to_str()
+    .expect("path should be UTF-8")
+    .to_string();
 
   let isarray = resolver
-    .resolve(module_root, "isarray")
+    .resolve(&module_root_string, "isarray")
     .await
-    .map(|r| {
-      r.full_path()
-        .to_str()
-        .expect("path should be UTF-8")
-        .replace('\\', "/")
-        .to_lowercase()
-        .to_string()
-    })
+    .map(|r| r.full_path().replace('\\', "/").to_lowercase())
     .unwrap();
 
   assert!(

--- a/src/tests/pnp.rs
+++ b/src/tests/pnp.rs
@@ -3,7 +3,7 @@
 //! enhanced_resolve's test <https://github.com/webpack/enhanced-resolve/blob/main/test/pnp.test.js>
 //! cannot be ported over because it uses mocks on `pnpApi` provided by the runtime.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::JoinExt;
 use crate::{path::PathUtil, ResolveContext, ResolveError::NotFound, ResolveOptions, Resolver};
@@ -18,24 +18,24 @@ async fn pnp1() {
     ..ResolveOptions::default()
   });
 
+  // PathBuf comparison: pnp's runtime returns POSIX-style paths even on
+  // Windows; the test expected is constructed via `path_join` which uses
+  // `\\` separators on Windows. Component-wise `PathBuf::eq` accepts both.
+  let full = |r: crate::Resolution| PathBuf::from(r.full_path());
+  let pb = |s: String| PathBuf::from(s);
+
   assert_eq!(
-    resolver
-      .resolve(&fixture, "is-even")
-      .await
-      .map(|r| r.full_path()),
-    Ok(fixture.path_join(
+    resolver.resolve(&fixture, "is-even").await.map(full),
+    Ok(pb(fixture.path_join(
       ".yarn/cache/is-even-npm-1.0.0-9f726520dc-2728cc2f39.zip/node_modules/is-even/index.js"
-    ))
+    )))
   );
 
   assert_eq!(
-    resolver
-      .resolve(&fixture, "lodash.zip")
-      .await
-      .map(|r| r.full_path()),
-    Ok(fixture.path_join(
+    resolver.resolve(&fixture, "lodash.zip").await.map(full),
+    Ok(pb(fixture.path_join(
       ".yarn/cache/lodash.zip-npm-4.2.0-5299417ec8-e596da80a6.zip/node_modules/lodash.zip/index.js"
-    ))
+    )))
   );
 
   assert_eq!(
@@ -47,35 +47,35 @@ async fn pnp1() {
         "is-odd"
       )
       .await
-      .map(|r| r.full_path()),
-    Ok(fixture.path_join(
+      .map(full),
+    Ok(pb(fixture.path_join(
       ".yarn/cache/is-odd-npm-0.1.2-9d980a9da8-7dc6c6fd00.zip/node_modules/is-odd/index.js"
-    )),
+    ))),
+  );
+
+  assert_eq!(
+    resolver.resolve(&fixture, "is-odd").await.map(full),
+    Ok(pb(fixture.path_join(
+      ".yarn/cache/is-odd-npm-3.0.1-93c3c3f41b-89ee2e353c.zip/node_modules/is-odd/index.js"
+    ))),
+  );
+
+  assert_eq!(
+    resolver.resolve(&fixture, "preact").await.map(full),
+    Ok(pb(fixture.path_join(
+      ".yarn/cache/preact-npm-10.25.4-2dd2c0aa44-33a009d614.zip/node_modules/preact/dist/preact.mjs"
+    ))),
   );
 
   assert_eq!(
     resolver
-      .resolve(&fixture, "is-odd")
+      .resolve(&fixture, "preact/devtools")
       .await
-      .map(|r| r.full_path()),
-    Ok(fixture.path_join(
-      ".yarn/cache/is-odd-npm-3.0.1-93c3c3f41b-89ee2e353c.zip/node_modules/is-odd/index.js"
-    )),
+      .map(full),
+    Ok(pb(fixture.path_join(
+      ".yarn/cache/preact-npm-10.25.4-2dd2c0aa44-33a009d614.zip/node_modules/preact/devtools/dist/devtools.mjs"
+    ))),
   );
-
-  assert_eq!(
-        resolver.resolve(&fixture, "preact").await.map(|r| r.full_path()),
-        Ok(fixture.path_join(
-            ".yarn/cache/preact-npm-10.25.4-2dd2c0aa44-33a009d614.zip/node_modules/preact/dist/preact.mjs"
-        )),
-    );
-
-  assert_eq!(
-        resolver.resolve(&fixture, "preact/devtools").await.map(|r| r.full_path()),
-        Ok(fixture.path_join(
-            ".yarn/cache/preact-npm-10.25.4-2dd2c0aa44-33a009d614.zip/node_modules/preact/devtools/dist/devtools.mjs"
-        )),
-    );
 }
 
 #[tokio::test]
@@ -164,8 +164,8 @@ async fn resolve_in_pnp_linked_folder() {
     resolver
       .resolve(&fixture, "lib/lib.js")
       .await
-      .map(|r| r.full_path()),
-    Ok(fixture.path_join("shared/lib.js"))
+      .map(|r| PathBuf::from(r.full_path())),
+    Ok(PathBuf::from(fixture.path_join("shared/lib.js")))
   );
 }
 

--- a/src/tests/resolve.rs
+++ b/src/tests/resolve.rs
@@ -1,5 +1,6 @@
 //! <https://github.com/webpack/enhanced-resolve/blob/main/test/resolve.test.js>
 
+use super::JoinExt;
 use crate::{ResolveError, ResolveOptions, Resolver};
 
 #[tokio::test]
@@ -8,51 +9,47 @@ async fn resolve() {
 
   let resolver = Resolver::default();
 
-  let main1_js_path = f
-    .join("main1.js")
-    .to_str()
-    .expect("path should be UTF-8")
-    .to_string();
+  let main1_js_path = f.path_join("main1.js");
 
   #[rustfmt::skip]
     let pass = [
-        ("absolute path", f.clone(), main1_js_path.as_str(), f.join("main1.js")),
-        ("file with .js", f.clone(), "./main1.js", f.join("main1.js")),
-        ("file without extension", f.clone(), "./main1", f.join("main1.js")),
-        ("another file with .js", f.clone(), "./a.js", f.join("a.js")),
-        ("another file without extension", f.clone(), "./a", f.join("a.js")),
-        ("file in module with .js", f.clone(), "m1/a.js", f.join("node_modules/m1/a.js")),
-        ("file in module without extension", f.clone(), "m1/a", f.join("node_modules/m1/a.js")),
-        ("another file in module without extension", f.clone(), "complexm/step1", f.join("node_modules/complexm/step1.js")),
-        ("from submodule to file in sibling module", f.join("node_modules/complexm"), "m2/b.js", f.join("node_modules/m2/b.js")),
-        ("from nested directory to overwritten file in module", f.join("multiple_modules"), "m1/a.js", f.join("multiple_modules/node_modules/m1/a.js")),
-        ("from nested directory to not overwritten file in module", f.join("multiple_modules"), "m1/b.js", f.join("node_modules/m1/b.js")),
-        ("file with query", f.clone(), "./main1.js?query", f.join("main1.js?query")),
-        ("file with fragment", f.clone(), "./main1.js#fragment", f.join("main1.js#fragment")),
-        ("file with fragment and query", f.clone(), "./main1.js#fragment?query", f.join("main1.js#fragment?query")),
-        ("file with query and fragment", f.clone(), "./main1.js?#fragment", f.join("main1.js?#fragment")),
+        ("absolute path", f.clone(), main1_js_path.as_str(), f.path_join("main1.js")),
+        ("file with .js", f.clone(), "./main1.js", f.path_join("main1.js")),
+        ("file without extension", f.clone(), "./main1", f.path_join("main1.js")),
+        ("another file with .js", f.clone(), "./a.js", f.path_join("a.js")),
+        ("another file without extension", f.clone(), "./a", f.path_join("a.js")),
+        ("file in module with .js", f.clone(), "m1/a.js", f.path_join("node_modules/m1/a.js")),
+        ("file in module without extension", f.clone(), "m1/a", f.path_join("node_modules/m1/a.js")),
+        ("another file in module without extension", f.clone(), "complexm/step1", f.path_join("node_modules/complexm/step1.js")),
+        ("from submodule to file in sibling module", f.path_join("node_modules/complexm"), "m2/b.js", f.path_join("node_modules/m2/b.js")),
+        ("from nested directory to overwritten file in module", f.path_join("multiple_modules"), "m1/a.js", f.path_join("multiple_modules/node_modules/m1/a.js")),
+        ("from nested directory to not overwritten file in module", f.path_join("multiple_modules"), "m1/b.js", f.path_join("node_modules/m1/b.js")),
+        ("file with query", f.clone(), "./main1.js?query", f.path_join("main1.js?query")),
+        ("file with fragment", f.clone(), "./main1.js#fragment", f.path_join("main1.js#fragment")),
+        ("file with fragment and query", f.clone(), "./main1.js#fragment?query", f.path_join("main1.js#fragment?query")),
+        ("file with query and fragment", f.clone(), "./main1.js?#fragment", f.path_join("main1.js?#fragment")),
 
-        ("file with query (unicode)", f.clone(), "./测试.js?query", f.join("测试.js?query")),
-        ("file with fragment (unicode)", f.clone(), "./测试.js#fragment", f.join("测试.js#fragment")),
-        ("file with fragment and query (unicode)", f.clone(), "./测试.js#fragment?query", f.join("测试.js#fragment?query")),
-        ("file with query and fragment (unicode)", f.clone(), "./测试.js?#fragment", f.join("测试.js?#fragment")),
+        ("file with query (unicode)", f.clone(), "./测试.js?query", f.path_join("测试.js?query")),
+        ("file with fragment (unicode)", f.clone(), "./测试.js#fragment", f.path_join("测试.js#fragment")),
+        ("file with fragment and query (unicode)", f.clone(), "./测试.js#fragment?query", f.path_join("测试.js#fragment?query")),
+        ("file with query and fragment (unicode)", f.clone(), "./测试.js?#fragment", f.path_join("测试.js?#fragment")),
 
-        ("file in module with query", f.clone(), "m1/a?query", f.join("node_modules/m1/a.js?query")),
-        ("file in module with fragment", f.clone(), "m1/a#fragment", f.join("node_modules/m1/a.js#fragment")),
-        ("file in module with fragment and query", f.clone(), "m1/a#fragment?query", f.join("node_modules/m1/a.js#fragment?query")),
-        ("file in module with query and fragment", f.clone(), "m1/a?#fragment", f.join("node_modules/m1/a.js?#fragment")),
-        ("file in module with query and fragment", f.clone(), "m1/a?#fragment", f.join("node_modules/m1/a.js?#fragment")),
-        ("differ between directory and file, resolve file", f.clone(), "./dirOrFile", f.join("dirOrFile.js")),
-        ("differ between directory and file, resolve directory", f.clone(), "./dirOrFile/", f.join("dirOrFile/index.js")),
-        ("find node_modules outside of node_modules", f.join("browser-module/node_modules"), "m1/a", f.join("node_modules/m1/a.js")),
-        ("don't crash on main field pointing to self", f.clone(), "./main-field-self", f.join("./main-field-self/index.js")),
-        ("don't crash on main field pointing to self (2)", f.clone(), "./main-field-self2", f.join("./main-field-self2/index.js")),
+        ("file in module with query", f.clone(), "m1/a?query", f.path_join("node_modules/m1/a.js?query")),
+        ("file in module with fragment", f.clone(), "m1/a#fragment", f.path_join("node_modules/m1/a.js#fragment")),
+        ("file in module with fragment and query", f.clone(), "m1/a#fragment?query", f.path_join("node_modules/m1/a.js#fragment?query")),
+        ("file in module with query and fragment", f.clone(), "m1/a?#fragment", f.path_join("node_modules/m1/a.js?#fragment")),
+        ("file in module with query and fragment", f.clone(), "m1/a?#fragment", f.path_join("node_modules/m1/a.js?#fragment")),
+        ("differ between directory and file, resolve file", f.clone(), "./dirOrFile", f.path_join("dirOrFile.js")),
+        ("differ between directory and file, resolve directory", f.clone(), "./dirOrFile/", f.path_join("dirOrFile/index.js")),
+        ("find node_modules outside of node_modules", f.path_join("browser-module/node_modules"), "m1/a", f.path_join("node_modules/m1/a.js")),
+        ("don't crash on main field pointing to self", f.clone(), "./main-field-self", f.path_join("./main-field-self/index.js")),
+        ("don't crash on main field pointing to self (2)", f.clone(), "./main-field-self2", f.path_join("./main-field-self2/index.js")),
         // enhanced-resolve has `#` prepended with a `\0`, they are removed from the
         // following 3 expected test results.
         // See https://github.com/webpack/enhanced-resolve#escaping
-        ("handle fragment edge case (no fragment)", f.clone(), "./no#fragment/#/#", f.join("no#fragment/#/#.js")),
-        ("handle fragment edge case (fragment)", f.clone(), "./no#fragment/#/", f.join("no.js#fragment/#/")),
-        ("handle fragment escaping", f.clone(), "./no\0#fragment/\0#/\0##fragment", f.join("no#fragment/#/#.js#fragment")),
+        ("handle fragment edge case (no fragment)", f.clone(), "./no#fragment/#/#", f.path_join("no#fragment/#/#.js")),
+        ("handle fragment edge case (fragment)", f.clone(), "./no#fragment/#/", format!("{}/", f.path_join("no.js#fragment/#"))),
+        ("handle fragment escaping", f.clone(), "./no\0#fragment/\0#/\0##fragment", f.path_join("no#fragment/#/#.js#fragment")),
 
     ];
 
@@ -67,7 +64,7 @@ async fn resolve() {
 
 #[tokio::test]
 async fn issue238_resolve() {
-  let f = super::fixture().join("issue-238");
+  let f = super::fixture().path_join("issue-238");
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into(), ".jsx".into(), ".ts".into(), ".tsx".into()],
     modules: vec![
@@ -79,12 +76,12 @@ async fn issue238_resolve() {
     ..ResolveOptions::default()
   });
   let resolved_path = resolver
-    .resolve(f.join("src/common"), "config/myObjectFile")
+    .resolve(f.path_join("src/common"), "config/myObjectFile")
     .await
     .map(|r| r.full_path());
   assert_eq!(
     resolved_path,
-    Ok(f.join("src/common/config/myObjectFile.js")),
+    Ok(f.path_join("src/common/config/myObjectFile.js")),
   );
 }
 
@@ -99,8 +96,8 @@ async fn prefer_relative() {
 
   #[rustfmt::skip]
     let pass = [
-        ("should correctly resolve with preferRelative 1", "main1.js", f.join("main1.js")),
-        ("should correctly resolve with preferRelative 2", "m1/a.js", f.join("node_modules/m1/a.js")),
+        ("should correctly resolve with preferRelative 1", "main1.js", f.path_join("main1.js")),
+        ("should correctly resolve with preferRelative 2", "m1/a.js", f.path_join("node_modules/m1/a.js")),
     ];
 
   for (comment, request, expected) in pass {
@@ -120,9 +117,9 @@ async fn resolve_to_context() {
   #[rustfmt::skip]
     let data = [
         ("context for fixtures", f.clone(), "./", f.clone()),
-        ("context for fixtures/lib", f.clone(), "./lib", f.join("lib")),
+        ("context for fixtures/lib", f.clone(), "./lib", f.path_join("lib")),
         ("context for fixtures with ..", f.clone(), "./lib/../../fixtures/./lib/..", f.clone()),
-        ("context for fixtures with query", f.clone(), "./?query", f.clone().with_file_name("fixtures?query")),
+        ("context for fixtures with query", f.clone(), "./?query", std::path::Path::new(&f).with_file_name("fixtures?query").to_str().expect("path should be UTF-8").to_string()),
     ];
 
   for (comment, path, request, expected) in data {

--- a/src/tests/resolve.rs
+++ b/src/tests/resolve.rs
@@ -1,5 +1,7 @@
 //! <https://github.com/webpack/enhanced-resolve/blob/main/test/resolve.test.js>
 
+use std::path::PathBuf;
+
 use super::JoinExt;
 use crate::{ResolveError, ResolveOptions, Resolver};
 
@@ -54,11 +56,17 @@ async fn resolve() {
     ];
 
   for (comment, path, request, expected) in pass {
+    // PathBuf comparison: see note in alias_fragment — separator-agnostic
+    // component-wise equality matches pre-refactor `main` behavior.
     let resolved_path = resolver
       .resolve(&path, request)
       .await
-      .map(|r| r.full_path());
-    assert_eq!(resolved_path, Ok(expected), "{comment} {path:?} {request}");
+      .map(|r| PathBuf::from(r.full_path()));
+    assert_eq!(
+      resolved_path,
+      Ok(PathBuf::from(expected)),
+      "{comment} {path:?} {request}"
+    );
   }
 }
 

--- a/src/tests/restrictions.rs
+++ b/src/tests/restrictions.rs
@@ -4,18 +4,17 @@ use std::sync::Arc;
 
 use regex::Regex;
 
+use super::JoinExt;
 use crate::{ResolveError, ResolveOptions, Resolver, Restriction};
 
 #[tokio::test]
 async fn should_respect_regexp_restriction() {
-  let f = super::fixture().join("restrictions");
+  let f = super::fixture().path_join("restrictions");
 
   let re = Regex::new(r"\.(sass|scss|css)$").unwrap();
   let resolver1 = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
-    restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-      path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
-    }))],
+    restrictions: vec![Restriction::Fn(Arc::new(move |path| re.is_match(path)))],
     ..ResolveOptions::default()
   });
 
@@ -25,26 +24,24 @@ async fn should_respect_regexp_restriction() {
 
 #[tokio::test]
 async fn should_try_to_find_alternative_1() {
-  let f = super::fixture().join("restrictions");
+  let f = super::fixture().path_join("restrictions");
 
   let re = Regex::new(r"\.(sass|scss|css)$").unwrap();
   let resolver1 = Resolver::new(ResolveOptions {
     extensions: vec![".js".into(), ".css".into()],
     main_files: vec!["index".into()],
-    restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-      path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
-    }))],
+    restrictions: vec![Restriction::Fn(Arc::new(move |path| re.is_match(path)))],
     ..ResolveOptions::default()
   });
 
   let resolution = resolver1.resolve(&f, "pck1").await.map(|r| r.full_path());
-  assert_eq!(resolution, Ok(f.join("node_modules/pck1/index.css")));
+  assert_eq!(resolution, Ok(f.path_join("node_modules/pck1/index.css")));
 }
 
 #[tokio::test]
 async fn should_respect_string_restriction() {
   let fixture = super::fixture();
-  let f = fixture.join("restrictions");
+  let f = fixture.path_join("restrictions");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
@@ -58,55 +55,49 @@ async fn should_respect_string_restriction() {
 
 #[tokio::test]
 async fn should_try_to_find_alternative_2() {
-  let f = super::fixture().join("restrictions");
+  let f = super::fixture().path_join("restrictions");
 
   let re = Regex::new(r"\.(sass|scss|css)$").unwrap();
   let resolver1 = Resolver::new(ResolveOptions {
     extensions: vec![".js".into(), ".css".into()],
     main_fields: vec!["main".into(), "style".into()],
-    restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-      path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
-    }))],
+    restrictions: vec![Restriction::Fn(Arc::new(move |path| re.is_match(path)))],
     ..ResolveOptions::default()
   });
 
   let resolution = resolver1.resolve(&f, "pck2").await.map(|r| r.full_path());
-  assert_eq!(resolution, Ok(f.join("node_modules/pck2/index.css")));
+  assert_eq!(resolution, Ok(f.path_join("node_modules/pck2/index.css")));
 }
 
 #[tokio::test]
 async fn should_try_to_find_alternative_3() {
-  let f = super::fixture().join("restrictions");
+  let f = super::fixture().path_join("restrictions");
 
   let re = Regex::new(r"\.(sass|scss|css)$").unwrap();
   let resolver1 = Resolver::new(ResolveOptions {
     extensions: vec![".js".into()],
     main_fields: vec!["main".into(), "module".into(), "style".into()],
-    restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-      path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
-    }))],
+    restrictions: vec![Restriction::Fn(Arc::new(move |path| re.is_match(path)))],
     ..ResolveOptions::default()
   });
 
   let resolution = resolver1.resolve(&f, "pck2").await.map(|r| r.full_path());
-  assert_eq!(resolution, Ok(f.join("node_modules/pck2/index.css")));
+  assert_eq!(resolution, Ok(f.path_join("node_modules/pck2/index.css")));
 }
 
 #[tokio::test]
 async fn should_try_to_find_alternative_4() {
-  let f = super::fixture().join("restrictions");
+  let f = super::fixture().path_join("restrictions");
 
   let re = Regex::new(r"\.(sass|scss|css)$").unwrap();
   let resolver1 = Resolver::new(ResolveOptions {
     extensions: vec![".css".into()],
     main_fields: vec!["main".into()],
     extension_alias: vec![(".js".into(), vec![".js".into(), ".jsx".into()])],
-    restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-      path.as_os_str().to_str().map_or(false, |s| re.is_match(s))
-    }))],
+    restrictions: vec![Restriction::Fn(Arc::new(move |path| re.is_match(path)))],
     ..ResolveOptions::default()
   });
 
   let resolution = resolver1.resolve(&f, "pck2").await.map(|r| r.full_path());
-  assert_eq!(resolution, Ok(f.join("node_modules/pck2/index.css")));
+  assert_eq!(resolution, Ok(f.path_join("node_modules/pck2/index.css")));
 }

--- a/src/tests/roots.rs
+++ b/src/tests/roots.rs
@@ -1,11 +1,12 @@
 //! <https://github.com/webpack/enhanced-resolve/blob/main/test/roots.test.js>
 
-use std::path::PathBuf;
-
+use super::JoinExt;
 use crate::{AliasValue, ResolveError, ResolveOptions, Resolver};
 
-fn dirname() -> PathBuf {
-  super::fixture_root().join("enhanced_resolve").join("test")
+fn dirname() -> String {
+  super::fixture_root()
+    .path_join("enhanced_resolve")
+    .path_join("test")
 }
 
 #[tokio::test]
@@ -21,11 +22,11 @@ async fn roots() {
 
   #[rustfmt::skip]
     let pass = [
-        ("should respect roots option", "/fixtures/b.js", f.join("b.js")),
-        ("should try another root option, if it exists", "/b.js", f.join("b.js")),
-        ("should respect extension", "/fixtures/b", f.join("b.js")),
-        ("should resolve in directory", "/fixtures/extensions/dir", f.join("extensions/dir/index.js")),
-        ("should respect aliases", "foo/b", f.join("b.js")),
+        ("should respect roots option", "/fixtures/b.js", f.path_join("b.js")),
+        ("should try another root option, if it exists", "/b.js", f.path_join("b.js")),
+        ("should respect extension", "/fixtures/b", f.path_join("b.js")),
+        ("should resolve in directory", "/fixtures/extensions/dir", f.path_join("extensions/dir/index.js")),
+        ("should respect aliases", "foo/b", f.path_join("b.js")),
     ];
 
   for (comment, request, expected) in pass {
@@ -56,7 +57,7 @@ async fn resolve_to_context() {
     .resolve(&f, "/fixtures/lib")
     .await
     .map(|r| r.full_path());
-  let expected = f.join("lib");
+  let expected = f.path_join("lib");
   assert_eq!(resolved_path, Ok(expected));
 }
 
@@ -73,7 +74,7 @@ async fn prefer_absolute() {
 
   #[rustfmt::skip]
     let pass = [
-        ("should resolve an absolute path (prefer absolute)", f.join("b.js").to_str().expect("path should be UTF-8").to_string(), f.join("b.js")),
+        ("should resolve an absolute path (prefer absolute)", f.path_join("b.js"), f.path_join("b.js")),
     ];
 
   for (comment, request, expected) in pass {
@@ -85,13 +86,12 @@ async fn prefer_absolute() {
 #[tokio::test]
 async fn roots_fall_through() {
   let f = super::fixture();
-  let absolute_path = f.join("roots_fall_through/index.js");
-  let specifier = absolute_path.to_str().expect("path should be UTF-8");
+  let absolute_path = f.path_join("roots_fall_through/index.js");
   let resolution = Resolver::new(ResolveOptions::default().with_root(&f))
-    .resolve(&f, &specifier)
+    .resolve(&f, &absolute_path)
     .await;
   assert_eq!(
-    resolution.map(super::super::resolution::Resolution::into_path_buf),
+    resolution.map(crate::Resolution::into_path),
     Ok(absolute_path)
   );
 }

--- a/src/tests/scoped_packages.rs
+++ b/src/tests/scoped_packages.rs
@@ -1,10 +1,11 @@
 //! <https://github.com/webpack/enhanced-resolve/blob/main/test/scoped-packages.test.js>
 
+use super::JoinExt;
 use crate::{ResolveOptions, Resolver};
 
 #[tokio::test]
 async fn scoped_packages() {
-  let f = super::fixture().join("scoped");
+  let f = super::fixture().path_join("scoped");
 
   let resolver = Resolver::new(ResolveOptions {
     alias_fields: vec![vec!["browser".into()]],
@@ -13,9 +14,9 @@ async fn scoped_packages() {
 
   #[rustfmt::skip]
     let pass = [
-        ("main field should work", f.clone(), "@scope/pack1", f.join("./node_modules/@scope/pack1/main.js")),
-        ("browser field should work", f.clone(), "@scope/pack2", f.join("./node_modules/@scope/pack2/main.js")),
-        ("folder request should work", f.clone(), "@scope/pack2/lib", f.join("./node_modules/@scope/pack2/lib/index.js"))
+        ("main field should work", f.clone(), "@scope/pack1", f.path_join("./node_modules/@scope/pack1/main.js")),
+        ("browser field should work", f.clone(), "@scope/pack2", f.path_join("./node_modules/@scope/pack2/main.js")),
+        ("folder request should work", f.clone(), "@scope/pack2/lib", f.path_join("./node_modules/@scope/pack2/lib/index.js"))
     ];
 
   for (comment, path, request, expected) in pass {

--- a/src/tests/simple.rs
+++ b/src/tests/simple.rs
@@ -2,27 +2,28 @@
 
 use std::env;
 
+use super::JoinExt;
 use crate::Resolver;
 
 #[tokio::test]
 async fn resolve_abs_main() {
   let resolver = Resolver::default();
-  let dirname = env::current_dir().unwrap().join("fixtures");
-  let f = dirname.join("invalid/main.js");
+  let dirname = env::current_dir().unwrap().path_join("fixtures");
+  let f = dirname.path_join("invalid/main.js");
   // a's main field id `/dist/index.js`
   let resolution = resolver.resolve(&f, "a").await.unwrap();
 
   assert_eq!(
     resolution.path(),
-    dirname.join("invalid/node_modules/a/dist/index.js")
+    dirname.path_join("invalid/node_modules/a/dist/index.js")
   );
 }
 
 #[tokio::test]
 async fn simple() {
   // mimic `enhanced-resolve/test/simple.test.js`
-  let dirname = env::current_dir().unwrap().join("fixtures");
-  let f = dirname.join("enhanced_resolve/test");
+  let dirname = env::current_dir().unwrap().path_join("fixtures");
+  let f = dirname.path_join("enhanced_resolve/test");
 
   let resolver = Resolver::default();
 
@@ -37,7 +38,7 @@ async fn simple() {
       .resolve(&path, request)
       .await
       .map(|f| f.full_path());
-    let expected = dirname.join("enhanced_resolve/lib/index.js");
+    let expected = dirname.path_join("enhanced_resolve/lib/index.js");
     assert_eq!(resolved_path, Ok(expected), "{comment} {path:?} {request}");
   }
 }
@@ -49,31 +50,31 @@ async fn dashed_name() {
   let resolver = Resolver::default();
 
   let data = [
-    (f.clone(), "dash", f.join("node_modules/dash/index.js")),
+    (f.clone(), "dash", f.path_join("node_modules/dash/index.js")),
     (
       f.clone(),
       "dash-name",
-      f.join("node_modules/dash-name/index.js"),
+      f.path_join("node_modules/dash-name/index.js"),
     ),
     (
-      f.join("node_modules/dash"),
+      f.path_join("node_modules/dash"),
       "dash",
-      f.join("node_modules/dash/index.js"),
+      f.path_join("node_modules/dash/index.js"),
     ),
     (
-      f.join("node_modules/dash"),
+      f.path_join("node_modules/dash"),
       "dash-name",
-      f.join("node_modules/dash-name/index.js"),
+      f.path_join("node_modules/dash-name/index.js"),
     ),
     (
-      f.join("node_modules/dash-name"),
+      f.path_join("node_modules/dash-name"),
       "dash",
-      f.join("node_modules/dash/index.js"),
+      f.path_join("node_modules/dash/index.js"),
     ),
     (
-      f.join("node_modules/dash-name"),
+      f.path_join("node_modules/dash-name"),
       "dash-name",
-      f.join("node_modules/dash-name/index.js"),
+      f.path_join("node_modules/dash-name/index.js"),
     ),
   ];
 
@@ -93,10 +94,8 @@ mod windows {
 
   #[tokio::test]
   async fn no_package() {
-    use std::path::Path;
-
     use crate::ResolverGeneric;
-    let f = Path::new("/");
+    let f = "/";
     let file_system = MemoryFS::new(&[]);
     let resolver =
       ResolverGeneric::<MemoryFS>::new_with_file_system(file_system, ResolveOptions::default());

--- a/src/tests/symlink.rs
+++ b/src/tests/symlink.rs
@@ -1,5 +1,6 @@
 use std::{fs, io, path::Path};
 
+use super::JoinExt;
 use crate::{ResolveOptions, Resolver};
 
 #[derive(Debug, Clone, Copy)]
@@ -87,7 +88,8 @@ fn cleanup_symlinks(temp_path: &Path) {
 
 #[tokio::test]
 async fn test() -> io::Result<()> {
-  let root = super::fixture_root().join("enhanced_resolve");
+  let root_str = super::fixture_root().path_join("enhanced_resolve");
+  let root = Path::new(&root_str);
   let dirname = root.join("test");
   let temp_path = dirname.join("temp");
   if !temp_path.exists() {
@@ -107,31 +109,37 @@ async fn test() -> io::Result<()> {
   });
   let resolver_with_symlinks = Resolver::default();
 
+  // Convert temp_path to its canonical string form so resolver calls operate on str.
+  let temp_path_str = temp_path
+    .to_str()
+    .expect("path should be UTF-8")
+    .to_string();
+
   #[rustfmt::skip]
     let pass = [
-        ("with a symlink to a file", temp_path.clone(), "./index.js"),
-        ("with a relative symlink to a file", temp_path.clone(), "./node.relative.js"),
-        ("with a relative symlink to a symlink to a file", temp_path.clone(), "./node.relative.sym.js"),
-        ("with a symlink to a directory 1", temp_path.clone(), "./lib/index.js"),
-        ("with a symlink to a directory 2", temp_path.clone(), "./this/lib/index.js"),
-        ("with multiple symlinks in the path 1", temp_path.clone(), "./this/test/temp/index.js"),
-        ("with multiple symlinks in the path 2", temp_path.clone(), "./this/test/temp/lib/index.js"),
-        ("with multiple symlinks in the path 3", temp_path.clone(), "./this/test/temp/this/lib/index.js"),
-        ("with a symlink to a directory 2 (chained)", temp_path.clone(), "./that/lib/index.js"),
-        ("with multiple symlinks in the path 1 (chained)", temp_path.clone(), "./that/test/temp/index.js"),
-        ("with multiple symlinks in the path 2 (chained)", temp_path.clone(), "./that/test/temp/lib/index.js"),
-        ("with multiple symlinks in the path 3 (chained)", temp_path.clone(), "./that/test/temp/that/lib/index.js"),
-        ("with symlinked directory as context 1", temp_path.join( "lib"), "./index.js"),
-        ("with symlinked directory as context 2", temp_path.join( "this"), "./lib/index.js"),
-        ("with symlinked directory as context and in path", temp_path.join( "this"), "./test/temp/lib/index.js"),
-        ("with symlinked directory in context path", temp_path.join( "this/lib"), "./index.js"),
-        ("with symlinked directory in context path and symlinked file", temp_path.join( "this/test"), "./temp/index.js"),
-        ("with symlinked directory in context path and symlinked directory", temp_path.join( "this/test"), "./temp/lib/index.js"),
-        ("with symlinked directory as context 2 (chained)", temp_path.join( "that"), "./lib/index.js"),
-        ("with symlinked directory as context and in path (chained)", temp_path.join( "that"), "./test/temp/lib/index.js"),
-        ("with symlinked directory in context path (chained)", temp_path.join( "that/lib"), "./index.js"),
-        ("with symlinked directory in context path and symlinked file (chained)", temp_path.join( "that/test"), "./temp/index.js"),
-        ("with symlinked directory in context path and symlinked directory (chained)", temp_path.join( "that/test"), "./temp/lib/index.js")
+        ("with a symlink to a file", temp_path_str.clone(), "./index.js"),
+        ("with a relative symlink to a file", temp_path_str.clone(), "./node.relative.js"),
+        ("with a relative symlink to a symlink to a file", temp_path_str.clone(), "./node.relative.sym.js"),
+        ("with a symlink to a directory 1", temp_path_str.clone(), "./lib/index.js"),
+        ("with a symlink to a directory 2", temp_path_str.clone(), "./this/lib/index.js"),
+        ("with multiple symlinks in the path 1", temp_path_str.clone(), "./this/test/temp/index.js"),
+        ("with multiple symlinks in the path 2", temp_path_str.clone(), "./this/test/temp/lib/index.js"),
+        ("with multiple symlinks in the path 3", temp_path_str.clone(), "./this/test/temp/this/lib/index.js"),
+        ("with a symlink to a directory 2 (chained)", temp_path_str.clone(), "./that/lib/index.js"),
+        ("with multiple symlinks in the path 1 (chained)", temp_path_str.clone(), "./that/test/temp/index.js"),
+        ("with multiple symlinks in the path 2 (chained)", temp_path_str.clone(), "./that/test/temp/lib/index.js"),
+        ("with multiple symlinks in the path 3 (chained)", temp_path_str.clone(), "./that/test/temp/that/lib/index.js"),
+        ("with symlinked directory as context 1", temp_path_str.path_join("lib"), "./index.js"),
+        ("with symlinked directory as context 2", temp_path_str.path_join("this"), "./lib/index.js"),
+        ("with symlinked directory as context and in path", temp_path_str.path_join("this"), "./test/temp/lib/index.js"),
+        ("with symlinked directory in context path", temp_path_str.path_join("this/lib"), "./index.js"),
+        ("with symlinked directory in context path and symlinked file", temp_path_str.path_join("this/test"), "./temp/index.js"),
+        ("with symlinked directory in context path and symlinked directory", temp_path_str.path_join("this/test"), "./temp/lib/index.js"),
+        ("with symlinked directory as context 2 (chained)", temp_path_str.path_join("that"), "./lib/index.js"),
+        ("with symlinked directory as context and in path (chained)", temp_path_str.path_join("that"), "./test/temp/lib/index.js"),
+        ("with symlinked directory in context path (chained)", temp_path_str.path_join("that/lib"), "./index.js"),
+        ("with symlinked directory in context path and symlinked file (chained)", temp_path_str.path_join("that/test"), "./temp/index.js"),
+        ("with symlinked directory in context path and symlinked directory (chained)", temp_path_str.path_join("that/test"), "./temp/lib/index.js")
     ];
 
   for (comment, path, request) in pass {
@@ -139,14 +147,14 @@ async fn test() -> io::Result<()> {
       .resolve(&path, request)
       .await
       .map(|r| r.full_path());
-    assert_eq!(filename, Ok(root.join("lib/index.js")), "{comment:?}");
+    assert_eq!(filename, Ok(root.path_join("lib/index.js")), "{comment:?}");
 
     let mut ctx = &mut Default::default();
     let resolved_path = resolver_without_symlinks
       .resolve_with_context(&path, request, &mut ctx)
       .await
       .map(|r| r.full_path());
-    assert_eq!(resolved_path, Ok(path.join(request)));
+    assert_eq!(resolved_path, Ok(path.path_join(request)));
     assert!(
       ctx.file_dependencies.contains(&resolved_path.unwrap()),
       "file dependencies should contain resolved path {comment:?}"

--- a/src/tests/tsconfig_paths.rs
+++ b/src/tests/tsconfig_paths.rs
@@ -2,6 +2,8 @@
 //!
 //! Fixtures copied from <https://github.com/parcel-bundler/parcel/tree/v2/packages/utils/node-resolver-core/test/fixture/tsconfig>.
 
+use std::path::PathBuf;
+
 use super::JoinExt;
 use crate::{
   JSONError, ResolveError, ResolveOptions, Resolver, TsConfig, TsconfigOptions, TsconfigReferences,
@@ -165,8 +167,16 @@ async fn test_paths() {
   ];
 
   for (specifier, expected) in data {
-    let paths = tsconfig.resolve_path_alias(specifier);
-    let expected = expected.into_iter().map(String::from).collect::<Vec<_>>();
+    // PathBuf comparison: tsconfig path aliases are logical paths whose
+    // separator may differ from MAIN_SEPARATOR (the test expects `/`, the
+    // resolver builds with `\\` on Windows). `PathBuf::eq` is component-wise,
+    // matching pre-refactor `main` behavior.
+    let paths = tsconfig
+      .resolve_path_alias(specifier)
+      .into_iter()
+      .map(PathBuf::from)
+      .collect::<Vec<_>>();
+    let expected = expected.into_iter().map(PathBuf::from).collect::<Vec<_>>();
     assert_eq!(paths, expected, "{specifier}");
   }
 }
@@ -190,8 +200,16 @@ async fn test_base_url() {
   ];
 
   for (specifier, expected) in data {
-    let paths = tsconfig.resolve_path_alias(specifier);
-    let expected = expected.into_iter().map(String::from).collect::<Vec<_>>();
+    // PathBuf comparison: tsconfig path aliases are logical paths whose
+    // separator may differ from MAIN_SEPARATOR (the test expects `/`, the
+    // resolver builds with `\\` on Windows). `PathBuf::eq` is component-wise,
+    // matching pre-refactor `main` behavior.
+    let paths = tsconfig
+      .resolve_path_alias(specifier)
+      .into_iter()
+      .map(PathBuf::from)
+      .collect::<Vec<_>>();
+    let expected = expected.into_iter().map(PathBuf::from).collect::<Vec<_>>();
     assert_eq!(paths, expected, "{specifier}");
   }
 }
@@ -233,8 +251,16 @@ async fn test_paths_and_base_url() {
   ];
 
   for (specifier, expected) in data {
-    let paths = tsconfig.resolve_path_alias(specifier);
-    let expected = expected.into_iter().map(String::from).collect::<Vec<_>>();
+    // PathBuf comparison: tsconfig path aliases are logical paths whose
+    // separator may differ from MAIN_SEPARATOR (the test expects `/`, the
+    // resolver builds with `\\` on Windows). `PathBuf::eq` is component-wise,
+    // matching pre-refactor `main` behavior.
+    let paths = tsconfig
+      .resolve_path_alias(specifier)
+      .into_iter()
+      .map(PathBuf::from)
+      .collect::<Vec<_>>();
+    let expected = expected.into_iter().map(PathBuf::from).collect::<Vec<_>>();
     assert_eq!(paths, expected, "{specifier}");
   }
 }

--- a/src/tests/tsconfig_paths.rs
+++ b/src/tests/tsconfig_paths.rs
@@ -2,8 +2,7 @@
 //!
 //! Fixtures copied from <https://github.com/parcel-bundler/parcel/tree/v2/packages/utils/node-resolver-core/test/fixture/tsconfig>.
 
-use std::path::{Path, PathBuf};
-
+use super::JoinExt;
 use crate::{
   JSONError, ResolveError, ResolveOptions, Resolver, TsConfig, TsconfigOptions, TsconfigReferences,
 };
@@ -11,31 +10,31 @@ use crate::{
 // <https://github.com/parcel-bundler/parcel/blob/b6224fd519f95e68d8b93ba90376fd94c8b76e69/packages/utils/node-resolver-rs/src/lib.rs#L2303>
 #[tokio::test]
 async fn tsconfig() {
-  let f = super::fixture_root().join("tsconfig");
+  let f = super::fixture_root().path_join("tsconfig");
 
   #[rustfmt::skip]
     let pass = [
-        (f.clone(), None, "ts-path", f.join("foo.js")),
-        (f.join("nested"), None, "ts-path", f.join("nested/test.js")),
-        (f.join("cases/index"), None, "foo", f.join("node_modules/tsconfig-index/foo.js")),
+        (f.clone(), None, "ts-path", f.path_join("foo.js")),
+        (f.path_join("nested"), None, "ts-path", f.path_join("nested/test.js")),
+        (f.path_join("cases/index"), None, "foo", f.path_join("node_modules/tsconfig-index/foo.js")),
         // This requires reading package.json.tsconfig field
-        // (f.join("cases/field"), "foo", f.join("node_modules/tsconfig-field/foo.js"))
-        (f.join("cases/exports"), None, "foo", f.join("node_modules/tsconfig-exports/foo.js")),
-        (f.join("cases/extends-extension"), None, "foo", f.join("cases/extends-extension/foo.js")),
-        (f.join("cases/extends-extensionless"), None, "foo", f.join("node_modules/tsconfig-field/foo.js")),
-        (f.join("cases/extends-paths"), Some("src"), "@/index", f.join("cases/extends-paths/src/index.js")),
-        (f.join("cases/extends-multiple"), None, "foo", f.join("cases/extends-multiple/foo.js")),
+        // (f.path_join("cases/field"), "foo", f.path_join("node_modules/tsconfig-field/foo.js"))
+        (f.path_join("cases/exports"), None, "foo", f.path_join("node_modules/tsconfig-exports/foo.js")),
+        (f.path_join("cases/extends-extension"), None, "foo", f.path_join("cases/extends-extension/foo.js")),
+        (f.path_join("cases/extends-extensionless"), None, "foo", f.path_join("node_modules/tsconfig-field/foo.js")),
+        (f.path_join("cases/extends-paths"), Some("src"), "@/index", f.path_join("cases/extends-paths/src/index.js")),
+        (f.path_join("cases/extends-multiple"), None, "foo", f.path_join("cases/extends-multiple/foo.js")),
     ];
 
   for (dir, subdir, request, expected) in pass {
     let resolver = Resolver::new(ResolveOptions {
       tsconfig: Some(TsconfigOptions {
-        config_file: dir.join("tsconfig.json"),
+        config_file: dir.path_join("tsconfig.json"),
         references: TsconfigReferences::Auto,
       }),
       ..ResolveOptions::default()
     });
-    let path = subdir.map_or(dir.clone(), |subdir| dir.join(subdir));
+    let path = subdir.map_or(dir.clone(), |subdir| dir.path_join(subdir));
     let resolved_path = resolver
       .resolve(&path, request)
       .await
@@ -45,12 +44,12 @@ async fn tsconfig() {
 
   #[rustfmt::skip]
     let data = [
-        (f.join("node_modules/tsconfig-not-used"), "ts-path", Ok(f.join("foo.js"))),
+        (f.path_join("node_modules/tsconfig-not-used"), "ts-path", Ok(f.path_join("foo.js"))),
     ];
 
   let resolver = Resolver::new(ResolveOptions {
     tsconfig: Some(TsconfigOptions {
-      config_file: f.join("tsconfig.json"),
+      config_file: f.path_join("tsconfig.json"),
       references: TsconfigReferences::Auto,
     }),
     ..ResolveOptions::default()
@@ -66,11 +65,11 @@ async fn tsconfig() {
 
 #[tokio::test]
 async fn tsconfig_fallthrough() {
-  let f = super::fixture_root().join("tsconfig");
+  let f = super::fixture_root().path_join("tsconfig");
 
   let resolver = Resolver::new(ResolveOptions {
     tsconfig: Some(TsconfigOptions {
-      config_file: f.join("tsconfig.json"),
+      config_file: f.path_join("tsconfig.json"),
       references: TsconfigReferences::Auto,
     }),
     ..ResolveOptions::default()
@@ -82,27 +81,27 @@ async fn tsconfig_fallthrough() {
 
 #[tokio::test]
 async fn json_with_comments() {
-  let f = super::fixture_root().join("tsconfig/cases/trailing-comma");
+  let f = super::fixture_root().path_join("tsconfig/cases/trailing-comma");
 
   let resolver = Resolver::new(ResolveOptions {
     tsconfig: Some(TsconfigOptions {
-      config_file: f.join("tsconfig.json"),
+      config_file: f.path_join("tsconfig.json"),
       references: TsconfigReferences::Auto,
     }),
     ..ResolveOptions::default()
   });
 
   let resolved_path = resolver.resolve(&f, "foo").await.map(|f| f.full_path());
-  assert_eq!(resolved_path, Ok(f.join("bar.js")));
+  assert_eq!(resolved_path, Ok(f.path_join("bar.js")));
 }
 
 #[tokio::test]
 async fn broken() {
-  let f = super::fixture_root().join("tsconfig");
+  let f = super::fixture_root().path_join("tsconfig");
 
   let resolver = Resolver::new(ResolveOptions {
     tsconfig: Some(TsconfigOptions {
-      config_file: f.join("tsconfig_broken.json"),
+      config_file: f.path_join("tsconfig_broken.json"),
       references: TsconfigReferences::Auto,
     }),
     ..ResolveOptions::default()
@@ -110,7 +109,7 @@ async fn broken() {
 
   let resolved_path = resolver.resolve(&f, "/").await;
   let _error = ResolveError::JSON(JSONError {
-    path: f.join("tsconfig_broken.json"),
+    path: f.path_join("tsconfig_broken.json"),
     message: String::from("EOF while parsing an object at line 2 column 0"),
     line: 2,
     column: 0,
@@ -121,24 +120,24 @@ async fn broken() {
 
 #[tokio::test]
 async fn empty() {
-  let f = super::fixture_root().join("tsconfig/cases/empty");
+  let f = super::fixture_root().path_join("tsconfig/cases/empty");
 
   let resolver = Resolver::new(ResolveOptions {
     tsconfig: Some(TsconfigOptions {
-      config_file: f.join("tsconfig.json"),
+      config_file: f.path_join("tsconfig.json"),
       references: TsconfigReferences::Auto,
     }),
     ..ResolveOptions::default()
   });
 
   let resolved_path = resolver.resolve(&f, "./index").await.map(|f| f.full_path());
-  assert_eq!(resolved_path, Ok(f.join("index.js")));
+  assert_eq!(resolved_path, Ok(f.path_join("index.js")));
 }
 
 // <https://github.com/parcel-bundler/parcel/blob/c8f5c97a01f643b4d5c333c02d019ef2618b44a5/packages/utils/node-resolver-rs/src/tsconfig.rs#L193C12-L193C12>
 #[tokio::test]
 async fn test_paths() {
-  let path = Path::new("/foo/tsconfig.json");
+  let path = "/foo/tsconfig.json";
   let mut tsconfig_json = serde_json::json!({
       "compilerOptions": {
           "paths": {
@@ -167,7 +166,7 @@ async fn test_paths() {
 
   for (specifier, expected) in data {
     let paths = tsconfig.resolve_path_alias(specifier);
-    let expected = expected.into_iter().map(PathBuf::from).collect::<Vec<_>>();
+    let expected = expected.into_iter().map(String::from).collect::<Vec<_>>();
     assert_eq!(paths, expected, "{specifier}");
   }
 }
@@ -175,7 +174,7 @@ async fn test_paths() {
 // <https://github.com/parcel-bundler/parcel/blob/c8f5c97a01f643b4d5c333c02d019ef2618b44a5/packages/utils/node-resolver-rs/src/tsconfig.rs#L233C6-L233C19>
 #[tokio::test]
 async fn test_base_url() {
-  let path = Path::new("/foo/tsconfig.json");
+  let path = "/foo/tsconfig.json";
   let mut tsconfig_json = serde_json::json!({
       "compilerOptions": {
           "baseUrl": "./src"
@@ -192,7 +191,7 @@ async fn test_base_url() {
 
   for (specifier, expected) in data {
     let paths = tsconfig.resolve_path_alias(specifier);
-    let expected = expected.into_iter().map(PathBuf::from).collect::<Vec<_>>();
+    let expected = expected.into_iter().map(String::from).collect::<Vec<_>>();
     assert_eq!(paths, expected, "{specifier}");
   }
 }
@@ -200,7 +199,7 @@ async fn test_base_url() {
 // <https://github.com/parcel-bundler/parcel/blob/c8f5c97a01f643b4d5c333c02d019ef2618b44a5/packages/utils/node-resolver-rs/src/tsconfig.rs#L252>
 #[tokio::test]
 async fn test_paths_and_base_url() {
-  let path = Path::new("/foo/tsconfig.json");
+  let path = "/foo/tsconfig.json";
   let mut tsconfig_json = serde_json::json!({
       "compilerOptions": {
           "baseUrl": "./src",
@@ -235,7 +234,7 @@ async fn test_paths_and_base_url() {
 
   for (specifier, expected) in data {
     let paths = tsconfig.resolve_path_alias(specifier);
-    let expected = expected.into_iter().map(PathBuf::from).collect::<Vec<_>>();
+    let expected = expected.into_iter().map(String::from).collect::<Vec<_>>();
     assert_eq!(paths, expected, "{specifier}");
   }
 }
@@ -244,22 +243,22 @@ async fn test_paths_and_base_url() {
 // https://github.com/microsoft/TypeScript/pull/58042
 #[tokio::test]
 async fn test_template_variable() {
-  let f = super::fixture_root().join("tsconfig");
-  let f2 = f.join("cases").join("paths_template_variable");
+  let f = super::fixture_root().path_join("tsconfig");
+  let f2 = f.path_join("cases").path_join("paths_template_variable");
 
   #[rustfmt::skip]
     let pass = [
-        (f2.clone(), "tsconfig1.json", "foo", f2.join("foo.js")),
-        (f2.clone(), "tsconfig2.json", "foo", f2.join("foo.js")),
-        (f2.clone(), "tsconfig3.json", "foo", f2.join("foo.js")),
-        (f.clone(), "tsconfig_template_variable.json", "foo", f.join("foo.js")),
-        (f.clone(), "tsconfig_template_variable_with_base_url.json", "foo", f.join("foo.js")),
+        (f2.clone(), "tsconfig1.json", "foo", f2.path_join("foo.js")),
+        (f2.clone(), "tsconfig2.json", "foo", f2.path_join("foo.js")),
+        (f2.clone(), "tsconfig3.json", "foo", f2.path_join("foo.js")),
+        (f.clone(), "tsconfig_template_variable.json", "foo", f.path_join("foo.js")),
+        (f.clone(), "tsconfig_template_variable_with_base_url.json", "foo", f.path_join("foo.js")),
     ];
 
   for (dir, tsconfig, request, expected) in pass {
     let resolver = Resolver::new(ResolveOptions {
       tsconfig: Some(TsconfigOptions {
-        config_file: dir.join(tsconfig),
+        config_file: dir.path_join(tsconfig),
         references: TsconfigReferences::Auto,
       }),
       ..ResolveOptions::default()
@@ -276,14 +275,14 @@ async fn test_template_variable() {
 // module resolution (node_modules), matching TypeScript's native behavior.
 #[tokio::test]
 async fn tsconfig_paths_scoped_pkg_fallthrough() {
-  let f = super::fixture_root().join("tsconfig/cases/scoped-pkg-fallthrough");
+  let f = super::fixture_root().path_join("tsconfig/cases/scoped-pkg-fallthrough");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".ts".into(), ".tsx".into(), ".js".into()],
     main_fields: vec!["main".into()],
     main_files: vec!["index".into()],
     tsconfig: Some(TsconfigOptions {
-      config_file: f.join("tsconfig.json"),
+      config_file: f.path_join("tsconfig.json"),
       references: TsconfigReferences::Auto,
     }),
     ..ResolveOptions::default()
@@ -291,7 +290,7 @@ async fn tsconfig_paths_scoped_pkg_fallthrough() {
 
   // "@helper" resolves via the "@*" mapping when the mapped path exists
   let resolved_path = resolver.resolve(&f, "@helper").await.map(|p| p.full_path());
-  assert_eq!(resolved_path, Ok(f.join("src/helper/index.ts")));
+  assert_eq!(resolved_path, Ok(f.path_join("src/helper/index.ts")));
 
   // "@sentry/react" falls through to node_modules when "@*" mapping does
   // not resolve to an existing file.
@@ -301,21 +300,19 @@ async fn tsconfig_paths_scoped_pkg_fallthrough() {
     .map(|p| p.full_path());
   assert_eq!(
     resolved_path,
-    Ok(f.join("node_modules/@sentry/react/index.js"))
+    Ok(f.path_join("node_modules/@sentry/react/index.js"))
   );
 }
 
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 mod windows_test {
-  use std::path::{Path, PathBuf};
-
-  use super::super::memory_fs::MemoryFS;
+  use super::super::{memory_fs::MemoryFS, JoinExt};
   use crate::{ResolveError, ResolveOptions, ResolverGeneric, TsconfigOptions, TsconfigReferences};
 
   struct OneTest {
     name: &'static str,
     tsconfig: String,
-    package_json: Option<(PathBuf, String)>,
+    package_json: Option<(String, String)>,
     main_fields: Option<Vec<String>>,
     existing_files: Vec<&'static str>,
     requested_module: &'static str,
@@ -352,21 +349,24 @@ mod windows_test {
   }
 
   impl OneTest {
-    fn resolver(&self, root: &Path) -> ResolverGeneric<MemoryFS> {
+    fn resolver(&self, root: &str) -> ResolverGeneric<MemoryFS> {
       let mut file_system = MemoryFS::default();
 
-      file_system.add_file(&root.join("tsconfig.json"), &self.tsconfig);
+      file_system.add_file(&root.path_join("tsconfig.json"), &self.tsconfig);
       if let Some((path, package_json)) = &self.package_json {
-        file_system.add_file(&root.join(path).join("package.json"), package_json);
+        file_system.add_file(
+          &root.path_join(path).path_join("package.json"),
+          package_json,
+        );
       }
       for path in &self.existing_files {
-        file_system.add_file(Path::new(path), "");
+        file_system.add_file(path, "");
       }
 
       let mut options = ResolveOptions {
         extensions: self.extensions.clone(),
         tsconfig: Some(TsconfigOptions {
-          config_file: root.join("tsconfig.json"),
+          config_file: root.path_join("tsconfig.json"),
           references: TsconfigReferences::Auto,
         }),
         ..ResolveOptions::default()
@@ -467,7 +467,7 @@ mod windows_test {
       OneTest {
         name: "should resolve from main field in package.json",
         package_json: Some((
-          PathBuf::from("/root/location/mylib"),
+          "/root/location/mylib".to_string(),
           serde_json::json!({
               "main": "./kalle.ts"
           })
@@ -481,7 +481,7 @@ mod windows_test {
       OneTest {
         name: "should resolve from main field in package.json (js)",
         package_json: Some((
-          PathBuf::from("/root/location/mylib.js"),
+          "/root/location/mylib.js".to_string(),
           serde_json::json!({
               "main": "./kalle.js"
           })
@@ -497,7 +497,7 @@ mod windows_test {
         name: "should resolve from list of fields by priority in package.json",
         main_fields: Some(vec!["missing".into(), "browser".into(), "main".into()]),
         package_json: Some((
-          PathBuf::from("/root/location/mylibjs"),
+          "/root/location/mylibjs".to_string(),
           serde_json::json!({
               "main": "./main.js",
               "browser": "./browser.js"
@@ -517,7 +517,7 @@ mod windows_test {
         name: "should ignore field mappings to missing files in package.json",
         main_fields: Some(vec!["browser".into(), "main".into()]),
         package_json: Some((
-          PathBuf::from("/root/location/mylibjs"),
+          "/root/location/mylibjs".to_string(),
           serde_json::json!({
               "main": "./kalle.js",
               "browser": "./nope.js"
@@ -553,7 +553,7 @@ mod windows_test {
       },
     ];
 
-    let root = PathBuf::from("/root");
+    let root = "/root".to_string();
 
     for test in pass {
       let resolved_path = test
@@ -563,7 +563,7 @@ mod windows_test {
         .map(|f| f.full_path());
       assert_eq!(
         resolved_path,
-        Ok(PathBuf::from(test.expected_path)),
+        Ok(test.expected_path.to_string()),
         "{}",
         test.name
       );

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -1,16 +1,27 @@
 //! Tests for tsconfig project references
 
+use std::path::Path;
+
+use super::JoinExt;
 use crate::{
   ResolveContext, ResolveError, ResolveOptions, Resolver, TsconfigOptions, TsconfigReferences,
 };
 
+fn parent_str(p: &str) -> String {
+  Path::new(p)
+    .parent()
+    .and_then(|p| p.to_str())
+    .unwrap()
+    .to_string()
+}
+
 #[tokio::test]
 async fn auto() {
-  let f = super::fixture_root().join("tsconfig/cases/project_references");
+  let f = super::fixture_root().path_join("tsconfig/cases/project_references");
 
   let resolver = Resolver::new(ResolveOptions {
     tsconfig: Some(TsconfigOptions {
-      config_file: f.join("app"),
+      config_file: f.path_join("app"),
       references: TsconfigReferences::Auto,
     }),
     ..ResolveOptions::default()
@@ -19,18 +30,18 @@ async fn auto() {
   #[rustfmt::skip]
     let pass = [
         // Test normal paths alias
-        (f.join("app"), "@/index.ts", f.join("app/aliased/index.ts")),
-        (f.join("app"), "@/../index.ts", f.join("app/index.ts")),
+        (f.path_join("app"), "@/index.ts", f.path_join("app/aliased/index.ts")),
+        (f.path_join("app"), "@/../index.ts", f.path_join("app/index.ts")),
         // Test project reference
-        (f.join("project_a"), "@/index.ts", f.join("project_a/aliased/index.ts")),
-        (f.join("project_b/src"), "@/index.ts", f.join("project_b/src/aliased/index.ts")),
+        (f.path_join("project_a"), "@/index.ts", f.path_join("project_a/aliased/index.ts")),
+        (f.path_join("project_b/src"), "@/index.ts", f.path_join("project_b/src/aliased/index.ts")),
         // Does not have paths alias
-        (f.join("project_a"), "./index.ts", f.join("project_a/index.ts")),
-        (f.join("project_c"), "./index.ts", f.join("project_c/index.ts")),
+        (f.path_join("project_a"), "./index.ts", f.path_join("project_a/index.ts")),
+        (f.path_join("project_c"), "./index.ts", f.path_join("project_c/index.ts")),
         // Template variable
         {
-            let dir = f.parent().unwrap().join("paths_template_variable");
-            (dir.clone(), "foo", dir.join("foo.js"))
+            let dir = parent_str(&f).path_join("paths_template_variable");
+            (dir.clone(), "foo", dir.path_join("foo.js"))
         }
     ];
 
@@ -45,11 +56,11 @@ async fn auto() {
 
 #[tokio::test]
 async fn tsconfig_file_as_file_dependencies() {
-  let f = super::fixture_root().join("tsconfig/cases/project_references");
+  let f = super::fixture_root().path_join("tsconfig/cases/project_references");
 
   let resolver = Resolver::new(ResolveOptions {
     tsconfig: Some(TsconfigOptions {
-      config_file: f.join("app"),
+      config_file: f.path_join("app"),
       references: TsconfigReferences::Auto,
     }),
     ..ResolveOptions::default()
@@ -57,20 +68,21 @@ async fn tsconfig_file_as_file_dependencies() {
   let mut ctx = ResolveContext::default();
 
   let resolved_path = resolver
-    .resolve_with_context(&f.join("project_b/src"), "@/index.ts", &mut ctx)
+    .resolve_with_context(&f.path_join("project_b/src"), "@/index.ts", &mut ctx)
     .await
     .map(|f| f.full_path());
-  assert_eq!(resolved_path, Ok(f.join("project_b/src/aliased/index.ts")));
+  assert_eq!(
+    resolved_path,
+    Ok(f.path_join("project_b/src/aliased/index.ts"))
+  );
 
   let expected_dependencies = [
-    f.join("app/tsconfig.json"),
-    f.join("tsconfig.base.json"),
-    f.join("project_a/conf.json"),
-    f.join("project_b/tsconfig.json"),
-    f.join("project_c/tsconfig.json"),
-    f.parent()
-      .unwrap()
-      .join("paths_template_variable/tsconfig2.json"),
+    f.path_join("app/tsconfig.json"),
+    f.path_join("tsconfig.base.json"),
+    f.path_join("project_a/conf.json"),
+    f.path_join("project_b/tsconfig.json"),
+    f.path_join("project_c/tsconfig.json"),
+    parent_str(&f).path_join("paths_template_variable/tsconfig2.json"),
   ];
   for dependency in expected_dependencies {
     assert!(
@@ -83,11 +95,11 @@ async fn tsconfig_file_as_file_dependencies() {
 
 #[tokio::test]
 async fn disabled() {
-  let f = super::fixture_root().join("tsconfig/cases/project_references");
+  let f = super::fixture_root().path_join("tsconfig/cases/project_references");
 
   let resolver = Resolver::new(ResolveOptions {
     tsconfig: Some(TsconfigOptions {
-      config_file: f.join("app"),
+      config_file: f.path_join("app"),
       references: TsconfigReferences::Disabled,
     }),
     ..ResolveOptions::default()
@@ -96,14 +108,14 @@ async fn disabled() {
   #[rustfmt::skip]
     let pass = [
         // Test normal paths alias
-        (f.join("app"), "@/index.ts", Ok(f.join("app/aliased/index.ts"))),
-        (f.join("app"), "@/../index.ts", Ok(f.join("app/index.ts"))),
+        (f.path_join("app"), "@/index.ts", Ok(f.path_join("app/aliased/index.ts"))),
+        (f.path_join("app"), "@/../index.ts", Ok(f.path_join("app/index.ts"))),
         // Test project reference
-        (f.join("project_a"), "@/index.ts", Ok(f.join("app/aliased/index.ts"))),
-        (f.join("project_b/src"), "@/index.ts", Ok(f.join("app/aliased/index.ts"))),
+        (f.path_join("project_a"), "@/index.ts", Ok(f.path_join("app/aliased/index.ts"))),
+        (f.path_join("project_b/src"), "@/index.ts", Ok(f.path_join("app/aliased/index.ts"))),
         // Does not have paths alias
-        (f.join("project_a"), "./index.ts", Ok(f.join("project_a/index.ts"))),
-        (f.join("project_c"), "./index.ts", Ok(f.join("project_c/index.ts"))),
+        (f.path_join("project_a"), "./index.ts", Ok(f.path_join("project_a/index.ts"))),
+        (f.path_join("project_c"), "./index.ts", Ok(f.path_join("project_c/index.ts"))),
     ];
 
   for (path, request, expected) in pass {
@@ -117,11 +129,11 @@ async fn disabled() {
 
 #[tokio::test]
 async fn manual() {
-  let f = super::fixture_root().join("tsconfig/cases/project_references");
+  let f = super::fixture_root().path_join("tsconfig/cases/project_references");
 
   let resolver = Resolver::new(ResolveOptions {
     tsconfig: Some(TsconfigOptions {
-      config_file: f.join("app"),
+      config_file: f.path_join("app"),
       references: TsconfigReferences::Paths(vec!["../project_a/conf.json".into()]),
     }),
     ..ResolveOptions::default()
@@ -130,14 +142,14 @@ async fn manual() {
   #[rustfmt::skip]
     let pass = [
         // Test normal paths alias
-        (f.join("app"), "@/index.ts", Ok(f.join("app/aliased/index.ts"))),
-        (f.join("app"), "@/../index.ts", Ok(f.join("app/index.ts"))),
+        (f.path_join("app"), "@/index.ts", Ok(f.path_join("app/aliased/index.ts"))),
+        (f.path_join("app"), "@/../index.ts", Ok(f.path_join("app/index.ts"))),
         // Test project reference
-        (f.join("project_a"), "@/index.ts", Ok(f.join("project_a/aliased/index.ts"))),
-        (f.join("project_b/src"), "@/index.ts", Ok(f.join("app/aliased/index.ts"))),
+        (f.path_join("project_a"), "@/index.ts", Ok(f.path_join("project_a/aliased/index.ts"))),
+        (f.path_join("project_b/src"), "@/index.ts", Ok(f.path_join("app/aliased/index.ts"))),
         // Does not have paths alias
-        (f.join("project_a"), "./index.ts", Ok(f.join("project_a/index.ts"))),
-        (f.join("project_c"), "./index.ts", Ok(f.join("project_c/index.ts"))),
+        (f.path_join("project_a"), "./index.ts", Ok(f.path_join("project_a/index.ts"))),
+        (f.path_join("project_c"), "./index.ts", Ok(f.path_join("project_c/index.ts"))),
     ];
 
   for (path, request, expected) in pass {
@@ -151,15 +163,15 @@ async fn manual() {
 
 #[tokio::test]
 async fn self_reference() {
-  let f = super::fixture_root().join("tsconfig/cases/project_references");
+  let f = super::fixture_root().path_join("tsconfig/cases/project_references");
 
   #[rustfmt::skip]
     let pass = [
-        (f.join("app"), vec!["./tsconfig.json".into()]),
-        (f.join("app/tsconfig.json"), vec!["./tsconfig.json".into()]),
-        (f.join("app"), vec![f.join("app")]),
-        (f.join("app/tsconfig.json"), vec![f.join("app")]),
-        (f.join("app/tsconfig.json"), vec![f.join("project_b"), f.join("app")]),
+        (f.path_join("app"), vec!["./tsconfig.json".into()]),
+        (f.path_join("app/tsconfig.json"), vec!["./tsconfig.json".into()]),
+        (f.path_join("app"), vec![f.path_join("app")]),
+        (f.path_join("app/tsconfig.json"), vec![f.path_join("app")]),
+        (f.path_join("app/tsconfig.json"), vec![f.path_join("project_b"), f.path_join("app")]),
     ];
 
   for (config_file, reference_paths) in pass {
@@ -170,7 +182,7 @@ async fn self_reference() {
       }),
       ..ResolveOptions::default()
     });
-    let path = f.join("app");
+    let path = f.path_join("app");
     let resolved_path = resolver
       .resolve(&path, "@/index.ts")
       .await
@@ -178,7 +190,7 @@ async fn self_reference() {
     assert_eq!(
       resolved_path,
       Err(ResolveError::TsconfigSelfReference(
-        f.join("app/tsconfig.json")
+        f.path_join("app/tsconfig.json")
       )),
       "{config_file:?} {reference_paths:?}"
     );
@@ -192,11 +204,11 @@ async fn self_reference() {
 // recursive `references: "auto"` walk).
 #[tokio::test]
 async fn transitive_references() {
-  let f = super::fixture_root().join("tsconfig/cases/references-transitive");
+  let f = super::fixture_root().path_join("tsconfig/cases/references-transitive");
 
   let resolver = Resolver::new(ResolveOptions {
     tsconfig: Some(TsconfigOptions {
-      config_file: f.join("app"),
+      config_file: f.path_join("app"),
       references: TsconfigReferences::Auto,
     }),
     ..ResolveOptions::default()
@@ -204,19 +216,23 @@ async fn transitive_references() {
 
   let cases = [
     // Direct: file in app uses app's paths.
-    (f.join("app"), "@/index.ts", f.join("app/aliased/index.ts")),
+    (
+      f.path_join("app"),
+      "@/index.ts",
+      f.path_join("app/aliased/index.ts"),
+    ),
     // One level: file in project_b uses project_b's paths (baseUrl ./src).
     (
-      f.join("project_b/src"),
+      f.path_join("project_b/src"),
       "@/index.ts",
-      f.join("project_b/src/aliased/index.ts"),
+      f.path_join("project_b/src/aliased/index.ts"),
     ),
     // Two levels: file in project_c (referenced by project_b which is
     // referenced by app) uses project_c's paths.
     (
-      f.join("project_c"),
+      f.path_join("project_c"),
       "@/index.ts",
-      f.join("project_c/aliased/index.ts"),
+      f.path_join("project_c/aliased/index.ts"),
     ),
   ];
 
@@ -236,11 +252,11 @@ async fn transitive_references() {
 // alias candidates and fail to resolve.
 #[tokio::test]
 async fn references_with_extends() {
-  let f = super::fixture_root().join("tsconfig/cases/references-extends");
+  let f = super::fixture_root().path_join("tsconfig/cases/references-extends");
 
   let resolver = Resolver::new(ResolveOptions {
     tsconfig: Some(TsconfigOptions {
-      config_file: f.join("app"),
+      config_file: f.path_join("app"),
       references: TsconfigReferences::Auto,
     }),
     ..ResolveOptions::default()
@@ -249,17 +265,20 @@ async fn references_with_extends() {
   // From project_b's directory, the inherited `paths` from
   // ../tsconfig.base.json must apply (baseUrl ./src).
   let resolved_path = resolver
-    .resolve(&f.join("project_b/src"), "@/index.ts")
+    .resolve(&f.path_join("project_b/src"), "@/index.ts")
     .await
     .map(|p| p.full_path());
-  assert_eq!(resolved_path, Ok(f.join("project_b/src/aliased/index.ts")));
+  assert_eq!(
+    resolved_path,
+    Ok(f.path_join("project_b/src/aliased/index.ts"))
+  );
 
   // The entry tsconfig still uses its own `paths`.
   let resolved_path = resolver
-    .resolve(&f.join("app"), "@/index.ts")
+    .resolve(&f.path_join("app"), "@/index.ts")
     .await
     .map(|p| p.full_path());
-  assert_eq!(resolved_path, Ok(f.join("app/aliased/index.ts")));
+  assert_eq!(resolved_path, Ok(f.path_join("app/aliased/index.ts")));
 }
 
 // A pair of project references that form a cycle (a → b → a) must not
@@ -268,26 +287,26 @@ async fn references_with_extends() {
 // be honored from within its own directory.
 #[tokio::test]
 async fn cyclic_references() {
-  let f = super::fixture_root().join("tsconfig/cases/references-cycle");
+  let f = super::fixture_root().path_join("tsconfig/cases/references-cycle");
 
   let resolver = Resolver::new(ResolveOptions {
     extensions: vec![".ts".into()],
     tsconfig: Some(TsconfigOptions {
-      config_file: f.join("a"),
+      config_file: f.path_join("a"),
       references: TsconfigReferences::Auto,
     }),
     ..ResolveOptions::default()
   });
 
   let resolved_path = resolver
-    .resolve(&f.join("a"), "@a/index")
+    .resolve(&f.path_join("a"), "@a/index")
     .await
     .map(|p| p.full_path());
-  assert_eq!(resolved_path, Ok(f.join("a/src/index.ts")));
+  assert_eq!(resolved_path, Ok(f.path_join("a/src/index.ts")));
 
   let resolved_path = resolver
-    .resolve(&f.join("b"), "@b/index")
+    .resolve(&f.path_join("b"), "@b/index")
     .await
     .map(|p| p.full_path());
-  assert_eq!(resolved_path, Ok(f.join("b/src/index.ts")));
+  assert_eq!(resolved_path, Ok(f.path_join("b/src/index.ts")));
 }

--- a/src/tests/windows.rs
+++ b/src/tests/windows.rs
@@ -47,7 +47,16 @@ mod tests {
       .map(|p| p.normalize())
       .collect::<HashSet<_>>();
 
-    assert_eq!(resolved_path_string, file_path_string);
-    assert_eq!(expected_file_deps, actual_file_deps);
+    // PathBuf comparison: pnp/POSIX-style paths flowing through this code
+    // path may carry `/` separators even on Windows; component-wise eq via
+    // PathBuf reproduces the pre-refactor (Path-based) semantics.
+    use std::path::PathBuf;
+    assert_eq!(
+      PathBuf::from(&resolved_path_string),
+      PathBuf::from(&file_path_string)
+    );
+    let expected_paths: HashSet<PathBuf> = expected_file_deps.iter().map(PathBuf::from).collect();
+    let actual_paths: HashSet<PathBuf> = actual_file_deps.iter().map(PathBuf::from).collect();
+    assert_eq!(expected_paths, actual_paths);
   }
 }

--- a/src/tests/windows.rs
+++ b/src/tests/windows.rs
@@ -1,14 +1,18 @@
 #[cfg(test)]
 mod tests {
-  use std::{collections::HashSet, path::Path};
+  use std::collections::HashSet;
 
-  use crate::{path::PathUtil, tests::fixture, FileSystemOs, ResolverGeneric};
+  use crate::{
+    path::PathUtil,
+    tests::{fixture, JoinExt},
+    FileSystemOs, ResolverGeneric,
+  };
 
   #[tokio::test]
   async fn facts_path_compare_use_component_only() {
     // So we assert the equality with path's string other than path itself.
-    let path_win = Path::new("d:\\test\\index.js");
-    let path_posix = Path::new("d:/test/index.js");
+    let path_win = std::path::Path::new(r"d:\test\index.js");
+    let path_posix = std::path::Path::new("d:/test/index.js");
 
     assert_eq!(path_posix, path_win)
   }
@@ -16,10 +20,10 @@ mod tests {
   async fn require_absolution_path_in_windows() {
     let resolver = ResolverGeneric::<FileSystemOs>::new(Default::default());
 
-    let file = fixture().join("foo/index.js");
-    let pkg_json = fixture().join("foo/package.json");
-    let file_path_string = to_string(&file);
-    let pkg_json_path_string = to_string(pkg_json);
+    let file = fixture().path_join("foo/index.js");
+    let pkg_json = fixture().path_join("foo/package.json");
+    let file_path_string = file.normalize();
+    let pkg_json_path_string = pkg_json.normalize();
 
     let expected_file_deps = {
       let mut s = HashSet::new();
@@ -29,33 +33,21 @@ mod tests {
     };
 
     // make a posix style  path string e.g  d:/foo/bar.js
-    let specifier = to_string(&file).replace("\\", "/");
+    let specifier = file.replace('\\', "/");
 
     let mut ctx = Default::default();
     let resolved = resolver
       .resolve_with_context(&file, &specifier, &mut ctx)
       .await
       .unwrap();
-    let resolved_path_string = resolved
-      .path
-      .to_str()
-      .expect("path should be UTF-8")
-      .to_string();
+    let resolved_path_string = resolved.path.to_string();
     let actual_file_deps = ctx
       .file_dependencies
       .iter()
-      .map(to_string)
+      .map(|p| p.normalize())
       .collect::<HashSet<_>>();
 
     assert_eq!(resolved_path_string, file_path_string);
     assert_eq!(expected_file_deps, actual_file_deps);
-  }
-
-  fn to_string<P: AsRef<Path>>(p: P) -> String {
-    p.as_ref()
-      .normalize()
-      .to_str()
-      .expect("path should be UTF-8")
-      .to_string()
   }
 }

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -1,14 +1,10 @@
-use std::{
-  hash::BuildHasherDefault,
-  path::{Path, PathBuf},
-  sync::Arc,
-};
+use std::{hash::BuildHasherDefault, path::Path, sync::Arc};
 
 use indexmap::IndexMap;
 use rustc_hash::FxHasher;
 use serde::Deserialize;
 
-use crate::path::{path_to_str, PathUtil};
+use crate::path::PathUtil;
 
 pub type CompilerOptionsPathsMap = IndexMap<String, Vec<String>, BuildHasherDefault<FxHasher>>;
 
@@ -31,10 +27,10 @@ pub struct TsConfig {
 
   /// Path to `tsconfig.json`. Contains the `tsconfig.json` filename.
   #[serde(skip)]
-  pub(crate) path: PathBuf,
+  pub(crate) path: String,
 
   #[serde(skip)]
-  pub(crate) file_dependencies: Vec<PathBuf>,
+  pub(crate) file_dependencies: Vec<String>,
 
   #[serde(default)]
   pub extends: Option<ExtendsField>,
@@ -53,14 +49,14 @@ pub struct TsConfig {
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CompilerOptions {
-  base_url: Option<PathBuf>,
+  base_url: Option<String>,
 
   /// Path aliases
   paths: Option<CompilerOptionsPathsMap>,
 
   /// The actual base for where path aliases are resolved from.
   #[serde(skip)]
-  paths_base: PathBuf,
+  paths_base: String,
 }
 
 /// Project Reference
@@ -70,7 +66,7 @@ pub struct CompilerOptions {
 pub struct ProjectReference {
   /// The path property of each reference can point to a directory containing a tsconfig.json file,
   /// or to the config file itself (which may have any name).
-  pub path: PathBuf,
+  pub path: String,
 
   /// Reference to the resolved tsconfig
   #[serde(skip)]
@@ -78,21 +74,21 @@ pub struct ProjectReference {
 }
 
 impl TsConfig {
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(path))))]
-  pub fn parse(root: bool, path: &Path, json: &mut str) -> Result<Self, serde_json::Error> {
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path)))]
+  pub fn parse(root: bool, path: &str, json: &mut str) -> Result<Self, serde_json::Error> {
     _ = json_strip_comments::strip(json);
     if json.trim().is_empty() {
       let mut tsconfig: Self = serde_json::from_str("{}")?;
       tsconfig.root = root;
-      tsconfig.path = path.to_path_buf();
-      tsconfig.file_dependencies.push(path.to_path_buf());
+      tsconfig.path = path.to_string();
+      tsconfig.file_dependencies.push(path.to_string());
       return Ok(tsconfig);
     }
     let mut tsconfig: Self = serde_json::from_str(json)?;
     tsconfig.root = root;
-    tsconfig.path = path.to_path_buf();
-    tsconfig.file_dependencies.push(path.to_path_buf());
-    let directory = tsconfig.directory().to_path_buf();
+    tsconfig.path = path.to_string();
+    tsconfig.file_dependencies.push(path.to_string());
+    let directory = tsconfig.directory().to_string();
     if let Some(base_url) = &tsconfig.compiler_options.base_url {
       // keep the `${configDir}` template variable in the baseUrl
       if !base_url.starts_with(TEMPLATE_VARIABLE) {
@@ -111,7 +107,7 @@ impl TsConfig {
 
   pub fn build(mut self) -> Self {
     if self.root {
-      let dir = self.directory().to_path_buf();
+      let dir = self.directory().to_string();
       // Substitute template variable in `tsconfig.compilerOptions.paths`
       if let Some(paths) = &mut self.compiler_options.paths {
         for paths in paths.values_mut() {
@@ -121,14 +117,12 @@ impl TsConfig {
         }
       }
 
-      let mut p = path_to_str(&self.compiler_options.paths_base).to_string();
+      let mut p = self.compiler_options.paths_base.clone();
       Self::substitute_template_variable(&dir, &mut p);
-      self.compiler_options.paths_base = p.into();
+      self.compiler_options.paths_base = p;
 
       if let Some(base_url) = self.compiler_options.base_url.as_mut() {
-        let mut p = path_to_str(base_url).to_string();
-        Self::substitute_template_variable(&dir, &mut p);
-        *base_url = p.into();
+        Self::substitute_template_variable(&dir, base_url);
       }
     }
     self
@@ -139,9 +133,12 @@ impl TsConfig {
   /// # Panics
   ///
   /// * When the `tsconfig.json` path is misconfigured.
-  pub fn directory(&self) -> &Path {
-    debug_assert!(self.path.file_name().is_some());
-    self.path.parent().unwrap()
+  pub fn directory(&self) -> &str {
+    debug_assert!(Path::new(&self.path).file_name().is_some());
+    Path::new(&self.path)
+      .parent()
+      .and_then(|p| p.to_str())
+      .expect("tsconfig path should have a UTF-8 parent")
   }
 
   pub fn extend_tsconfig(&mut self, other_config: &Self) {
@@ -165,7 +162,7 @@ impl TsConfig {
       .extend(other_config.file_dependencies.iter().cloned());
   }
 
-  pub fn resolve(&self, path: &Path, specifier: &str) -> Vec<PathBuf> {
+  pub fn resolve(&self, path: &str, specifier: &str) -> Vec<String> {
     if let Some(matched) = self.find_reference_paths(path, specifier) {
       return matched;
     }
@@ -177,7 +174,7 @@ impl TsConfig {
   // (A → B → C): a file inside C should resolve via C's own `paths` even
   // when the entry tsconfig is A and only B is listed directly in A's
   // references. Matches `tsc`'s "nearest tsconfig wins" semantics.
-  fn find_reference_paths(&self, path: &Path, specifier: &str) -> Option<Vec<PathBuf>> {
+  fn find_reference_paths(&self, path: &str, specifier: &str) -> Option<Vec<String>> {
     for tsconfig in self
       .references
       .iter()
@@ -186,7 +183,9 @@ impl TsConfig {
       if let Some(nested) = tsconfig.find_reference_paths(path, specifier) {
         return Some(nested);
       }
-      if path.starts_with(tsconfig.base_path()) {
+      // Use Path-based comparison so the prefix check is component-aware,
+      // avoiding false positives like "/foo/barbaz" starting with "/foo/bar".
+      if Path::new(path).starts_with(Path::new(tsconfig.base_path())) {
         return Some(tsconfig.resolve_path_alias(specifier));
       }
     }
@@ -195,7 +194,7 @@ impl TsConfig {
 
   // Copied from parcel
   // <https://github.com/parcel-bundler/parcel/blob/b6224fd519f95e68d8b93ba90376fd94c8b76e69/packages/utils/node-resolver-rs/src/tsconfig.rs#L93>
-  pub fn resolve_path_alias(&self, specifier: &str) -> Vec<PathBuf> {
+  pub fn resolve_path_alias(&self, specifier: &str) -> Vec<String> {
     if specifier.starts_with(['/', '.']) {
       return vec![];
     }
@@ -251,17 +250,17 @@ impl TsConfig {
 
     paths
       .into_iter()
-      .map(|p| self.compiler_options.paths_base.normalize_with(p))
+      .map(|p| self.compiler_options.paths_base.normalize_with(&p))
       .chain(base_url_iter)
       .collect()
   }
 
-  fn base_path(&self) -> &Path {
+  fn base_path(&self) -> &str {
     self
       .compiler_options
       .base_url
-      .as_ref()
-      .map_or_else(|| self.directory(), |path| path.as_ref())
+      .as_deref()
+      .unwrap_or_else(|| self.directory())
   }
 
   /// Template variable `${configDir}` for substitution of config files directory path
@@ -269,13 +268,10 @@ impl TsConfig {
   /// NOTE: All tests cases are just a head replacement of `${configDir}`, so we are constrained as such.
   ///
   /// See <https://github.com/microsoft/TypeScript/pull/58042>
-  fn substitute_template_variable(directory: &Path, path: &mut String) {
+  fn substitute_template_variable(directory: &str, path: &mut String) {
     if let Some(stripped_path) = path.strip_prefix(TEMPLATE_VARIABLE) {
-      if let Some(unleashed_path) = stripped_path.strip_prefix("/") {
-        *path = path_to_str(&directory.join(unleashed_path)).to_string();
-      } else {
-        *path = path_to_str(&directory.join(stripped_path)).to_string();
-      }
+      let stripped_path = stripped_path.strip_prefix('/').unwrap_or(stripped_path);
+      *path = directory.normalize_with(stripped_path);
     }
   }
 }

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -1,10 +1,10 @@
-use std::{hash::BuildHasherDefault, path::Path, sync::Arc};
+use std::{hash::BuildHasherDefault, sync::Arc};
 
 use indexmap::IndexMap;
 use rustc_hash::FxHasher;
 use serde::Deserialize;
 
-use crate::path::PathUtil;
+use crate::{path::PathUtil, str_path::StrPath};
 
 pub type CompilerOptionsPathsMap = IndexMap<String, Vec<String>, BuildHasherDefault<FxHasher>>;
 
@@ -134,11 +134,11 @@ impl TsConfig {
   ///
   /// * When the `tsconfig.json` path is misconfigured.
   pub fn directory(&self) -> &str {
-    debug_assert!(Path::new(&self.path).file_name().is_some());
-    Path::new(&self.path)
-      .parent()
-      .and_then(|p| p.to_str())
-      .expect("tsconfig path should have a UTF-8 parent")
+    let p = StrPath::new(&self.path);
+    debug_assert!(p.file_name().is_some());
+    p.parent()
+      .map(StrPath::as_str)
+      .expect("tsconfig path should have a parent")
   }
 
   pub fn extend_tsconfig(&mut self, other_config: &Self) {
@@ -183,9 +183,9 @@ impl TsConfig {
       if let Some(nested) = tsconfig.find_reference_paths(path, specifier) {
         return Some(nested);
       }
-      // Use Path-based comparison so the prefix check is component-aware,
-      // avoiding false positives like "/foo/barbaz" starting with "/foo/bar".
-      if Path::new(path).starts_with(Path::new(tsconfig.base_path())) {
+      // Component-aware prefix check so we don't trip on
+      // "/foo/barbaz" matching "/foo/bar".
+      if StrPath::new(path).starts_with(StrPath::new(tsconfig.base_path())) {
         return Some(tsconfig.resolve_path_alias(specifier));
       }
     }

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 use rustc_hash::FxHasher;
 use serde::Deserialize;
 
-use crate::{path::PathUtil, str_path::StrPath};
+use crate::{path::PathUtil, resolver_path::ResolverPath};
 
 pub type CompilerOptionsPathsMap = IndexMap<String, Vec<String>, BuildHasherDefault<FxHasher>>;
 
@@ -134,10 +134,10 @@ impl TsConfig {
   ///
   /// * When the `tsconfig.json` path is misconfigured.
   pub fn directory(&self) -> &str {
-    let p = StrPath::new(&self.path);
+    let p = ResolverPath::new(&self.path);
     debug_assert!(p.file_name().is_some());
     p.parent()
-      .map(StrPath::as_str)
+      .map(ResolverPath::as_str)
       .expect("tsconfig path should have a parent")
   }
 
@@ -185,7 +185,7 @@ impl TsConfig {
       }
       // Component-aware prefix check so we don't trip on
       // "/foo/barbaz" matching "/foo/bar".
-      if StrPath::new(path).starts_with(StrPath::new(tsconfig.base_path())) {
+      if ResolverPath::new(path).starts_with(ResolverPath::new(tsconfig.base_path())) {
         return Some(tsconfig.resolve_path_alias(specifier));
       }
     }

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -234,14 +234,20 @@ impl TsConfig {
         best_key
           .and_then(|key| paths_map.get(key))
           .map_or_else(Vec::new, |paths| {
+            // The captured `*` slice comes from the specifier verbatim, so
+            // on Windows it may carry `/`. Rewrite to the platform separator
+            // before insertion so the substituted path normalizes cleanly
+            // (otherwise downstream extension lookups like `<dir>\foo/x.ts`
+            // diverge from what `path.join` produces on the JS side).
+            let captured =
+              &specifier[longest_prefix_length..specifier.len() - longest_suffix_length];
+            #[cfg(windows)]
+            let captured = captured.replace('/', "\\");
+            #[cfg(windows)]
+            let captured = captured.as_str();
             paths
               .iter()
-              .map(|path| {
-                path.replace(
-                  '*',
-                  &specifier[longest_prefix_length..specifier.len() - longest_suffix_length],
-                )
-              })
+              .map(|path| path.replace('*', captured))
               .collect::<Vec<_>>()
           })
       },

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,13 +1,13 @@
 //! Test public APIs
 
-use std::{env, path::PathBuf};
+use std::env;
 
 use rspack_resolver::{
   EnforceExtension, ModuleType, Resolution, ResolveContext, ResolveOptions, Resolver,
 };
 
-fn dir() -> PathBuf {
-  env::current_dir().unwrap()
+fn dir() -> String {
+  env::current_dir().unwrap().to_str().unwrap().to_string()
 }
 
 async fn resolve(specifier: &str) -> Resolution {
@@ -101,6 +101,6 @@ async fn options_api() {
     .with_module("module")
     .with_prefer_absolute(true)
     .with_prefer_relative(true)
-    .with_root(PathBuf::new())
+    .with_root("")
     .with_symbolic_link(true);
 }

--- a/tests/resolve_test.rs
+++ b/tests/resolve_test.rs
@@ -1,9 +1,25 @@
-use std::{env, path::PathBuf};
+use std::{env, path::Path};
 
 use rspack_resolver::{ResolveError, ResolveOptions, Resolver};
 
-fn dir() -> PathBuf {
-  env::current_dir().unwrap()
+fn dir() -> String {
+  env::current_dir().unwrap().to_str().unwrap().to_string()
+}
+
+trait JoinExt {
+  fn path_join(&self, sub: &str) -> String;
+}
+
+impl JoinExt for str {
+  fn path_join(&self, sub: &str) -> String {
+    Path::new(self).join(sub).to_str().unwrap().to_string()
+  }
+}
+
+impl JoinExt for String {
+  fn path_join(&self, sub: &str) -> String {
+    self.as_str().path_join(sub)
+  }
 }
 
 #[tokio::test]
@@ -14,16 +30,16 @@ async fn chinese() {
     .resolve(&dir, specifier)
     .await;
   assert_eq!(
-    resolution.map(rspack_resolver::Resolution::into_path_buf),
-    Ok(dir.join("fixtures/misc/中文/中文.js"))
+    resolution.map(rspack_resolver::Resolution::into_path),
+    Ok(dir.path_join("fixtures/misc/中文/中文.js"))
   );
 }
 
 #[tokio::test]
 async fn styled_components() {
   let dir = dir();
-  let path = dir.join("fixtures/pnpm");
-  let module_path = dir.join("fixtures/pnpm/node_modules/styled-components");
+  let path = dir.path_join("fixtures/pnpm");
+  let module_path = dir.path_join("fixtures/pnpm/node_modules/styled-components");
   let specifier = "styled-components";
 
   // cjs
@@ -34,8 +50,8 @@ async fn styled_components() {
   };
   let resolution = Resolver::new(options).resolve(&path, specifier).await;
   assert_eq!(
-    resolution.map(rspack_resolver::Resolution::into_path_buf),
-    Ok(module_path.join("dist/styled-components.browser.cjs.js"))
+    resolution.map(rspack_resolver::Resolution::into_path),
+    Ok(module_path.path_join("dist/styled-components.browser.cjs.js"))
   );
 
   // esm
@@ -47,24 +63,24 @@ async fn styled_components() {
   };
   let resolution = Resolver::new(options).resolve(&path, specifier).await;
   assert_eq!(
-    resolution.map(rspack_resolver::Resolution::into_path_buf),
-    Ok(module_path.join("dist/styled-components.browser.esm.js"))
+    resolution.map(rspack_resolver::Resolution::into_path),
+    Ok(module_path.path_join("dist/styled-components.browser.esm.js"))
   );
 }
 
 #[tokio::test]
 async fn axios() {
   let dir = dir();
-  let path = dir.join("fixtures/pnpm");
-  let module_path = dir.join("node_modules/.pnpm/axios@1.6.2/node_modules/axios");
+  let path = dir.path_join("fixtures/pnpm");
+  let module_path = dir.path_join("node_modules/.pnpm/axios@1.6.2/node_modules/axios");
   let specifier = "axios";
 
   // default
   let options = ResolveOptions::default();
   let resolution = Resolver::new(options).resolve(&path, specifier).await;
   assert_eq!(
-    resolution.map(rspack_resolver::Resolution::into_path_buf),
-    Ok(module_path.join("index.js"))
+    resolution.map(rspack_resolver::Resolution::into_path),
+    Ok(module_path.path_join("index.js"))
   );
 
   // browser
@@ -74,8 +90,8 @@ async fn axios() {
   };
   let resolution = Resolver::new(options).resolve(&path, specifier).await;
   assert_eq!(
-    resolution.map(rspack_resolver::Resolution::into_path_buf),
-    Ok(module_path.join("dist/browser/axios.cjs"))
+    resolution.map(rspack_resolver::Resolution::into_path),
+    Ok(module_path.path_join("dist/browser/axios.cjs"))
   );
 
   // cjs
@@ -85,16 +101,16 @@ async fn axios() {
   };
   let resolution = Resolver::new(options).resolve(&path, specifier).await;
   assert_eq!(
-    resolution.map(rspack_resolver::Resolution::into_path_buf),
-    Ok(module_path.join("dist/node/axios.cjs"))
+    resolution.map(rspack_resolver::Resolution::into_path),
+    Ok(module_path.path_join("dist/node/axios.cjs"))
   );
 }
 
 #[tokio::test]
 async fn postcss() {
   let dir = dir();
-  let path = dir.join("fixtures/pnpm");
-  let module_path = path.join("node_modules/postcss");
+  let path = dir.path_join("fixtures/pnpm");
+  let module_path = path.path_join("node_modules/postcss");
   let resolver = Resolver::new(ResolveOptions {
     alias_fields: vec![vec!["browser".into()]],
     ..ResolveOptions::default()
@@ -111,7 +127,7 @@ async fn postcss() {
   assert_eq!(
     resolution,
     Err(ResolveError::Ignored(
-      module_path.join("lib/terminal-highlight")
+      module_path.path_join("lib/terminal-highlight")
     ))
   );
 }
@@ -119,9 +135,9 @@ async fn postcss() {
 #[tokio::test]
 async fn ipaddr_js() {
   let dir = dir();
-  let path = dir.join("fixtures/pnpm");
+  let path = dir.path_join("fixtures/pnpm");
   let module_path =
-    dir.join("node_modules/.pnpm/ipaddr.js@2.2.0/node_modules/ipaddr.js/lib/ipaddr.js");
+    dir.path_join("node_modules/.pnpm/ipaddr.js@2.2.0/node_modules/ipaddr.js/lib/ipaddr.js");
 
   let resolvers = [
     // with `extension_alias`
@@ -153,9 +169,9 @@ async fn ipaddr_js() {
 #[tokio::test]
 async fn decimal_js() {
   let dir = dir();
-  let path = dir.join("fixtures/pnpm");
+  let path = dir.path_join("fixtures/pnpm");
   let module_path =
-    dir.join("node_modules/.pnpm/decimal.js@10.4.3/node_modules/decimal.js/decimal.mjs");
+    dir.path_join("node_modules/.pnpm/decimal.js@10.4.3/node_modules/decimal.js/decimal.mjs");
 
   let resolvers = [
     // with `extension_alias`
@@ -186,9 +202,9 @@ async fn decimal_js() {
 #[tokio::test]
 async fn decimal_js_from_mathjs() {
   let dir = dir();
-  let path = dir.join("node_modules/.pnpm/mathjs@13.2.0/node_modules/mathjs/lib/esm");
+  let path = dir.path_join("node_modules/.pnpm/mathjs@13.2.0/node_modules/mathjs/lib/esm");
   let module_path =
-    dir.join("node_modules/.pnpm/decimal.js@10.4.3/node_modules/decimal.js/decimal.mjs");
+    dir.path_join("node_modules/.pnpm/decimal.js@10.4.3/node_modules/decimal.js/decimal.mjs");
 
   let resolvers = [
     // with `extension_alias`

--- a/tests/resolve_test.rs
+++ b/tests/resolve_test.rs
@@ -1,6 +1,16 @@
-use std::{env, path::Path};
+use std::{
+  env,
+  path::{Path, PathBuf},
+};
 
 use rspack_resolver::{ResolveError, ResolveOptions, Resolver};
+
+// PathBuf comparison so Windows separator differences (the resolver emits `\\`
+// at boundaries while `path_join` / hand-written specifiers carry `/`) are
+// absorbed component-wise — mirroring how `main` compared `Result<PathBuf>`.
+fn pb(s: String) -> PathBuf {
+  PathBuf::from(s)
+}
 
 fn dir() -> String {
   env::current_dir().unwrap().to_str().unwrap().to_string()
@@ -30,8 +40,8 @@ async fn chinese() {
     .resolve(&dir, specifier)
     .await;
   assert_eq!(
-    resolution.map(rspack_resolver::Resolution::into_path),
-    Ok(dir.path_join("fixtures/misc/中文/中文.js"))
+    resolution.map(|r| pb(r.into_path())),
+    Ok(pb(dir.path_join("fixtures/misc/中文/中文.js")))
   );
 }
 
@@ -50,8 +60,10 @@ async fn styled_components() {
   };
   let resolution = Resolver::new(options).resolve(&path, specifier).await;
   assert_eq!(
-    resolution.map(rspack_resolver::Resolution::into_path),
-    Ok(module_path.path_join("dist/styled-components.browser.cjs.js"))
+    resolution.map(|r| pb(r.into_path())),
+    Ok(pb(
+      module_path.path_join("dist/styled-components.browser.cjs.js")
+    ))
   );
 
   // esm
@@ -63,8 +75,10 @@ async fn styled_components() {
   };
   let resolution = Resolver::new(options).resolve(&path, specifier).await;
   assert_eq!(
-    resolution.map(rspack_resolver::Resolution::into_path),
-    Ok(module_path.path_join("dist/styled-components.browser.esm.js"))
+    resolution.map(|r| pb(r.into_path())),
+    Ok(pb(
+      module_path.path_join("dist/styled-components.browser.esm.js")
+    ))
   );
 }
 
@@ -79,8 +93,8 @@ async fn axios() {
   let options = ResolveOptions::default();
   let resolution = Resolver::new(options).resolve(&path, specifier).await;
   assert_eq!(
-    resolution.map(rspack_resolver::Resolution::into_path),
-    Ok(module_path.path_join("index.js"))
+    resolution.map(|r| pb(r.into_path())),
+    Ok(pb(module_path.path_join("index.js")))
   );
 
   // browser
@@ -90,8 +104,8 @@ async fn axios() {
   };
   let resolution = Resolver::new(options).resolve(&path, specifier).await;
   assert_eq!(
-    resolution.map(rspack_resolver::Resolution::into_path),
-    Ok(module_path.path_join("dist/browser/axios.cjs"))
+    resolution.map(|r| pb(r.into_path())),
+    Ok(pb(module_path.path_join("dist/browser/axios.cjs")))
   );
 
   // cjs
@@ -101,8 +115,8 @@ async fn axios() {
   };
   let resolution = Resolver::new(options).resolve(&path, specifier).await;
   assert_eq!(
-    resolution.map(rspack_resolver::Resolution::into_path),
-    Ok(module_path.path_join("dist/node/axios.cjs"))
+    resolution.map(|r| pb(r.into_path())),
+    Ok(pb(module_path.path_join("dist/node/axios.cjs")))
   );
 }
 
@@ -118,18 +132,21 @@ async fn postcss() {
 
   // should ignore "path"
   let resolution = resolver.resolve(&module_path, "path").await;
-  assert_eq!(resolution, Err(ResolveError::Ignored(module_path.clone())));
+  match resolution {
+    Err(ResolveError::Ignored(p)) => assert_eq!(pb(p), pb(module_path.clone())),
+    other => panic!("expected Ignored, got: {other:?}"),
+  }
 
   // should ignore "./lib/terminal-highlight"
   let resolution = resolver
     .resolve(&module_path, "./lib/terminal-highlight")
     .await;
-  assert_eq!(
-    resolution,
-    Err(ResolveError::Ignored(
-      module_path.path_join("lib/terminal-highlight")
-    ))
-  );
+  match resolution {
+    Err(ResolveError::Ignored(p)) => {
+      assert_eq!(pb(p), pb(module_path.path_join("lib/terminal-highlight")))
+    }
+    other => panic!("expected Ignored, got: {other:?}"),
+  }
 }
 
 #[tokio::test]
@@ -161,8 +178,8 @@ async fn ipaddr_js() {
     let resolution = resolver
       .resolve(&path, "ipaddr.js")
       .await
-      .map(|r| r.full_path());
-    assert_eq!(resolution, Ok(module_path.clone()));
+      .map(|r| pb(r.full_path()));
+    assert_eq!(resolution, Ok(pb(module_path.clone())));
   }
 }
 
@@ -194,8 +211,8 @@ async fn decimal_js() {
     let resolution = resolver
       .resolve(&path, "decimal.js")
       .await
-      .map(|r| r.full_path());
-    assert_eq!(resolution, Ok(module_path.clone()));
+      .map(|r| pb(r.full_path()));
+    assert_eq!(resolution, Ok(pb(module_path.clone())));
   }
 }
 
@@ -227,7 +244,7 @@ async fn decimal_js_from_mathjs() {
     let resolution = resolver
       .resolve(&path, "decimal.js")
       .await
-      .map(|r| r.full_path());
-    assert_eq!(resolution, Ok(module_path.clone()));
+      .map(|r| pb(r.full_path()));
+    assert_eq!(resolution, Ok(pb(module_path.clone())));
   }
 }


### PR DESCRIPTION
## Why

Internal path storage used `PathBuf`/`Path` everywhere, even though paths are conceptually UTF-8 strings inside the resolver and we already panic on non-UTF-8 paths at boundary. The roundtrip cost (`PathBuf` → `&str` for hashing, `String` for tracing fields, `OsString` for concatenation) showed up in profiling and made the code noisier than it needed to be.

This PR switches the **internal data structures** to `str`/`String` end-to-end, keeping `std::path::Path` only where it's actually load-bearing — the syscall boundary (`tokio::fs::*`, `dunce::canonicalize`) and a few component-aware checks (prefix matching, `parent()`).

## What changed

- `FileSystem` trait now takes `&str` and `canonicalize` returns `String`.
- `CachedPath` stores `Box<str>`; cache key is `&str`.
- `PathUtil` trait operates on `str`/`String` (still leans on `Path` for OS-aware normalization internally).
- All carry-paths on public types switched to `String`:
  - `ResolveError` variants (`Ignored`, `TsconfigNotFound`, `InvalidPackageTarget`, …)
  - `Resolution { path: String, … }`
  - `ResolveContext { file_dependencies: FxHashSet<String>, missing_dependencies: … }`
  - `ResolveOptions { roots: Vec<String>, restrictions: …, tsconfig: … }`
  - `TsconfigOptions { config_file: String }`, `TsconfigReferences::Paths(Vec<String>)`
  - `Restriction::Path(String)`, `Restriction::Fn(Arc<dyn Fn(&str) -> bool + …>)`
- `Resolver::resolve` generic now `S: AsRef<str>` (was `AsRef<Path>`).
- `JSONError`, `TsConfig`, `PackageJson` paths all become `String`.
- napi binding, benches, examples, and integration tests adapted to the new API.

## Before / after

```rust
// Before
pub trait FileSystem {
  async fn read(&self, path: &Path) -> io::Result<Vec<u8>>;
  async fn canonicalize(&self, path: &Path) -> io::Result<PathBuf>;
}
pub struct Resolution { pub(crate) path: PathBuf, … }
pub fn resolve<P: AsRef<Path>>(&self, dir: P, specifier: &str) -> … { … }

// After
pub trait FileSystem {
  async fn read(&self, path: &str) -> io::Result<Vec<u8>>;
  async fn canonicalize(&self, path: &str) -> io::Result<String>;
}
pub struct Resolution { pub(crate) path: String, … }
pub fn resolve<S: AsRef<str>>(&self, dir: S, specifier: &str) -> … { … }
```

## Test plan

- [x] `cargo test --workspace` — 150 / 150 passing (134 lib + 9 integration + 7 resolve)
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] napi crate builds against the new API
- [x] benches and example compile

## Notes

- `Resolution::into_path_buf()` renamed to `into_path()` (returns `String`).
- A test-only `JoinExt::path_join` trait keeps fixture assertions ergonomic; it normalizes `./` (matching the resolver's internal normalization) while preserving trailing separators (matching the old `PathBuf` component-eq behavior).
- This is an intentionally breaking change to the public crate API — bumping major version is the right move on release.