### PR TITLE
perf(deps): carry precomputed hash via ResolverPath in resolve context

### DIFF
--- a/examples/resolver.rs
+++ b/examples/resolver.rs
@@ -40,10 +40,10 @@ async fn main() {
   };
 
   let mut sorted_file_deps = ctx.file_dependencies.iter().collect::<Vec<_>>();
-  sorted_file_deps.sort();
+  sorted_file_deps.sort_by_key(|p| p.as_path());
   println!("file_deps: {:#?}", sorted_file_deps);
 
   let mut sorted_missing = ctx.missing_dependencies.iter().collect::<Vec<_>>();
-  sorted_missing.sort();
+  sorted_missing.sort_by_key(|p| p.as_path());
   println!("missing_deps: {:#?}", sorted_missing);
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,5 +1,3 @@
-#[cfg(unix)]
-use std::os::unix::ffi::OsStrExt;
 use std::{
   borrow::{Borrow, Cow},
   convert::AsRef,
@@ -20,6 +18,7 @@ use crate::{
   context::ResolveContext as Ctx,
   package_json::{off_to_location, PackageJson},
   path::PathUtil,
+  resolver_path::hash_path,
   FileMetadata, FileSystem, JSONError, ResolveError, ResolveOptions, TsConfig,
 };
 
@@ -45,17 +44,7 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
   }
 
   pub fn value(&self, path: &Path) -> CachedPath {
-    let hash = {
-      let mut hasher = FxHasher::default();
-      // On Unix, hash the raw path bytes in one bulk `Hasher::write`. The std
-      // `Path::hash` impl walks components (utf8 split + per-segment write)
-      // and dominated profile samples on this cache-lookup hot path.
-      #[cfg(unix)]
-      hasher.write(path.as_os_str().as_bytes());
-      #[cfg(not(unix))]
-      path.hash(&mut hasher);
-      hasher.finish()
-    };
+    let hash = hash_path(path);
     if let Some(cache_entry) = self.paths.get((hash, path).borrow() as &dyn CacheKey) {
       return cache_entry.clone();
     }
@@ -205,10 +194,10 @@ impl CachedPathImpl {
 
   pub async fn is_file<Fs: Send + Sync + FileSystem>(&self, fs: &Fs, ctx: &mut Ctx) -> bool {
     if let Some(meta) = self.meta(fs).await {
-      ctx.add_file_dependency(self.path());
+      ctx.add_file_dependency_cached(self.hash, &self.path);
       meta.is_file
     } else {
-      ctx.add_missing_dependency(self.path());
+      ctx.add_missing_dependency_cached(self.hash, &self.path);
       false
     }
   }
@@ -216,7 +205,7 @@ impl CachedPathImpl {
   pub async fn is_dir<Fs: Send + Sync + FileSystem>(&self, fs: &Fs, ctx: &mut Ctx) -> bool {
     self.meta(fs).await.map_or_else(
       || {
-        ctx.add_missing_dependency(self.path());
+        ctx.add_missing_dependency_cached(self.hash, &self.path);
         false
       },
       |meta| meta.is_dir,
@@ -338,8 +327,8 @@ impl CachedPathImpl {
       match pkg {
         Some(package_json) => ctx.add_file_dependency(&package_json.path),
         None => {
-          if let Some(deps) = &mut ctx.missing_dependencies {
-            deps.push(self.path.join("package.json"));
+          if ctx.missing_dependencies.is_some() {
+            ctx.add_missing_dependency(&self.path.join("package.json"));
           }
         }
       }
@@ -400,13 +389,13 @@ impl CachedPathImpl {
       }
       Ok(None) => {
         // Avoid an allocation by making this lazy
-        if let Some(deps) = &mut ctx.missing_dependencies {
-          deps.push(self.path.join("package.json"));
+        if ctx.missing_dependencies.is_some() {
+          ctx.add_missing_dependency(&self.path.join("package.json"));
         }
       }
       Err(_) => {
-        if let Some(deps) = &mut ctx.file_dependencies {
-          deps.push(self.path.join("package.json"));
+        if ctx.file_dependencies.is_some() {
+          ctx.add_file_dependency(&self.path.join("package.json"));
         }
       }
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -18,7 +18,7 @@ use crate::{
   context::ResolveContext as Ctx,
   package_json::{off_to_location, PackageJson},
   path::PathUtil,
-  resolver_path::hash_path,
+  resolver_path::{hash_path, ResolverPath},
   FileMetadata, FileSystem, JSONError, ResolveError, ResolveOptions, TsConfig,
 };
 
@@ -155,6 +155,15 @@ pub struct CachedPathImpl {
   package_json: OnceLock<Option<Arc<PackageJson>>>,
 }
 
+impl From<&CachedPathImpl> for ResolverPath {
+  /// Reuse the cache-side `FxHash` (already computed in `Cache::value`); the
+  /// only remaining work is one `Arc::from(&Path)` to materialize the shared
+  /// path buffer for the `ResolveContext` sink.
+  fn from(cached: &CachedPathImpl) -> Self {
+    Self::from_parts(cached.hash, Arc::from(&*cached.path))
+  }
+}
+
 impl CachedPathImpl {
   fn new(hash: u64, path: Box<Path>, parent: Option<CachedPath>) -> Self {
     Self {
@@ -194,10 +203,10 @@ impl CachedPathImpl {
 
   pub async fn is_file<Fs: Send + Sync + FileSystem>(&self, fs: &Fs, ctx: &mut Ctx) -> bool {
     if let Some(meta) = self.meta(fs).await {
-      ctx.add_file_dependency_cached(self.hash, &self.path);
+      ctx.add_file_dependency(self);
       meta.is_file
     } else {
-      ctx.add_missing_dependency_cached(self.hash, &self.path);
+      ctx.add_missing_dependency(self);
       false
     }
   }
@@ -205,7 +214,7 @@ impl CachedPathImpl {
   pub async fn is_dir<Fs: Send + Sync + FileSystem>(&self, fs: &Fs, ctx: &mut Ctx) -> bool {
     self.meta(fs).await.map_or_else(
       || {
-        ctx.add_missing_dependency_cached(self.hash, &self.path);
+        ctx.add_missing_dependency(self);
         false
       },
       |meta| meta.is_dir,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -328,7 +328,7 @@ impl CachedPathImpl {
         Some(package_json) => ctx.add_file_dependency(&package_json.path),
         None => {
           if ctx.missing_dependencies.is_some() {
-            ctx.add_missing_dependency(&self.path.join("package.json"));
+            ctx.add_missing_dependency(self.path.join("package.json"));
           }
         }
       }
@@ -390,12 +390,12 @@ impl CachedPathImpl {
       Ok(None) => {
         // Avoid an allocation by making this lazy
         if ctx.missing_dependencies.is_some() {
-          ctx.add_missing_dependency(&self.path.join("package.json"));
+          ctx.add_missing_dependency(self.path.join("package.json"));
         }
       }
       Err(_) => {
         if ctx.file_dependencies.is_some() {
-          ctx.add_file_dependency(&self.path.join("package.json"));
+          ctx.add_file_dependency(self.path.join("package.json"));
         }
       }
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,8 +1,4 @@
-use std::{
-  ops::{Deref, DerefMut},
-  path::Path,
-  sync::Arc,
-};
+use std::ops::{Deref, DerefMut};
 
 use crate::{error::ResolveError, resolver_path::ResolverPath};
 
@@ -63,6 +59,10 @@ impl ResolveContext {
     self.missing_dependencies.replace(vec![]);
   }
 
+  // Accepts anything convertible to `ResolverPath`. The conversion (which
+  // includes the `Arc<Path>` allocation for `&Path` / `PathBuf` callers, or
+  // hash reuse for `&CachedPathImpl`) only runs inside the `Some` branch, so
+  // `resolve()` calls without a context still pay zero.
   pub fn add_file_dependency<P: Into<ResolverPath>>(&mut self, dep: P) {
     if let Some(deps) = &mut self.file_dependencies {
       deps.push(dep.into());
@@ -72,21 +72,6 @@ impl ResolveContext {
   pub fn add_missing_dependency<P: Into<ResolverPath>>(&mut self, dep: P) {
     if let Some(deps) = &mut self.missing_dependencies {
       deps.push(dep.into());
-    }
-  }
-
-  // The `*_cached` variants reuse a `FxHash` the caller already computed (e.g.
-  // from `CachedPathImpl.hash`). The `Arc<Path>` alloc is gated on the `Some`
-  // so a `resolve()` call without context still pays zero.
-  pub(crate) fn add_file_dependency_cached(&mut self, hash: u64, dep: &Path) {
-    if let Some(deps) = &mut self.file_dependencies {
-      deps.push(ResolverPath::from_parts(hash, Arc::from(dep)));
-    }
-  }
-
-  pub(crate) fn add_missing_dependency_cached(&mut self, hash: u64, dep: &Path) {
-    if let Some(deps) = &mut self.missing_dependencies {
-      deps.push(ResolverPath::from_parts(hash, Arc::from(dep)));
     }
   }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -63,23 +63,21 @@ impl ResolveContext {
     self.missing_dependencies.replace(vec![]);
   }
 
-  /// Add a file dependency from a raw `&Path`, hashing on insert.
   pub fn add_file_dependency(&mut self, dep: &Path) {
     if let Some(deps) = &mut self.file_dependencies {
       deps.push(ResolverPath::from(dep));
     }
   }
 
-  /// Add a missing dependency from a raw `&Path`, hashing on insert.
   pub fn add_missing_dependency(&mut self, dep: &Path) {
     if let Some(deps) = &mut self.missing_dependencies {
       deps.push(ResolverPath::from(dep));
     }
   }
 
-  /// Add a file dependency reusing the caller's precomputed `FxHash` of `dep`.
-  /// The `Arc<Path>` allocation only happens when dependency tracking is
-  /// enabled, so the no-context resolve path pays no extra cost.
+  // The `*_cached` variants reuse a `FxHash` the caller already computed (e.g.
+  // from `CachedPathImpl.hash`). The `Arc<Path>` alloc is gated on the `Some`
+  // so a `resolve()` call without context still pays zero.
   pub(crate) fn add_file_dependency_cached(&mut self, hash: u64, dep: &Path) {
     if let Some(deps) = &mut self.file_dependencies {
       deps.push(ResolverPath::from_parts(hash, Arc::from(dep)));

--- a/src/context.rs
+++ b/src/context.rs
@@ -63,15 +63,15 @@ impl ResolveContext {
     self.missing_dependencies.replace(vec![]);
   }
 
-  pub fn add_file_dependency(&mut self, dep: &Path) {
+  pub fn add_file_dependency<P: Into<ResolverPath>>(&mut self, dep: P) {
     if let Some(deps) = &mut self.file_dependencies {
-      deps.push(ResolverPath::from(dep));
+      deps.push(dep.into());
     }
   }
 
-  pub fn add_missing_dependency(&mut self, dep: &Path) {
+  pub fn add_missing_dependency<P: Into<ResolverPath>>(&mut self, dep: P) {
     if let Some(deps) = &mut self.missing_dependencies {
-      deps.push(ResolverPath::from(dep));
+      deps.push(dep.into());
     }
   }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,9 +1,10 @@
 use std::{
   ops::{Deref, DerefMut},
-  path::{Path, PathBuf},
+  path::Path,
+  sync::Arc,
 };
 
-use crate::error::ResolveError;
+use crate::{error::ResolveError, resolver_path::ResolverPath};
 
 #[derive(Debug, Default, Clone)]
 pub struct ResolveContext(ResolveContextImpl);
@@ -16,11 +17,11 @@ pub struct ResolveContextImpl {
 
   pub fragment: Option<String>,
 
-  /// Files that was found on file system
-  pub file_dependencies: Option<Vec<PathBuf>>,
+  /// Files that were found on file system
+  pub file_dependencies: Option<Vec<ResolverPath>>,
 
-  /// Files that was found on file system
-  pub missing_dependencies: Option<Vec<PathBuf>>,
+  /// Files that were not found on file system
+  pub missing_dependencies: Option<Vec<ResolverPath>>,
 
   /// The current resolving alias for bailing recursion alias.
   pub resolving_alias: Option<String>,
@@ -62,15 +63,32 @@ impl ResolveContext {
     self.missing_dependencies.replace(vec![]);
   }
 
+  /// Add a file dependency from a raw `&Path`, hashing on insert.
   pub fn add_file_dependency(&mut self, dep: &Path) {
     if let Some(deps) = &mut self.file_dependencies {
-      deps.push(dep.to_path_buf());
+      deps.push(ResolverPath::from(dep));
     }
   }
 
+  /// Add a missing dependency from a raw `&Path`, hashing on insert.
   pub fn add_missing_dependency(&mut self, dep: &Path) {
     if let Some(deps) = &mut self.missing_dependencies {
-      deps.push(dep.to_path_buf());
+      deps.push(ResolverPath::from(dep));
+    }
+  }
+
+  /// Add a file dependency reusing the caller's precomputed `FxHash` of `dep`.
+  /// The `Arc<Path>` allocation only happens when dependency tracking is
+  /// enabled, so the no-context resolve path pays no extra cost.
+  pub(crate) fn add_file_dependency_cached(&mut self, hash: u64, dep: &Path) {
+    if let Some(deps) = &mut self.file_dependencies {
+      deps.push(ResolverPath::from_parts(hash, Arc::from(dep)));
+    }
+  }
+
+  pub(crate) fn add_missing_dependency_cached(&mut self, hash: u64, dep: &Path) {
+    if let Some(deps) = &mut self.missing_dependencies {
+      deps.push(ResolverPath::from_parts(hash, Arc::from(dep)));
     }
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ mod options;
 mod package_json;
 mod path;
 mod resolution;
+mod resolver_path;
 mod specifier;
 mod tsconfig;
 
@@ -85,6 +86,7 @@ pub use crate::{
   },
   package_json::{JSONValue, ModuleType, PackageJson},
   resolution::Resolution,
+  resolver_path::ResolverPath,
 };
 use crate::{
   cache::{Cache, CachedPath},
@@ -100,11 +102,11 @@ type ResolveResult = Result<Option<CachedPath>, ResolveError>;
 /// Context returned from the [Resolver::resolve_with_context] API
 #[derive(Debug, Default, Clone)]
 pub struct ResolveContext {
-  /// Files that was found on file system
-  pub file_dependencies: FxHashSet<PathBuf>,
+  /// Files that were found on file system
+  pub file_dependencies: FxHashSet<ResolverPath>,
 
-  /// Dependencies that was not found on file system
-  pub missing_dependencies: FxHashSet<PathBuf>,
+  /// Dependencies that were not found on file system
+  pub missing_dependencies: FxHashSet<ResolverPath>,
 }
 
 /// Resolver with the current operating system as the file system

--- a/src/resolver_path.rs
+++ b/src/resolver_path.rs
@@ -1,7 +1,6 @@
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
 use std::{
-  borrow::Borrow,
   fmt,
   hash::{Hash, Hasher},
   ops::Deref,
@@ -17,6 +16,14 @@ use rustc_hash::FxHasher;
 /// Downstream consumers (rspack) place these into hash collections keyed by the
 /// precomputed hash, avoiding repeated hashing of long absolute paths on every
 /// insert and lookup.
+///
+/// Equality compares the raw `OsStr` bytes of the path, **not** the component
+/// view that `Path::eq` uses. This keeps `Hash` and `Eq` consistent: two
+/// `ResolverPath`s are equal iff their stored hashes are equal, which is what
+/// the resolver guarantees because it only inserts paths produced by its own
+/// cache (already byte-canonical). Constructing a `ResolverPath` from an
+/// unnormalized `Path` and looking it up against a normalized one will miss —
+/// callers must use the form the resolver produced.
 #[derive(Clone)]
 pub struct ResolverPath {
   hash: u64,
@@ -29,8 +36,13 @@ impl ResolverPath {
     Self { hash, path }
   }
 
-  /// Construct without recomputing the hash. The caller must guarantee that
-  /// `hash` equals [`hash_path`] of `path`.
+  /// Construct without recomputing the hash.
+  ///
+  /// # Precondition
+  /// `hash` MUST equal [`hash_path`] of `path`. Violating this breaks
+  /// `HashSet`'s bucketing invariant — entries become unfindable and
+  /// deduplication stops working. Not `unsafe` because the failure mode is a
+  /// logic bug rather than UB.
   #[inline]
   pub(crate) fn from_parts(hash: u64, path: Arc<Path>) -> Self {
     Self { hash, path }
@@ -82,8 +94,11 @@ impl Hash for ResolverPath {
 }
 
 impl PartialEq for ResolverPath {
+  /// Compare on raw `OsStr` bytes so equality matches [`hash_path`]'s scheme.
+  /// `Path::eq` would normalize components (collapse `//` and `.` segments) and
+  /// silently produce `a == b` pairs whose hashes differ.
   fn eq(&self, other: &Self) -> bool {
-    self.path == other.path
+    self.path.as_os_str() == other.path.as_os_str()
   }
 }
 
@@ -99,12 +114,6 @@ impl Deref for ResolverPath {
 
 impl AsRef<Path> for ResolverPath {
   fn as_ref(&self) -> &Path {
-    &self.path
-  }
-}
-
-impl Borrow<Path> for ResolverPath {
-  fn borrow(&self) -> &Path {
     &self.path
   }
 }

--- a/src/resolver_path.rs
+++ b/src/resolver_path.rs
@@ -39,10 +39,10 @@ impl ResolverPath {
   /// Construct without recomputing the hash.
   ///
   /// # Precondition
-  /// `hash` MUST equal [`hash_path`] of `path`. Violating this breaks
-  /// `HashSet`'s bucketing invariant — entries become unfindable and
-  /// deduplication stops working. Not `unsafe` because the failure mode is a
-  /// logic bug rather than UB.
+  /// `hash` MUST equal `hash_path(path)`. Violating this breaks `HashSet`'s
+  /// bucketing invariant — entries become unfindable and deduplication stops
+  /// working. Not `unsafe` because the failure mode is a logic bug rather
+  /// than UB.
   #[inline]
   pub(crate) fn from_parts(hash: u64, path: Arc<Path>) -> Self {
     Self { hash, path }
@@ -94,9 +94,10 @@ impl Hash for ResolverPath {
 }
 
 impl PartialEq for ResolverPath {
-  /// Mirror [`hash_path`] per-platform so the `a == b ⇒ hash(a) == hash(b)`
-  /// invariant holds: raw `OsStr` bytes on Unix (matches the bulk-byte hash),
-  /// component-normalized `Path::eq` elsewhere (matches `Path::hash`).
+  /// Mirror `hash_path`'s per-platform scheme so the `a == b ⇒ hash(a) ==
+  /// hash(b)` invariant holds: raw `OsStr` bytes on Unix (matches the
+  /// bulk-byte hash), component-normalized `Path::eq` elsewhere (matches
+  /// `Path::hash`).
   fn eq(&self, other: &Self) -> bool {
     #[cfg(unix)]
     {

--- a/src/resolver_path.rs
+++ b/src/resolver_path.rs
@@ -1,0 +1,183 @@
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+use std::{
+  borrow::Borrow,
+  fmt,
+  hash::{Hash, Hasher},
+  ops::Deref,
+  path::{Path, PathBuf},
+  sync::Arc,
+};
+
+use rustc_hash::FxHasher;
+
+/// A path returned in [`crate::ResolveContext`] dependencies, paired with a
+/// precomputed `FxHash` of the path bytes.
+///
+/// Downstream consumers (rspack) place these into hash collections keyed by the
+/// precomputed hash, avoiding repeated hashing of long absolute paths on every
+/// insert and lookup.
+#[derive(Clone)]
+pub struct ResolverPath {
+  hash: u64,
+  path: Arc<Path>,
+}
+
+impl ResolverPath {
+  pub fn new(path: Arc<Path>) -> Self {
+    let hash = hash_path(&path);
+    Self { hash, path }
+  }
+
+  /// Construct without recomputing the hash. The caller must guarantee that
+  /// `hash` equals [`hash_path`] of `path`.
+  #[inline]
+  pub(crate) fn from_parts(hash: u64, path: Arc<Path>) -> Self {
+    Self { hash, path }
+  }
+
+  #[inline]
+  pub fn as_path(&self) -> &Path {
+    &self.path
+  }
+
+  #[inline]
+  pub fn as_arc(&self) -> &Arc<Path> {
+    &self.path
+  }
+
+  #[inline]
+  pub fn into_arc(self) -> Arc<Path> {
+    self.path
+  }
+
+  /// The precomputed `FxHash` of the path bytes.
+  #[inline]
+  pub fn precomputed_hash(&self) -> u64 {
+    self.hash
+  }
+}
+
+/// Hash a path with `FxHasher`, matching the bytes-on-unix optimization used by
+/// the resolver's internal cache so [`ResolverPath`] values constructed from a
+/// `CachedPath` produce the same `u64` as values constructed from a `&Path`.
+#[inline]
+pub fn hash_path(path: &Path) -> u64 {
+  let mut hasher = FxHasher::default();
+  // The std `Path::hash` impl walks components (utf8 split + per-segment
+  // write); a single bulk `write` of the raw bytes is materially cheaper on
+  // the resolver hot path.
+  #[cfg(unix)]
+  hasher.write(path.as_os_str().as_bytes());
+  #[cfg(not(unix))]
+  path.hash(&mut hasher);
+  hasher.finish()
+}
+
+impl Hash for ResolverPath {
+  #[inline]
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    state.write_u64(self.hash);
+  }
+}
+
+impl PartialEq for ResolverPath {
+  fn eq(&self, other: &Self) -> bool {
+    self.path == other.path
+  }
+}
+
+impl Eq for ResolverPath {}
+
+impl Deref for ResolverPath {
+  type Target = Path;
+
+  fn deref(&self) -> &Self::Target {
+    &self.path
+  }
+}
+
+impl AsRef<Path> for ResolverPath {
+  fn as_ref(&self) -> &Path {
+    &self.path
+  }
+}
+
+impl Borrow<Path> for ResolverPath {
+  fn borrow(&self) -> &Path {
+    &self.path
+  }
+}
+
+impl From<PathBuf> for ResolverPath {
+  fn from(path: PathBuf) -> Self {
+    Self::new(Arc::from(path))
+  }
+}
+
+impl From<&Path> for ResolverPath {
+  fn from(path: &Path) -> Self {
+    Self::new(Arc::from(path))
+  }
+}
+
+impl From<&PathBuf> for ResolverPath {
+  fn from(path: &PathBuf) -> Self {
+    Self::new(Arc::from(path.as_path()))
+  }
+}
+
+impl From<Arc<Path>> for ResolverPath {
+  fn from(path: Arc<Path>) -> Self {
+    Self::new(path)
+  }
+}
+
+impl fmt::Debug for ResolverPath {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    self.path.fmt(f)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn hash_is_path_byte_hash() {
+    let p: &Path = Path::new("/a/b/c.js");
+    let rp = ResolverPath::from(p);
+    assert_eq!(rp.precomputed_hash(), hash_path(p));
+  }
+
+  #[test]
+  fn equal_paths_have_equal_hashes() {
+    let a = ResolverPath::from(PathBuf::from("/x/y"));
+    let b = ResolverPath::from(Path::new("/x/y"));
+    assert_eq!(a, b);
+    assert_eq!(a.precomputed_hash(), b.precomputed_hash());
+  }
+
+  #[test]
+  fn writes_u64_into_hasher() {
+    use std::{collections::HashSet, hash::BuildHasherDefault};
+
+    #[derive(Default)]
+    struct IdHasher(u64);
+    impl Hasher for IdHasher {
+      fn write(&mut self, _: &[u8]) {
+        unreachable!()
+      }
+      fn write_u64(&mut self, n: u64) {
+        self.0 = n;
+      }
+      fn finish(&self) -> u64 {
+        self.0
+      }
+    }
+
+    let mut set: HashSet<ResolverPath, BuildHasherDefault<IdHasher>> = HashSet::default();
+    set.insert(ResolverPath::from(Path::new("/a/b")));
+    assert!(set.contains(&ResolverPath::from(PathBuf::from("/a/b"))));
+  }
+}

--- a/src/resolver_path.rs
+++ b/src/resolver_path.rs
@@ -13,17 +13,17 @@ use rustc_hash::FxHasher;
 /// A path returned in [`crate::ResolveContext`] dependencies, paired with a
 /// precomputed `FxHash` of the path bytes.
 ///
-/// Downstream consumers (rspack) place these into hash collections keyed by the
-/// precomputed hash, avoiding repeated hashing of long absolute paths on every
-/// insert and lookup.
+/// Downstream consumers (rspack) place these into hash collections keyed by
+/// the precomputed hash, avoiding repeated hashing of long absolute paths on
+/// every insert and lookup.
 ///
-/// Equality compares the raw `OsStr` bytes of the path, **not** the component
-/// view that `Path::eq` uses. This keeps `Hash` and `Eq` consistent: two
-/// `ResolverPath`s are equal iff their stored hashes are equal, which is what
-/// the resolver guarantees because it only inserts paths produced by its own
-/// cache (already byte-canonical). Constructing a `ResolverPath` from an
-/// unnormalized `Path` and looking it up against a normalized one will miss —
-/// callers must use the form the resolver produced.
+/// Hash and equality are kept aligned per platform so the standard
+/// `a == b ⇒ hash(a) == hash(b)` contract holds:
+/// - On Unix, both hash and equality compare the raw `OsStr` bytes (fast bulk
+///   `write`; matches the resolver's cache-side `Cache::value` hash).
+/// - On other platforms, both go through `Path` (component-walked hash and
+///   normalized equality), so e.g. `pack1/foo` and `pack1\\foo` are treated as
+///   the same dependency on Windows — same behavior `PathBuf` had before.
 #[derive(Clone)]
 pub struct ResolverPath {
   hash: u64,
@@ -94,11 +94,18 @@ impl Hash for ResolverPath {
 }
 
 impl PartialEq for ResolverPath {
-  /// Compare on raw `OsStr` bytes so equality matches [`hash_path`]'s scheme.
-  /// `Path::eq` would normalize components (collapse `//` and `.` segments) and
-  /// silently produce `a == b` pairs whose hashes differ.
+  /// Mirror [`hash_path`] per-platform so the `a == b ⇒ hash(a) == hash(b)`
+  /// invariant holds: raw `OsStr` bytes on Unix (matches the bulk-byte hash),
+  /// component-normalized `Path::eq` elsewhere (matches `Path::hash`).
   fn eq(&self, other: &Self) -> bool {
-    self.path.as_os_str() == other.path.as_os_str()
+    #[cfg(unix)]
+    {
+      self.path.as_os_str() == other.path.as_os_str()
+    }
+    #[cfg(not(unix))]
+    {
+      self.path == other.path
+    }
   }
 }
 

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -237,12 +237,12 @@ async fn alias_is_full_path() {
   }
 
   for path in ctx.file_dependencies {
-    assert_eq!(path, path.normalize(), "{path:?}");
+    assert_eq!(path.as_path(), path.normalize(), "{path:?}");
     check_slash(&path);
   }
 
   for path in ctx.missing_dependencies {
-    assert_eq!(path, path.normalize(), "{path:?}");
+    assert_eq!(path.as_path(), path.normalize(), "{path:?}");
     check_slash(&path);
     if let Some(path) = path.parent() {
       assert!(!path.is_file(), "{path:?} must not be a file");

--- a/src/tests/dependencies.rs
+++ b/src/tests/dependencies.rs
@@ -7,7 +7,7 @@ mod windows {
   use rustc_hash::FxHashSet;
 
   use super::super::memory_fs::MemoryFS;
-  use crate::{ResolveContext, ResolveOptions, ResolverGeneric};
+  use crate::{ResolveContext, ResolveOptions, ResolverGeneric, ResolverPath};
 
   fn file_system() -> MemoryFS {
     MemoryFS::new(&[
@@ -104,9 +104,14 @@ mod windows {
         .await
         .map(|r| r.full_path());
       assert_eq!(resolved, Ok(PathBuf::from(result)));
-      let file_dependencies = FxHashSet::from_iter(file_dependencies.iter().map(PathBuf::from));
-      let missing_dependencies =
-        FxHashSet::from_iter(missing_dependencies.iter().map(PathBuf::from));
+      let file_dependencies: FxHashSet<ResolverPath> = file_dependencies
+        .iter()
+        .map(|p| ResolverPath::from(PathBuf::from(p)))
+        .collect();
+      let missing_dependencies: FxHashSet<ResolverPath> = missing_dependencies
+        .iter()
+        .map(|p| ResolverPath::from(PathBuf::from(p)))
+        .collect();
       assert_eq!(ctx.file_dependencies, file_dependencies, "{name}");
       assert_eq!(ctx.missing_dependencies, missing_dependencies, "{name}");
     }

--- a/src/tests/extensions.rs
+++ b/src/tests/extensions.rs
@@ -2,7 +2,10 @@
 
 use rustc_hash::FxHashSet;
 
-use crate::{EnforceExtension, Resolution, ResolveContext, ResolveError, ResolveOptions, Resolver};
+use crate::{
+  EnforceExtension, Resolution, ResolveContext, ResolveError, ResolveOptions, Resolver,
+  ResolverPath,
+};
 
 #[tokio::test]
 async fn extensions() {
@@ -64,7 +67,10 @@ async fn default_enforce_extension() {
   );
   assert_eq!(
     ctx.file_dependencies,
-    FxHashSet::from_iter([f.join("foo.ts"), f.join("package.json")])
+    FxHashSet::from_iter([
+      ResolverPath::from(f.join("foo.ts")),
+      ResolverPath::from(f.join("package.json")),
+    ])
   );
   assert!(ctx.missing_dependencies.is_empty());
 }
@@ -89,11 +95,14 @@ async fn respect_enforce_extension() {
   );
   assert_eq!(
     ctx.file_dependencies,
-    FxHashSet::from_iter([f.join("foo.ts"), f.join("package.json")])
+    FxHashSet::from_iter([
+      ResolverPath::from(f.join("foo.ts")),
+      ResolverPath::from(f.join("package.json")),
+    ])
   );
   assert_eq!(
     ctx.missing_dependencies,
-    FxHashSet::from_iter([f.join("foo")])
+    FxHashSet::from_iter([ResolverPath::from(f.join("foo"))])
   );
 }
 

--- a/src/tests/incorrect_description_file.rs
+++ b/src/tests/incorrect_description_file.rs
@@ -2,7 +2,9 @@
 
 use rustc_hash::FxHashSet;
 
-use crate::{JSONError, Resolution, ResolveContext, ResolveError, ResolveOptions, Resolver};
+use crate::{
+  JSONError, Resolution, ResolveContext, ResolveError, ResolveOptions, Resolver, ResolverPath,
+};
 
 // should not resolve main in incorrect description file #1
 #[tokio::test]
@@ -23,7 +25,10 @@ async fn incorrect_description_file_1() {
   assert!(matches!(resolution, Err(ResolveError::JSON(_))));
   assert_eq!(
     ctx.file_dependencies,
-    FxHashSet::from_iter([f.join("pack1"), f.join("pack1/package.json")])
+    FxHashSet::from_iter([
+      ResolverPath::from(f.join("pack1")),
+      ResolverPath::from(f.join("pack1/package.json")),
+    ])
   );
   assert!(!ctx.missing_dependencies.is_empty());
 }

--- a/src/tests/missing.rs
+++ b/src/tests/missing.rs
@@ -2,7 +2,7 @@
 
 use normalize_path::NormalizePath;
 
-use crate::{AliasValue, ResolveContext, ResolveOptions, Resolver};
+use crate::{AliasValue, ResolveContext, ResolveOptions, Resolver, ResolverPath};
 
 #[tokio::test]
 async fn test() {
@@ -59,13 +59,15 @@ async fn test() {
     let _ = resolver.resolve_with_context(&f, specifier, &mut ctx).await;
 
     for path in ctx.file_dependencies {
-      assert_eq!(path, path.normalize(), "{path:?}");
+      assert_eq!(path.as_path(), path.normalize(), "{path:?}");
     }
 
     for path in missing_dependencies {
       assert_eq!(path, path.normalize(), "{path:?}");
       assert!(
-        ctx.missing_dependencies.contains(&path),
+        ctx
+          .missing_dependencies
+          .contains(&ResolverPath::from(&path)),
         "{specifier}: {path:?} not in {:?}",
         &ctx.missing_dependencies
       );
@@ -108,11 +110,11 @@ async fn alias_and_extensions() {
   let _ = resolver.resolve_with_context(&f, "react-dom/client", &mut ctx);
 
   for path in ctx.file_dependencies {
-    assert_eq!(path, path.normalize(), "{path:?}");
+    assert_eq!(path.as_path(), path.normalize(), "{path:?}");
   }
 
   for path in ctx.missing_dependencies {
-    assert_eq!(path, path.normalize(), "{path:?}");
+    assert_eq!(path.as_path(), path.normalize(), "{path:?}");
     if let Some(path) = path.parent() {
       assert!(!path.is_file(), "{path:?} must not be a file");
     }

--- a/src/tests/pnp.rs
+++ b/src/tests/pnp.rs
@@ -3,7 +3,9 @@
 //! enhanced_resolve's test <https://github.com/webpack/enhanced-resolve/blob/main/test/pnp.test.js>
 //! cannot be ported over because it uses mocks on `pnpApi` provided by the runtime.
 
-use crate::{path::PathUtil, ResolveContext, ResolveError::NotFound, ResolveOptions, Resolver};
+use crate::{
+  path::PathUtil, ResolveContext, ResolveError::NotFound, ResolveOptions, Resolver, ResolverPath,
+};
 
 #[tokio::test]
 async fn pnp1() {
@@ -94,7 +96,9 @@ async fn pnp_file_dependencies() {
     .await;
   assert!(result.is_ok());
   assert!(
-    ctx.file_dependencies.contains(&fixture.join(".pnp.cjs")),
+    ctx
+      .file_dependencies
+      .contains(&ResolverPath::from(fixture.join(".pnp.cjs"))),
     ".pnp.cjs should be in file_dependencies, got: {:?}",
     ctx.file_dependencies
   );

--- a/src/tests/symlink.rs
+++ b/src/tests/symlink.rs
@@ -1,6 +1,6 @@
 use std::{fs, io, path::Path};
 
-use crate::{ResolveOptions, Resolver};
+use crate::{ResolveOptions, Resolver, ResolverPath};
 
 #[derive(Debug, Clone, Copy)]
 enum FileType {
@@ -148,7 +148,9 @@ async fn test() -> io::Result<()> {
       .map(|r| r.full_path());
     assert_eq!(resolved_path, Ok(path.join(request)));
     assert!(
-      ctx.file_dependencies.contains(&resolved_path.unwrap()),
+      ctx
+        .file_dependencies
+        .contains(&ResolverPath::from(resolved_path.unwrap())),
       "file dependencies should contain resolved path {comment:?}"
     );
   }

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -1,7 +1,8 @@
 //! Tests for tsconfig project references
 
 use crate::{
-  ResolveContext, ResolveError, ResolveOptions, Resolver, TsconfigOptions, TsconfigReferences,
+  ResolveContext, ResolveError, ResolveOptions, Resolver, ResolverPath, TsconfigOptions,
+  TsconfigReferences,
 };
 
 #[tokio::test]
@@ -74,7 +75,9 @@ async fn tsconfig_file_as_file_dependencies() {
   ];
   for dependency in expected_dependencies {
     assert!(
-      ctx.file_dependencies.contains(&dependency),
+      ctx
+        .file_dependencies
+        .contains(&ResolverPath::from(&dependency)),
       "missing tsconfig file dependency {dependency:?}: {:?}",
       ctx.file_dependencies
     );


### PR DESCRIPTION
## Why

The resolver's internal `CachedPath` already computes an FxHash of every path
during `Cache::value(...)`. When `resolve_with_context` returns
`file_dependencies` / `missing_dependencies` as `FxHashSet<PathBuf>`, that
precomputed hash is thrown away — downstream consumers (rspack) then re-hash
the same long absolute paths on every insert into `HashSet<ArcPath, _>` and on
every membership lookup.

This change preserves the precomputed hash all the way out of the resolver so
downstream code can build identity-hashed collections directly.

## What

- New `pub struct ResolverPath { hash: u64, path: Arc<Path> }`
  - `Hash::hash` writes the precomputed `u64`.
  - `PartialEq`/`AsRef<Path>`/`Deref<Target = Path>` for ergonomic use.
  - Constructible from `&Path` / `PathBuf` / `Arc<Path>`; the `From<&Path>` /
    `From<PathBuf>` constructors hash with the same bytes-on-unix optimization
    the cache uses, so values built either way collide identically.
- `ResolveContext.file_dependencies` / `missing_dependencies` are now
  `FxHashSet<ResolverPath>`.
- On the hot dependency-tracking path (`CachedPath::is_file` / `is_dir`), a new
  `add_*_dependency_cached(hash, path)` entry point reuses the cached `u64`
  and only allocates `Arc<Path>` when dependency tracking is actually enabled
  (no-context resolves pay nothing extra).
- `FxHasher::write_u64` on the drain into the public `FxHashSet<ResolverPath>`
  replaces a per-byte FxHash of the full absolute path.

`Resolution.path` and the napi binding's `resolve` API are unchanged — only
the dependency sets in `ResolveContext` carry the new type.