### PR TITLE
perf: unify cache/result path into hashed ResolverPath

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,8 +1,7 @@
-#[cfg(unix)]
-use std::os::unix::ffi::OsStrExt;
 use std::{
   borrow::{Borrow, Cow},
   convert::AsRef,
+  fmt,
   future::Future,
   hash::{BuildHasherDefault, Hash, Hasher},
   io,
@@ -19,14 +18,14 @@ use tokio::sync::OnceCell as OnceLock;
 use crate::{
   context::ResolveContext as Ctx,
   package_json::{off_to_location, PackageJson},
-  path::PathUtil,
+  path::{join_str, parent_str, PathUtil},
   FileMetadata, FileSystem, JSONError, ResolveError, ResolveOptions, TsConfig,
 };
 
 #[derive(Default)]
 pub struct Cache<Fs> {
   pub(crate) fs: Fs,
-  paths: DashSet<CachedPath, BuildHasherDefault<IdentityHasher>>,
+  paths: DashSet<ResolverPath, BuildHasherDefault<IdentityHasher>>,
   tsconfigs: DashMap<PathBuf, Arc<TsConfig>, BuildHasherDefault<FxHasher>>,
 }
 
@@ -44,29 +43,26 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
     self.tsconfigs.clear();
   }
 
-  pub fn value(&self, path: &Path) -> CachedPath {
-    let hash = {
-      let mut hasher = FxHasher::default();
-      // On Unix, hash the raw path bytes in one bulk `Hasher::write`. The std
-      // `Path::hash` impl walks components (utf8 split + per-segment write)
-      // and dominated profile samples on this cache-lookup hot path.
-      #[cfg(unix)]
-      hasher.write(path.as_os_str().as_bytes());
-      #[cfg(not(unix))]
-      path.hash(&mut hasher);
-      hasher.finish()
-    };
-    if let Some(cache_entry) = self.paths.get((hash, path).borrow() as &dyn CacheKey) {
-      return cache_entry.clone();
+  /// Look up or create a [`ResolverPath`]. Errors if `path` is not valid UTF-8.
+  pub fn value<P: AsRef<Path>>(&self, path: P) -> Result<ResolverPath, ResolveError> {
+    let path = path.as_ref();
+    let s = path
+      .to_str()
+      .ok_or_else(|| ResolveError::PathNotUtf8(path.to_path_buf()))?;
+    Ok(self.value_str(s))
+  }
+
+  /// Internal hot-path entry. Caller guarantees UTF-8.
+  pub(crate) fn value_str(&self, s: &str) -> ResolverPath {
+    let hash = fx_hash_bytes(s.as_bytes());
+    if let Some(entry) = self.paths.get((hash, s).borrow() as &dyn CacheKey) {
+      return entry.clone();
     }
-    let parent = path.parent().map(|p| self.value(p));
-    let data = CachedPath(Arc::new(CachedPathImpl::new(
-      hash,
-      path.to_path_buf().into_boxed_path(),
-      parent,
-    )));
-    self.paths.insert(data.clone());
-    data
+    let parent = parent_str(s).map(|p| self.value_str(p));
+    let inner = ResolverPathInner::new(hash, s.into(), parent);
+    let rp = ResolverPath(Arc::new(inner));
+    self.paths.insert(rp.clone());
+    rp
   }
 
   pub async fn tsconfig<F, Fut>(
@@ -114,60 +110,128 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
   }
 }
 
-#[derive(Clone)]
-pub struct CachedPath(Arc<CachedPathImpl>);
+#[inline]
+fn fx_hash_bytes(bytes: &[u8]) -> u64 {
+  let mut hasher = FxHasher::default();
+  hasher.write(bytes);
+  hasher.finish()
+}
 
-impl Hash for CachedPath {
-  fn hash<H: Hasher>(&self, state: &mut H) {
-    self.0.hash.hash(state);
+/// Unified path value carrying a precomputed `FxHasher` u64 and a UTF-8 path
+/// string. Cloning is one `Arc` bump; the cache hands back the same instance
+/// it stores internally.
+#[derive(Clone)]
+pub struct ResolverPath(pub(crate) Arc<ResolverPathInner>);
+
+impl ResolverPath {
+  #[inline]
+  pub fn path(&self) -> &Path {
+    Path::new(self.0.path.as_ref())
+  }
+
+  #[inline]
+  pub fn as_str(&self) -> &str {
+    &self.0.path
+  }
+
+  /// Precomputed FxHasher u64 over the path bytes — downstream may reuse this
+  /// directly when storing `ResolverPath` in an FxHashMap.
+  #[inline]
+  pub fn hash(&self) -> u64 {
+    self.0.hash
+  }
+
+  #[inline]
+  pub fn parent(&self) -> Option<&Self> {
+    self.0.parent.as_ref()
   }
 }
 
-impl PartialEq for CachedPath {
+impl Hash for ResolverPath {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    state.write_u64(self.0.hash);
+  }
+}
+
+impl PartialEq for ResolverPath {
   fn eq(&self, other: &Self) -> bool {
     self.0.path == other.0.path
   }
 }
-impl Eq for CachedPath {}
+impl Eq for ResolverPath {}
 
-impl Deref for CachedPath {
-  type Target = CachedPathImpl;
-
+impl Deref for ResolverPath {
+  type Target = ResolverPathInner;
   fn deref(&self) -> &Self::Target {
     self.0.as_ref()
   }
 }
 
-impl<'a> Borrow<dyn CacheKey + 'a> for CachedPath {
+impl AsRef<ResolverPathInner> for ResolverPath {
+  fn as_ref(&self) -> &ResolverPathInner {
+    self.0.as_ref()
+  }
+}
+
+impl AsRef<Path> for ResolverPath {
+  fn as_ref(&self) -> &Path {
+    self.path()
+  }
+}
+
+impl Borrow<str> for ResolverPath {
+  fn borrow(&self) -> &str {
+    self.as_str()
+  }
+}
+
+impl fmt::Debug for ResolverPath {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_tuple("ResolverPath").field(&self.as_str()).finish()
+  }
+}
+
+impl fmt::Display for ResolverPath {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+impl<'a> Borrow<dyn CacheKey + 'a> for ResolverPath {
   fn borrow(&self) -> &(dyn CacheKey + 'a) {
     self
   }
 }
 
-impl AsRef<CachedPathImpl> for CachedPath {
-  fn as_ref(&self) -> &CachedPathImpl {
-    self.0.as_ref()
+impl CacheKey for ResolverPath {
+  fn tuple(&self) -> (u64, &str) {
+    (self.0.hash, self.as_str())
   }
 }
 
-impl CacheKey for CachedPath {
-  fn tuple(&self) -> (u64, &Path) {
-    (self.hash, &self.path)
+#[cfg(test)]
+impl ResolverPath {
+  /// Construct a `ResolverPath` directly from a UTF-8 string — test-only.
+  #[doc(hidden)]
+  pub fn for_test(s: &str) -> Self {
+    let hash = fx_hash_bytes(s.as_bytes());
+    let inner = ResolverPathInner::new(hash, s.into(), None);
+    ResolverPath(Arc::new(inner))
   }
 }
 
-pub struct CachedPathImpl {
+pub struct ResolverPathInner {
   hash: u64,
-  path: Box<Path>,
-  parent: Option<CachedPath>,
+  path: Box<str>,
+  parent: Option<ResolverPath>,
   meta: OnceLock<Option<FileMetadata>>,
   canonicalized: OnceLock<Option<PathBuf>>,
-  node_modules: OnceLock<Option<CachedPath>>,
+  node_modules: OnceLock<Option<ResolverPath>>,
   package_json: OnceLock<Option<Arc<PackageJson>>>,
 }
 
-impl CachedPathImpl {
-  fn new(hash: u64, path: Box<Path>, parent: Option<CachedPath>) -> Self {
+impl ResolverPathInner {
+  fn new(hash: u64, path: Box<str>, parent: Option<ResolverPath>) -> Self {
     Self {
       hash,
       path,
@@ -180,14 +244,18 @@ impl CachedPathImpl {
   }
 
   pub fn path(&self) -> &Path {
+    Path::new(self.path.as_ref())
+  }
+
+  pub fn as_str(&self) -> &str {
     &self.path
   }
 
   pub fn to_path_buf(&self) -> PathBuf {
-    self.path.to_path_buf()
+    PathBuf::from(self.path.as_ref())
   }
 
-  pub fn parent(&self) -> Option<&CachedPath> {
+  pub fn parent(&self) -> Option<&ResolverPath> {
     self.parent.as_ref()
   }
 
@@ -199,7 +267,7 @@ impl CachedPathImpl {
     }
     *self
       .meta
-      .get_or_init(|| async { fs.metadata(&self.path).await.ok() })
+      .get_or_init(|| async { fs.metadata(self.path()).await.ok() })
       .await
   }
 
@@ -231,33 +299,29 @@ impl CachedPathImpl {
       // Cache hit: return immediately and avoid the recursive parent walk +
       // `Box::pin` per call on the hot path.
       if let Some(cached) = self.canonicalized.get() {
-        return Ok(
-          cached
-            .clone()
-            .unwrap_or_else(|| self.path.clone().to_path_buf()),
-        );
+        return Ok(cached.clone().unwrap_or_else(|| self.to_path_buf()));
       }
       self
         .canonicalized
         .get_or_try_init(|| async move {
           if fs
-            .symlink_metadata(&self.path)
+            .symlink_metadata(self.path())
             .await
             .is_ok_and(|m| m.is_symlink)
           {
-            return fs.canonicalize(&self.path).await.map(Some);
+            return fs.canonicalize(self.path()).await.map(Some);
           }
           if let Some(parent) = self.parent() {
             let parent_path = parent.realpath(fs).await?;
             return Ok(Some(
-              parent_path.normalize_with(self.path.strip_prefix(&parent.path).unwrap()),
+              parent_path.normalize_with(self.path().strip_prefix(parent.path()).unwrap()),
             ));
           }
           Ok(None)
         })
         .await
         .cloned()
-        .map(|r| r.unwrap_or_else(|| self.path.clone().to_path_buf()))
+        .map(|r| r.unwrap_or_else(|| self.to_path_buf()))
     };
     Box::pin(fut)
   }
@@ -267,8 +331,9 @@ impl CachedPathImpl {
     module_name: &str,
     cache: &Cache<Fs>,
     ctx: &mut Ctx,
-  ) -> Option<CachedPath> {
-    let cached_path = cache.value(&self.path.join(module_name));
+  ) -> Option<ResolverPath> {
+    let joined = join_str(&self.path, module_name);
+    let cached_path = cache.value_str(&joined);
     cached_path
       .is_dir(&cache.fs, ctx)
       .await
@@ -279,7 +344,7 @@ impl CachedPathImpl {
     &self,
     cache: &Cache<Fs>,
     ctx: &mut Ctx,
-  ) -> Option<CachedPath> {
+  ) -> Option<ResolverPath> {
     if let Some(nm) = self.node_modules.get() {
       return nm.clone();
     }
@@ -295,7 +360,7 @@ impl CachedPathImpl {
   /// # Errors
   ///
   /// * [ResolveError::JSON]
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %self.path.display())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %self.path().display())))]
   pub async fn find_package_json<Fs: FileSystem + Send + Sync>(
     &self,
     fs: &Fs,
@@ -326,7 +391,7 @@ impl CachedPathImpl {
   /// # Errors
   ///
   /// * [ResolveError::JSON]
-  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %self.path.display())))]
+  #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = %self.path().display())))]
   pub async fn package_json<Fs: FileSystem + Send + Sync>(
     &self,
     fs: &Fs,
@@ -339,7 +404,7 @@ impl CachedPathImpl {
         Some(package_json) => ctx.add_file_dependency(&package_json.path),
         None => {
           if let Some(deps) = &mut ctx.missing_dependencies {
-            deps.push(self.path.join("package.json"));
+            deps.push(self.path().join("package.json"));
           }
         }
       }
@@ -349,7 +414,7 @@ impl CachedPathImpl {
     let result = self
       .package_json
       .get_or_try_init(|| async {
-        let package_json_path = self.path.join("package.json");
+        let package_json_path = self.path().join("package.json");
         let Ok(package_json_string) = fs.read(&package_json_path).await else {
           return Ok(None);
         };
@@ -361,7 +426,7 @@ impl CachedPathImpl {
         match PackageJson::parse(package_json_path.clone(), real_path, package_json_string) {
           Ok(v) => Ok(Some(Arc::new(v))),
           Err(parse_err) => {
-            let package_json_path = self.path.join("package.json");
+            let package_json_path = self.path().join("package.json");
             let package_json_string = match fs.read_to_string(&package_json_path).await {
               Ok(c) => c,
               Err(io_err) => {
@@ -401,12 +466,12 @@ impl CachedPathImpl {
       Ok(None) => {
         // Avoid an allocation by making this lazy
         if let Some(deps) = &mut ctx.missing_dependencies {
-          deps.push(self.path.join("package.json"));
+          deps.push(self.path().join("package.json"));
         }
       }
       Err(_) => {
         if let Some(deps) = &mut ctx.file_dependencies {
-          deps.push(self.path.join("package.json"));
+          deps.push(self.path().join("package.json"));
         }
       }
     }
@@ -416,12 +481,12 @@ impl CachedPathImpl {
 
 /// Memoized cache key, code adapted from <https://stackoverflow.com/a/50478038>.
 trait CacheKey {
-  fn tuple(&self) -> (u64, &Path);
+  fn tuple(&self) -> (u64, &str);
 }
 
 impl Hash for dyn CacheKey + '_ {
   fn hash<H: Hasher>(&self, state: &mut H) {
-    self.tuple().0.hash(state);
+    state.write_u64(self.tuple().0);
   }
 }
 
@@ -433,13 +498,13 @@ impl PartialEq for dyn CacheKey + '_ {
 
 impl Eq for dyn CacheKey + '_ {}
 
-impl CacheKey for (u64, &Path) {
-  fn tuple(&self) -> (u64, &Path) {
+impl CacheKey for (u64, &str) {
+  fn tuple(&self) -> (u64, &str) {
     (self.0, self.1)
   }
 }
 
-impl<'a> Borrow<dyn CacheKey + 'a> for (u64, &'a Path) {
+impl<'a> Borrow<dyn CacheKey + 'a> for (u64, &'a str) {
   fn borrow(&self) -> &(dyn CacheKey + 'a) {
     self
   }
@@ -459,5 +524,60 @@ impl Hasher for IdentityHasher {
   }
   fn finish(&self) -> u64 {
     self.0
+  }
+}
+
+#[cfg(test)]
+mod cache_path_tests {
+  use super::*;
+  use crate::FileSystemOs;
+
+  fn fresh_cache() -> Cache<FileSystemOs> {
+    Cache::new(FileSystemOs::default())
+  }
+
+  #[test]
+  fn resolver_path_hash_matches_fx_of_bytes() {
+    let cache = fresh_cache();
+    let rp = cache.value("/a/b/c").expect("utf8");
+    let mut h = FxHasher::default();
+    h.write(b"/a/b/c");
+    assert_eq!(rp.hash(), h.finish());
+  }
+
+  #[test]
+  fn equal_paths_share_arc() {
+    let cache = fresh_cache();
+    let a = cache.value("/foo/bar").expect("utf8");
+    let b = cache.value("/foo/bar").expect("utf8");
+    assert!(Arc::ptr_eq(&a.0, &b.0));
+  }
+
+  #[test]
+  fn parent_chain_walks_cache() {
+    let cache = fresh_cache();
+    let child = cache.value("/foo/bar").expect("utf8");
+    let parent_via_chain = child.parent().expect("has parent").clone();
+    let parent_via_lookup = cache.value("/foo").expect("utf8");
+    assert!(Arc::ptr_eq(&parent_via_chain.0, &parent_via_lookup.0));
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn non_utf8_path_errors() {
+    use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
+    let cache = fresh_cache();
+    let bytes = [0xff, 0xfe, 0x2f, 0x61];
+    let p = PathBuf::from(OsStr::from_bytes(&bytes));
+    let err = cache.value(&p).unwrap_err();
+    assert!(matches!(err, ResolveError::PathNotUtf8(_)), "got {err:?}");
+  }
+
+  #[test]
+  fn as_str_and_path_view() {
+    let cache = fresh_cache();
+    let rp = cache.value("/abc/def").expect("utf8");
+    assert_eq!(rp.as_str(), "/abc/def");
+    assert_eq!(rp.path(), Path::new("/abc/def"));
   }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -209,6 +209,29 @@ impl CacheKey for ResolverPath {
   }
 }
 
+impl ResolverPath {
+  /// Construct a standalone [`ResolverPath`] from a path — does NOT touch the
+  /// cache. Used for resolver results (e.g. the canonicalized realpath) that
+  /// the caller needs as a typed `ResolverPath` but should not pollute the
+  /// resolver cache with.
+  ///
+  /// The returned value has `parent: None` and empty fs OnceCells. Cheap to
+  /// allocate (one `Arc<ResolverPathInner>`) and intentionally not stored
+  /// anywhere — drop it when done.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`ResolveError::PathNotUtf8`] if `path` is not valid UTF-8.
+  pub(crate) fn shallow<P: AsRef<Path>>(path: P) -> Result<Self, ResolveError> {
+    let path = path.as_ref();
+    let s = path
+      .to_str()
+      .ok_or_else(|| ResolveError::PathNotUtf8(path.to_path_buf()))?;
+    let hash = fx_hash_bytes(s.as_bytes());
+    Ok(Self(Arc::new(ResolverPathInner::new(hash, s.into(), None))))
+  }
+}
+
 #[cfg(test)]
 impl ResolverPath {
   /// Construct a `ResolverPath` directly from a UTF-8 string — test-only.

--- a/src/error.rs
+++ b/src/error.rs
@@ -95,6 +95,10 @@ pub enum ResolveError {
   /// Occurs when alias paths reference each other.
   #[error("Recursion in resolving")]
   Recursion,
+
+  /// The given path is not valid UTF-8. `rspack_resolver` only supports UTF-8 paths.
+  #[error("path is not valid UTF-8: {}", .0.display())]
+  PathNotUtf8(PathBuf),
 }
 
 impl ResolveError {
@@ -193,4 +197,10 @@ async fn test_coverage() {
   let error = ResolveError::Specifier(SpecifierError::Empty("x".into()));
   assert_eq!(format!("{error:?}"), r#"Specifier(Empty("x"))"#);
   assert_eq!(error.clone(), error);
+}
+
+#[tokio::test]
+async fn test_path_not_utf8_display() {
+  let err = ResolveError::PathNotUtf8(PathBuf::from("/some/path"));
+  assert_eq!(err.to_string(), "path is not valid UTF-8: /some/path");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -723,12 +723,14 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       .await
       .map_err(ResolveError::from)?;
     ctx.add_file_dependency(&path_buf);
-    // Common path: realpath returns the input bytes unchanged (no symlink in
-    // chain). Reuse the existing cache entry instead of allocating a new one.
     if path_buf.as_os_str() == cached_path.as_str() {
       return Ok(cached_path.clone());
     }
-    self.cache.value(&path_buf)
+    // The realpath landed on a different file (symlink resolved). Wrap it in
+    // a standalone ResolverPath rather than inserting into the resolver cache
+    // — the realpath result is rarely queried again and inserting it builds
+    // the full parent chain, which is what made #231 regress memory by 22%.
+    ResolverPath::shallow(&path_buf)
   }
 
   fn check_restrictions(&self, path: &Path) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ use rustc_hash::FxHashSet;
 
 pub use crate::{
   builtins::NODEJS_BUILTINS,
+  cache::ResolverPath,
   error::{JSONError, ResolveError, SpecifierError},
   file_system::{FileMetadata, FileSystem, FileSystemOptions, FileSystemOs},
   options::{
@@ -87,7 +88,7 @@ pub use crate::{
   resolution::Resolution,
 };
 use crate::{
-  cache::{Cache, CachedPath},
+  cache::Cache,
   context::ResolveContext as Ctx,
   package_json::JSONMap,
   path::{path_to_str, PathUtil, SLASH_START},
@@ -95,7 +96,7 @@ use crate::{
   tsconfig::{ExtendsField, ProjectReference, TsConfig},
 };
 
-type ResolveResult = Result<Option<CachedPath>, ResolveError>;
+type ResolveResult = Result<Option<ResolverPath>, ResolveError>;
 
 /// Context returned from the [Resolver::resolve_with_context] API
 #[derive(Debug, Default, Clone)]
@@ -118,7 +119,7 @@ pub struct ResolverGeneric<Fs> {
   pnp_manifest: Arc<arc_swap::ArcSwapOption<(PathBuf, pnp::Manifest)>>,
   /// Paths that have been searched and confirmed to have no `.pnp.cjs` reachable by filesystem walk.
   #[cfg(feature = "yarn_pnp")]
-  pnp_no_manifest_cache: Arc<DashSet<CachedPath>>,
+  pnp_no_manifest_cache: Arc<DashSet<ResolverPath>>,
   /// Lazily parsed directories from `NODE_PATH` env var.
   node_path_dirs: OnceLock<Vec<PathBuf>>,
 }
@@ -267,16 +268,17 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     ctx: &mut Ctx,
   ) -> Result<Resolution, ResolveError> {
     ctx.with_fully_specified(self.options.fully_specified);
-    let cached_path = self.cache.value(path);
+    let cached_path = self.cache.value(path)?;
     let cached_path = self.require(&cached_path, specifier, ctx).await?;
-    let path = self.load_realpath(&cached_path, ctx).await?;
+    let path_buf = self.load_realpath(&cached_path, ctx).await?;
+    let path = self.cache.value(&path_buf)?;
 
     let package_json = cached_path
       .find_package_json(&self.cache.fs, &self.options, ctx)
       .await?;
     if let Some(package_json) = &package_json {
       // path must be inside the package.
-      debug_assert!(path.starts_with(package_json.directory()));
+      debug_assert!(path.path().starts_with(package_json.directory()));
     }
     Ok(Resolution {
       path,
@@ -294,10 +296,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   /// <https://nodejs.org/api/modules.html#all-together>
   fn require<'a>(
     &'a self,
-    cached_path: &'a CachedPath,
+    cached_path: &'a ResolverPath,
     specifier: &'a str,
     ctx: &'a mut Ctx,
-  ) -> BoxFuture<'a, Result<CachedPath, ResolveError>> {
+  ) -> BoxFuture<'a, Result<ResolverPath, ResolveError>> {
     let fut = async move {
       ctx.test_for_infinite_recursion()?;
 
@@ -316,10 +318,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
   async fn require_without_parse(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     specifier: &str,
     ctx: &mut Ctx,
-  ) -> Result<CachedPath, ResolveError> {
+  ) -> Result<ResolverPath, ResolveError> {
     // tsconfig-paths
     if let Some(path) = self
       .load_tsconfig_paths(cached_path, specifier, ctx)
@@ -396,10 +398,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
   async fn require_absolute(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     specifier: &str,
     ctx: &mut Ctx,
-  ) -> Result<CachedPath, ResolveError> {
+  ) -> Result<ResolverPath, ResolveError> {
     // Make sure only path prefixes gets called
     debug_assert!(Path::new(specifier)
       .components()
@@ -424,7 +426,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       &Path::new(specifier).normalize(),
       #[cfg(not(windows))]
       Path::new(specifier),
-    );
+    )?;
 
     if let Some(path) = self
       .load_as_file_or_directory(&path, specifier, ctx)
@@ -439,10 +441,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
   async fn require_relative(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     specifier: &str,
     ctx: &mut Ctx,
-  ) -> Result<CachedPath, ResolveError> {
+  ) -> Result<ResolverPath, ResolveError> {
     // Make sure only relative or normal paths gets called
     debug_assert!(Path::new(specifier)
       .components()
@@ -452,7 +454,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
         Component::CurDir | Component::ParentDir | Component::Normal(_)
       )));
     let path = cached_path.path().normalize_with(specifier);
-    let cached_path = self.cache.value(&path);
+    let cached_path = self.cache.value(&path)?;
     // a. LOAD_AS_FILE(Y + X)
     // b. LOAD_AS_DIRECTORY(Y + X)
     if let Some(path) = self
@@ -467,10 +469,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
   async fn require_hash(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     specifier: &str,
     ctx: &mut Ctx,
-  ) -> Result<CachedPath, ResolveError> {
+  ) -> Result<ResolverPath, ResolveError> {
     debug_assert_eq!(specifier.chars().next(), Some('#'));
     // a. LOAD_PACKAGE_IMPORTS(X, dirname(Y))
     if let Some(path) = self
@@ -487,10 +489,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier)))]
   async fn require_bare(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     specifier: &str,
     ctx: &mut Ctx,
-  ) -> Result<CachedPath, ResolveError> {
+  ) -> Result<ResolverPath, ResolveError> {
     // Make sure no other path prefixes gets called
     debug_assert!(Path::new(specifier)
       .components()
@@ -516,10 +518,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   /// <https://github.com/webpack/enhanced-resolve#escaping>
   async fn load_parse<'s>(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     specifier: &'s str,
     ctx: &mut Ctx,
-  ) -> Result<(Specifier<'s>, Option<CachedPath>), ResolveError> {
+  ) -> Result<(Specifier<'s>, Option<ResolverPath>), ResolveError> {
     let parsed = Specifier::parse(specifier).map_err(ResolveError::Specifier)?;
     ctx.with_query_fragment(parsed.query, parsed.fragment);
 
@@ -539,10 +541,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
   async fn load_package_self_or_node_modules(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     specifier: &str,
     ctx: &mut Ctx,
-  ) -> Result<CachedPath, ResolveError> {
+  ) -> Result<ResolverPath, ResolveError> {
     let (_, subpath) = Self::parse_package_specifier(specifier);
     if subpath.is_empty() {
       ctx.with_fully_specified(false);
@@ -566,7 +568,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   /// LOAD_PACKAGE_IMPORTS(X, DIR)
   async fn load_package_imports(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     specifier: &str,
     ctx: &mut Ctx,
   ) -> ResolveResult {
@@ -591,7 +593,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   }
 
   #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(cached_path.path()))))]
-  async fn load_as_file(&self, cached_path: &CachedPath, ctx: &mut Ctx) -> ResolveResult {
+  async fn load_as_file(&self, cached_path: &ResolverPath, ctx: &mut Ctx) -> ResolveResult {
     // enhanced-resolve feature: extension_alias
     if let Some(path) = self.load_extension_alias(cached_path, ctx).await? {
       return Ok(Some(path));
@@ -614,7 +616,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     Ok(None)
   }
 
-  async fn load_as_directory(&self, cached_path: &CachedPath, ctx: &mut Ctx) -> ResolveResult {
+  async fn load_as_directory(&self, cached_path: &ResolverPath, ctx: &mut Ctx) -> ResolveResult {
     // TODO: Only package.json is supported, so warn about having other values
     // Checking for empty files is needed for omitting checks on package.json
     // 1. If X/package.json is a file,
@@ -636,7 +638,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
           // c. let M = X + (json main field)
           let main_field_path = cached_path.path().normalize_with(main_field.as_ref());
           // d. LOAD_AS_FILE(M)
-          let cached_path = self.cache.value(&main_field_path);
+          let cached_path = self.cache.value(&main_field_path)?;
           if let Ok(Some(path)) = self.load_as_file(&cached_path, ctx).await {
             return Ok(Some(path));
           }
@@ -656,7 +658,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
   async fn load_as_file_or_directory(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     specifier: &str,
     ctx: &mut Ctx,
   ) -> ResolveResult {
@@ -684,7 +686,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(path.path()))))]
   async fn load_extensions(
     &self,
-    path: &CachedPath,
+    path: &ResolverPath,
     extensions: &[String],
     ctx: &mut Ctx,
   ) -> ResolveResult {
@@ -700,7 +702,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     for extension in extensions {
       path_with_extension_buffer.truncate(base_len);
       path_with_extension_buffer.push_str(extension);
-      let cached_path = self.cache.value(Path::new(&path_with_extension_buffer));
+      let cached_path = self.cache.value(Path::new(&path_with_extension_buffer))?;
       if let Some(path) = self.load_alias_or_file(&cached_path, ctx).await? {
         return Ok(Some(path));
       }
@@ -711,7 +713,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(cached_path.path()))))]
   async fn load_realpath(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     ctx: &mut Ctx,
   ) -> Result<PathBuf, ResolveError> {
     if self.options.symlinks {
@@ -759,10 +761,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   }
 
   #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(cached_path.path()))))]
-  async fn load_index(&self, cached_path: &CachedPath, ctx: &mut Ctx) -> ResolveResult {
+  async fn load_index(&self, cached_path: &ResolverPath, ctx: &mut Ctx) -> ResolveResult {
     for main_file in &self.options.main_files {
       let main_path = cached_path.path().normalize_with(main_file);
-      let cached_path = self.cache.value(&main_path);
+      let cached_path = self.cache.value(&main_path)?;
       if self.options.enforce_extension.is_disabled() {
         if let Some(path) = self.load_alias_or_file(&cached_path, ctx).await? {
           if self.check_restrictions(path.path()) {
@@ -783,7 +785,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     Ok(None)
   }
 
-  async fn load_alias_or_file(&self, cached_path: &CachedPath, ctx: &mut Ctx) -> ResolveResult {
+  async fn load_alias_or_file(&self, cached_path: &ResolverPath, ctx: &mut Ctx) -> ResolveResult {
     if !self.options.alias_fields.is_empty() {
       if let Some(package_json) = cached_path
         .find_package_json(&self.cache.fs, &self.options, ctx)
@@ -815,7 +817,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
   async fn load_node_modules(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     specifier: &str,
     ctx: &mut Ctx,
   ) -> ResolveResult {
@@ -858,7 +860,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   /// Try resolving a specifier within a single module directory (e.g. a node_modules dir or a NODE_PATH dir).
   async fn resolve_in_module_dir(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     specifier: &str,
     package_name: &str,
     subpath: &str,
@@ -870,7 +872,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     //    may have a @scope/ prefix and the subpath begins with a slash (`/`).
     if !package_name.is_empty() {
       let package_path = cached_path.path().normalize_with(package_name);
-      let pkg_cached = self.cache.value(&package_path);
+      let pkg_cached = self.cache.value(&package_path)?;
       if pkg_cached.is_dir(&self.cache.fs, ctx).await {
         // a. LOAD_PACKAGE_EXPORTS(X, DIR)
         if let Some(path) = self
@@ -900,7 +902,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     // b. LOAD_AS_FILE(DIR/X)
     // c. LOAD_AS_DIRECTORY(DIR/X)
     let node_module_file = cached_path.path().normalize_with(specifier);
-    let file_cached = self.cache.value(&node_module_file);
+    let file_cached = self.cache.value(&node_module_file)?;
     self
       .load_as_file_or_directory(&file_cached, specifier, ctx)
       .await
@@ -941,7 +943,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     }
     let (package_name, subpath) = Self::parse_package_specifier(specifier);
     for dir in dirs {
-      let cached_path = self.cache.value(dir);
+      let cached_path = self.cache.value(dir)?;
       if !cached_path.is_dir(&self.cache.fs, ctx).await {
         continue;
       }
@@ -957,7 +959,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
   #[cfg(feature = "yarn_pnp")]
   #[cfg_attr(feature = "enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path_to_str(cached_path.path()))))]
-  fn find_pnp_manifest(&self, cached_path: &CachedPath) -> Option<Arc<(PathBuf, pnp::Manifest)>> {
+  fn find_pnp_manifest(&self, cached_path: &ResolverPath) -> Option<Arc<(PathBuf, pnp::Manifest)>> {
     // 1. Already have a manifest → return it (covers global cache paths too)
     if let Some(manifest) = self.pnp_manifest.load_full() {
       return Some(manifest);
@@ -974,7 +976,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       self.pnp_no_manifest_cache.insert(cached_path.clone());
 
       for p in base_path.ancestors() {
-        let p_cached = self.cache.value(p);
+        let p_cached = self.cache.value(p).ok()?;
         if self.pnp_no_manifest_cache.contains(&p_cached) {
           break;
         }
@@ -1003,10 +1005,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
   async fn load_pnp(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     specifier: &str,
     ctx: &mut Ctx,
-  ) -> Result<Option<CachedPath>, ResolveError> {
+  ) -> Result<Option<ResolverPath>, ResolveError> {
     let Some(pnp_data) = self.find_pnp_manifest(cached_path) else {
       return Ok(None);
     };
@@ -1021,7 +1023,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
     match resolution {
       Ok(pnp::Resolution::Resolved(path, subpath)) => {
-        let cached_path = self.cache.value(&path);
+        let cached_path = self.cache.value(&path)?;
 
         let export_resolution = self.load_package_self(&cached_path, specifier, ctx).await?;
         // can be found in pnp cached folder
@@ -1049,7 +1051,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
           return Err(ResolveError::NotFound(specifier.to_string()));
         };
 
-        Ok(Some(self.cache.value(inner_resolution.path())))
+        Ok(Some(self.cache.value(inner_resolution.path())?))
       }
 
       Ok(pnp::Resolution::Skipped) => Ok(None),
@@ -1059,10 +1061,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
   async fn get_module_directory(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     module_name: &str,
     ctx: &mut Ctx,
-  ) -> Option<CachedPath> {
+  ) -> Option<ResolverPath> {
     if module_name == "node_modules" {
       cached_path.cached_node_modules(&self.cache, ctx).await
     } else if cached_path.path().components().next_back()
@@ -1080,7 +1082,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     &self,
     specifier: &str,
     subpath: &str,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     ctx: &mut Ctx,
   ) -> ResolveResult {
     // 2. If X does not match this pattern or DIR/NAME/package.json is not a file,
@@ -1111,7 +1113,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = specifier, path = path_to_str(cached_path.path()))))]
   async fn load_package_self(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     specifier: &str,
     ctx: &mut Ctx,
   ) -> ResolveResult {
@@ -1156,7 +1158,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   async fn resolve_esm_match(
     &self,
     specifier: &str,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     ctx: &mut Ctx,
   ) -> ResolveResult {
     // 1. let RESOLVED_PATH = fileURLToPath(MATCH)
@@ -1175,7 +1177,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     while let Some(s) = path_str {
       if let Some((before, _)) = s.rsplit_once('?') {
         if (self
-          .load_as_file_or_directory(&self.cache.value(Path::new(before)), "", ctx)
+          .load_as_file_or_directory(&self.cache.value(Path::new(before))?, "", ctx)
           .await?)
           .is_some()
         {
@@ -1195,7 +1197,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(specifier = module_specifier, path = path_to_str(cached_path.path()))))]
   async fn load_browser_field(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     module_specifier: Option<&str>,
     package_json: &PackageJson,
     ctx: &mut Ctx,
@@ -1235,7 +1237,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     }
     ctx.with_resolving_alias(new_specifier.to_string());
     ctx.with_fully_specified(false);
-    let cached_path = self.cache.value(package_json.directory());
+    let cached_path = self.cache.value(package_json.directory())?;
     self
       .require(&cached_path, new_specifier, ctx)
       .await
@@ -1245,7 +1247,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   /// enhanced-resolve: AliasPlugin for [ResolveOptions::alias] and [ResolveOptions::fallback].
   async fn load_alias(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     specifier: &str,
     aliases: &Alias,
     ctx: &mut Ctx,
@@ -1302,7 +1304,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
   async fn load_alias_value(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     alias_key: &str,
     alias_value: &str,
     request: &str,
@@ -1321,7 +1323,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       } else {
         let alias_path = Path::new(alias_value).normalize();
         // Must not append anything to alias_value if it is a file.
-        let alias_value_cached_path = self.cache.value(&alias_path);
+        let alias_value_cached_path = self.cache.value(&alias_path)?;
         if alias_value_cached_path.is_file(&self.cache.fs, ctx).await {
           return Ok(None);
         }
@@ -1355,7 +1357,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   /// # Errors
   ///
   /// * [ResolveError::ExtensionAlias]: When all of the aliased extensions are not found
-  async fn load_extension_alias(&self, cached_path: &CachedPath, ctx: &mut Ctx) -> ResolveResult {
+  async fn load_extension_alias(&self, cached_path: &ResolverPath, ctx: &mut Ctx) -> ResolveResult {
     if self.options.extension_alias.is_empty() {
       return Ok(None);
     }
@@ -1381,7 +1383,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       let mut path_with_extension = path_without_extension.clone().into_os_string();
       path_with_extension.reserve_exact(extension.len());
       path_with_extension.push(extension);
-      let cached_path = self.cache.value(Path::new(&path_with_extension));
+      let cached_path = self.cache.value(Path::new(&path_with_extension))?;
       if let Some(path) = self.load_alias_or_file(&cached_path, ctx).await? {
         ctx.with_fully_specified(false);
         return Ok(Some(path));
@@ -1416,13 +1418,13 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   /// defaults to context configuration option.
   ///
   /// On non-Windows systems these requests are resolved as an absolute path first.
-  async fn load_roots(&self, specifier: &str, ctx: &mut Ctx) -> Option<CachedPath> {
+  async fn load_roots(&self, specifier: &str, ctx: &mut Ctx) -> Option<ResolverPath> {
     if self.options.roots.is_empty() {
       return None;
     }
     if let Some(specifier) = specifier.strip_prefix(SLASH_START) {
       for root in &self.options.roots {
-        let cached_path = self.cache.value(root);
+        let cached_path = self.cache.value(root).ok()?;
         if let Ok(path) = self.require_relative(&cached_path, specifier, ctx).await {
           return Some(path);
         }
@@ -1433,7 +1435,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
   async fn load_tsconfig_paths(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     specifier: &str,
     ctx: &mut Ctx,
   ) -> ResolveResult {
@@ -1452,7 +1454,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     }
     let paths = tsconfig.resolve(cached_path.path(), specifier);
     for path in paths {
-      let cached_path = self.cache.value(&path);
+      let cached_path = self.cache.value(&path)?;
       if let Ok(path) = self.require_relative(&cached_path, ".", ctx).await {
         return Ok(Some(path));
       }
@@ -1471,7 +1473,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       self
         .cache
         .tsconfig(root, path, |mut tsconfig| async move {
-          let directory = self.cache.value(tsconfig.directory());
+          let directory = self.cache.value(tsconfig.directory())?;
           tracing::trace!(tsconfig = ?tsconfig, "load_tsconfig");
 
           // Extend tsconfig
@@ -1553,7 +1555,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
                 }
                 // Apply `extends` so the reference inherits its base config's
                 // `baseUrl`/`paths` before its own references are walked.
-                let directory = self.cache.value(reference_tsconfig.directory());
+                let directory = self.cache.value(reference_tsconfig.directory())?;
                 self
                   .merge_tsconfig_extends(&mut reference_tsconfig, &directory)
                   .await?;
@@ -1577,7 +1579,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   async fn merge_tsconfig_extends(
     &self,
     tsconfig: &mut TsConfig,
-    directory: &CachedPath,
+    directory: &ResolverPath,
   ) -> Result<(), ResolveError> {
     let Some(extends) = &tsconfig.extends else {
       return Ok(());
@@ -1614,7 +1616,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
   async fn get_extended_tsconfig_path(
     &self,
-    directory: &CachedPath,
+    directory: &ResolverPath,
     tsconfig: &TsConfig,
     specifier: &str,
   ) -> Result<PathBuf, ResolveError> {
@@ -1644,7 +1646,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   /// PACKAGE_RESOLVE(packageSpecifier, parentURL)
   async fn package_resolve(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     specifier: &str,
     ctx: &mut Ctx,
   ) -> ResolveResult {
@@ -1675,7 +1677,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
 
     // Fallback: search NODE_PATH directories
     for dir in self.node_path_dirs() {
-      let cached_path = self.cache.value(dir);
+      let cached_path = self.cache.value(dir)?;
       if !cached_path.is_dir(&self.cache.fs, ctx).await {
         continue;
       }
@@ -1693,13 +1695,13 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
   /// Try ESM package resolution within a single module directory.
   async fn package_resolve_in_dir(
     &self,
-    cached_path: &CachedPath,
+    cached_path: &ResolverPath,
     package_name: &str,
     subpath: &str,
     ctx: &mut Ctx,
   ) -> ResolveResult {
     let package_path = cached_path.path().normalize_with(package_name);
-    let cached_path = self.cache.value(&package_path);
+    let cached_path = self.cache.value(&package_path)?;
     if !cached_path.is_dir(&self.cache.fs, ctx).await {
       return Ok(None);
     }
@@ -1718,7 +1720,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       if subpath == "." {
         for main_field in package_json.main_fields(&self.options.main_fields) {
           let path = cached_path.path().normalize_with(main_field);
-          let main_cached = self.cache.value(&path);
+          let main_cached = self.cache.value(&path)?;
           if main_cached.is_file(&self.cache.fs, ctx).await
             && self.check_restrictions(main_cached.path())
           {
@@ -1853,7 +1855,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     specifier: &str,
     package_json: &PackageJson,
     ctx: &mut Ctx,
-  ) -> Result<Option<CachedPath>, ResolveError> {
+  ) -> Result<Option<ResolverPath>, ResolveError> {
     // 1. Assert: specifier begins with "#".
     debug_assert!(specifier.starts_with('#'), "{specifier}");
     //   2. If specifier is exactly equal to "#", then
@@ -1915,7 +1917,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     ctx: &mut Ctx,
   ) -> ResolveResult {
     // enhanced-resolve behaves differently, it throws
-    // Error: CachedPath to directories is not possible with the exports field (specifier was ./dist/)
+    // Error: ResolverPath to directories is not possible with the exports field (specifier was ./dist/)
     if match_key.ends_with('/') {
       return Ok(None);
     }
@@ -2048,7 +2050,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
             // 2. If patternMatch is a String, then
             //   1. Return PACKAGE_RESOLVE(target with every instance of "*" replaced by patternMatch, packageURL + "/").
             let target = normalize_string_target(target_key, target, pattern_match, package_url)?;
-            let package_url = self.cache.value(package_url);
+            let package_url = self.cache.value(package_url)?;
             // // 3. Return PACKAGE_RESOLVE(target, packageURL + "/").
             return self.package_resolve(&package_url, &target, ctx).await;
           }
@@ -2068,7 +2070,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
           let resolved_target = package_url.normalize_with(target.as_ref());
           // 6. If patternMatch split on "/" or "\" contains any "", ".", "..", or "node_modules" segments, case insensitive and including percent encoded variants, throw an Invalid Module Specifier error.
           // 7. Return the URL resolution of resolvedTarget with every instance of "*" replaced with patternMatch.
-          let value = self.cache.value(&resolved_target);
+          let value = self.cache.value(&resolved_target)?;
           return Ok(Some(value));
         }
         // 2. Otherwise, if target is a non-null Object, then

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,8 +270,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     ctx.with_fully_specified(self.options.fully_specified);
     let cached_path = self.cache.value(path)?;
     let cached_path = self.require(&cached_path, specifier, ctx).await?;
-    let path_buf = self.load_realpath(&cached_path, ctx).await?;
-    let path = self.cache.value(&path_buf)?;
+    let path = self.load_realpath(&cached_path, ctx).await?;
 
     let package_json = cached_path
       .find_package_json(&self.cache.fs, &self.options, ctx)
@@ -715,19 +714,21 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     &self,
     cached_path: &ResolverPath,
     ctx: &mut Ctx,
-  ) -> Result<PathBuf, ResolveError> {
-    if self.options.symlinks {
-      cached_path
-        .realpath(&self.cache.fs)
-        .await
-        .map(|path| {
-          ctx.add_file_dependency(&path);
-          path
-        })
-        .map_err(ResolveError::from)
-    } else {
-      Ok(cached_path.to_path_buf())
+  ) -> Result<ResolverPath, ResolveError> {
+    if !self.options.symlinks {
+      return Ok(cached_path.clone());
     }
+    let path_buf = cached_path
+      .realpath(&self.cache.fs)
+      .await
+      .map_err(ResolveError::from)?;
+    ctx.add_file_dependency(&path_buf);
+    // Common path: realpath returns the input bytes unchanged (no symlink in
+    // chain). Reuse the existing cache entry instead of allocating a new one.
+    if path_buf.as_os_str() == cached_path.as_str() {
+      return Ok(cached_path.clone());
+    }
+    self.cache.value(&path_buf)
   }
 
   fn check_restrictions(&self, path: &Path) -> bool {

--- a/src/path.rs
+++ b/src/path.rs
@@ -11,6 +11,83 @@ pub fn path_to_str(path: &Path) -> &str {
   path.to_str().expect("path should be UTF-8")
 }
 
+/// Strip a single trailing path separator (platform-aware). Used so that
+/// `parent_str("/a/b/")` walks to `"/a"` instead of `"/a/b"`.
+#[inline]
+fn trim_one_trailing_sep(s: &str) -> &str {
+  #[cfg(windows)]
+  {
+    s.strip_suffix('\\')
+      .or_else(|| s.strip_suffix('/'))
+      .unwrap_or(s)
+  }
+  #[cfg(not(windows))]
+  {
+    s.strip_suffix('/').unwrap_or(s)
+  }
+}
+
+#[inline]
+fn last_sep_index(s: &str) -> Option<usize> {
+  #[cfg(windows)]
+  {
+    match (s.rfind('/'), s.rfind('\\')) {
+      (Some(a), Some(b)) => Some(a.max(b)),
+      (Some(a), None) | (None, Some(a)) => Some(a),
+      (None, None) => None,
+    }
+  }
+  #[cfg(not(windows))]
+  {
+    s.rfind('/')
+  }
+}
+
+/// Return the parent slice of a UTF-8 path string.
+///
+/// Splits on the last `/` (and `\` on Windows). Returns `None` when the path
+/// has no parent (Unix root `/`, Windows drive root `C:\`, or a relative single
+/// component).
+#[inline]
+pub fn parent_str(s: &str) -> Option<&str> {
+  if s.is_empty() {
+    return None;
+  }
+  let trimmed = trim_one_trailing_sep(s);
+  let idx = last_sep_index(trimmed)?;
+  let prefix = &trimmed[..idx];
+  let include_sep =
+    prefix.is_empty() || (cfg!(windows) && prefix.len() == 2 && prefix.ends_with(':'));
+  if include_sep {
+    Some(&trimmed[..=idx])
+  } else {
+    Some(prefix)
+  }
+}
+
+/// Join a UTF-8 base path with a single segment using the platform separator.
+///
+/// Mirrors `std::path::Path::join` semantics: when `segment` is absolute
+/// (starts with `/`, or `\` on Windows) it replaces `base` entirely. Otherwise
+/// the segment is appended, inserting a separator only when `base` does not
+/// already end in one.
+#[inline]
+pub fn join_str(base: &str, segment: &str) -> String {
+  if Path::new(segment).is_absolute() {
+    return segment.to_string();
+  }
+  let already_sep =
+    base.ends_with(std::path::MAIN_SEPARATOR) || (cfg!(windows) && base.ends_with('/'));
+  let extra = usize::from(!already_sep);
+  let mut out = String::with_capacity(base.len() + extra + segment.len());
+  out.push_str(base);
+  if !already_sep {
+    out.push(std::path::MAIN_SEPARATOR);
+  }
+  out.push_str(segment);
+  out
+}
+
 /// Extension trait to add path normalization to std's [`Path`].
 pub trait PathUtil {
   /// Normalize this path without performing I/O.
@@ -138,4 +215,38 @@ async fn normalize() {
     Path::new(r"\\server\share").normalize(),
     Path::new(r"\\server\share")
   );
+}
+
+#[test]
+fn parent_str_handles_common_cases() {
+  assert_eq!(parent_str("/a/b/c"), Some("/a/b"));
+  assert_eq!(parent_str("/a/b"), Some("/a"));
+  assert_eq!(parent_str("/a"), Some("/"));
+  assert_eq!(parent_str("/"), None);
+  assert_eq!(parent_str("a"), None);
+  assert_eq!(parent_str(""), None);
+  assert_eq!(parent_str("/a/b/"), Some("/a"));
+}
+
+#[cfg(windows)]
+#[test]
+fn parent_str_handles_windows_separators() {
+  assert_eq!(parent_str(r"C:\a\b\c"), Some(r"C:\a\b"));
+  assert_eq!(parent_str(r"C:\a"), Some(r"C:\"));
+  assert_eq!(parent_str(r"C:\"), None);
+}
+
+#[test]
+fn join_str_appends_with_separator() {
+  let sep = std::path::MAIN_SEPARATOR;
+  assert_eq!(join_str("/a/b", "c"), format!("/a/b{sep}c"));
+  assert_eq!(join_str("/", "c"), "/c");
+  assert_eq!(join_str(&format!("/a{sep}"), "b"), format!("/a{sep}b"));
+}
+
+#[test]
+fn join_str_absolute_segment_replaces_base() {
+  // Mirror Path::join semantics: an absolute segment replaces the base.
+  assert_eq!(join_str("/a/b", "/modules"), "/modules");
+  assert_eq!(join_str("/x", "/y/z"), "/y/z");
 }

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -4,12 +4,12 @@ use std::{
   sync::Arc,
 };
 
-use crate::package_json::PackageJson;
+use crate::{cache::ResolverPath, package_json::PackageJson};
 
-/// The final path resolution with optional `?query` and `#fragment`
+/// The final path resolution with optional `?query` and `#fragment`.
 #[derive(Clone)]
 pub struct Resolution {
-  pub(crate) path: PathBuf,
+  pub(crate) path: ResolverPath,
 
   /// path query `?query`, contains `?`.
   pub(crate) query: Option<String>,
@@ -23,7 +23,7 @@ pub struct Resolution {
 impl fmt::Debug for Resolution {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.debug_struct("Resolution")
-      .field("path", &self.path)
+      .field("path", &self.path.path())
       .field("query", &self.query)
       .field("fragment", &self.fragment)
       .field("package_json", &self.package_json.as_ref().map(|p| &p.path))
@@ -39,34 +39,34 @@ impl PartialEq for Resolution {
 impl Eq for Resolution {}
 
 impl Resolution {
-  /// Returns the path without query and fragment
+  /// Returns the path without query and fragment.
   pub fn path(&self) -> &Path {
-    &self.path
+    self.path.path()
   }
 
-  /// Returns the path without query and fragment
+  /// Returns the path without query and fragment.
   pub fn into_path_buf(self) -> PathBuf {
-    self.path
+    self.path.path().to_path_buf()
   }
 
-  /// Returns the path query `?query`, contains the leading `?`
+  /// Returns the path query `?query`, contains the leading `?`.
   pub fn query(&self) -> Option<&str> {
     self.query.as_deref()
   }
 
-  /// Returns the path fragment `#fragment`, contains the leading `#`
+  /// Returns the path fragment `#fragment`, contains the leading `#`.
   pub fn fragment(&self) -> Option<&str> {
     self.fragment.as_deref()
   }
 
-  /// Returns serialized package_json
+  /// Returns serialized package_json.
   pub fn package_json(&self) -> Option<&Arc<PackageJson>> {
     self.package_json.as_ref()
   }
 
-  /// Returns the full path with query and fragment
+  /// Returns the full path with query and fragment.
   pub fn full_path(&self) -> PathBuf {
-    let mut path = self.path.clone().into_os_string();
+    let mut path = self.path.path().to_path_buf().into_os_string();
     if let Some(query) = &self.query {
       path.push(query);
     }
@@ -75,12 +75,24 @@ impl Resolution {
     }
     PathBuf::from(path)
   }
+
+  /// Borrow the underlying [`ResolverPath`], which carries a precomputed
+  /// FxHasher u64 and a UTF-8 `&str` view. Downstream may reuse this directly
+  /// to avoid re-hashing the path.
+  pub fn resolver_path(&self) -> &ResolverPath {
+    &self.path
+  }
+
+  /// Move out the underlying [`ResolverPath`] (cheap `Arc` clone semantics).
+  pub fn into_resolver_path(self) -> ResolverPath {
+    self.path
+  }
 }
 
 #[tokio::test]
 async fn test() {
   let resolution = Resolution {
-    path: PathBuf::from("foo"),
+    path: ResolverPath::for_test("foo"),
     query: Some("?query".to_string()),
     fragment: Some("#fragment".to_string()),
     package_json: None,
@@ -90,4 +102,25 @@ async fn test() {
   assert_eq!(resolution.fragment(), Some("#fragment"));
   assert_eq!(resolution.full_path(), PathBuf::from("foo?query#fragment"));
   assert_eq!(resolution.into_path_buf(), PathBuf::from("foo"));
+}
+
+#[tokio::test]
+async fn resolver_path_exposes_hash() {
+  use std::env;
+
+  use crate::{ResolveOptions, Resolver};
+
+  let dir = env::current_dir().expect("cwd");
+  let resolver = Resolver::new(ResolveOptions::default());
+  let res = resolver
+    .resolve(&dir, "./Cargo.toml")
+    .await
+    .expect("resolve");
+
+  let rp = res.resolver_path();
+  let mut h = rustc_hash::FxHasher::default();
+  use std::hash::Hasher;
+  h.write(rp.as_str().as_bytes());
+  assert_eq!(rp.hash(), h.finish());
+  assert_eq!(rp.path(), res.path());
 }


### PR DESCRIPTION
## Why

Resolver consumers (rspack) re-hash the returned `PathBuf` for their own module-id maps. Today every resolver result pays a path hash twice — once inside the cache, once downstream. The internal cache also threads paths through `OsStr`-backed `Path::hash`, which on Windows walks per component.

This PR unifies the internal `CachedPath` and the public `Resolution.path: PathBuf` into a single `ResolverPath`:

- carries a precomputed `FxHasher` u64 over the path bytes
- holds the path as `Box<str>` (UTF-8)
- cheap `Arc` clone, same single-allocation footprint as the old `Arc<CachedPathImpl>`
- exposed off `Resolution` via `resolver_path()` / `into_resolver_path()`

Downstream can plug the prehash straight into an `FxHashMap` without re-walking the bytes.

## What

- `ResolverPath` replaces `CachedPath` everywhere in the resolver and is the type carried by `Resolution`.
- New public accessors `Resolution::resolver_path` / `into_resolver_path`. Existing `path()` / `into_path_buf()` / `full_path()` / `query()` / `fragment()` / `package_json()` keep their signatures — no public input API change.
- `Cache::value` now returns `Result<ResolverPath, ResolveError>`. New error variant `ResolveError::PathNotUtf8(PathBuf)` is raised at the boundary instead of the previous `path_to_str` panic.
- Internal hot-path joins use `join_str` / `parent_str` on `&str`, skipping `OsStr ↔ str` conversions and the per-component walk in `Path::hash` (the win is most visible on Windows; Unix is at parity with #226).

## Before / after

```rust
// before
let res = resolver.resolve(dir, spec).await?;
let mut h = FxHasher::default();
h.write(res.path().as_os_str().as_bytes()); // second walk over the bytes
let hash = h.finish();

// after
let res = resolver.resolve(dir, spec).await?;
let hash = res.resolver_path().hash(); // already computed inside the cache
```

## Tests

- 144 lib + 9 cache contract + 7 integration tests all pass.
- New tests: `ResolverPath::hash` matches `FxHasher::write(bytes)`, equal lookups share `Arc`, parent walk matches direct lookup, non-UTF-8 input returns `PathNotUtf8`.
- napi build (`cargo check -p rspack_napi_resolver`) clean.