### PR TITLE
fix(cache): replay missing_dependency tracking in cached_node_modules warm path

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -279,6 +279,11 @@ impl CachedPathImpl {
     ctx: &mut Ctx,
   ) -> Option<CachedPath> {
     if let Some(nm) = self.node_modules.get() {
+      // Replay ctx tracking from the cold path: module_directory -> is_dir calls
+      // ctx.add_missing_dependency when node_modules doesn't exist on disk.
+      if nm.is_none() {
+        ctx.add_missing_dependency(self.path.join("node_modules"));
+      }
       return nm.clone();
     }
     self

--- a/src/tests/dependencies.rs
+++ b/src/tests/dependencies.rs
@@ -1,5 +1,60 @@
 //! https://github.com/webpack/enhanced-resolve/blob/main/test/dependencies.test.js
 
+// Warm-cache calls must report the same missing_dependencies as the cold path so that
+// webpack/rspack watchers can track non-existent node_modules dirs across multiple resolves.
+#[cfg(not(target_os = "windows"))]
+mod warm_cache_missing_dependencies {
+  use std::path::PathBuf;
+
+  use super::super::memory_fs::MemoryFS;
+  use crate::{ResolveContext, ResolveOptions, ResolverGeneric};
+
+  fn file_system() -> MemoryFS {
+    MemoryFS::new(&[
+      ("/a/b/c/some.js", ""), // makes /a/b/c and /a/b real dirs; neither has node_modules
+      ("/a/node_modules/module/index.js", ""),
+    ])
+  }
+
+  #[tokio::test]
+  async fn node_modules_missing_deps_same_on_warm_cache() {
+    let resolver = ResolverGeneric::<MemoryFS>::new_with_file_system(
+      file_system(),
+      ResolveOptions {
+        extensions: vec![".js".into()],
+        ..ResolveOptions::default()
+      },
+    );
+
+    let path = PathBuf::from("/a/b/c");
+
+    let mut ctx_cold = ResolveContext::default();
+    let cold = resolver
+      .resolve_with_context(path.clone(), "module", &mut ctx_cold)
+      .await;
+
+    let mut ctx_warm = ResolveContext::default();
+    let warm = resolver
+      .resolve_with_context(path.clone(), "module", &mut ctx_warm)
+      .await;
+
+    assert_eq!(cold.map(|r| r.full_path()), warm.map(|r| r.full_path()));
+
+    assert_eq!(
+      ctx_cold.missing_dependencies, ctx_warm.missing_dependencies,
+      "cold: {:?}\nwarm: {:?}",
+      ctx_cold.missing_dependencies, ctx_warm.missing_dependencies,
+    );
+
+    // enhanced-resolve lists traversed-but-absent node_modules dirs in missingDependencies
+    for dir in ["/a/b/c/node_modules", "/a/b/node_modules"] {
+      assert!(ctx_warm
+        .missing_dependencies
+        .contains(&PathBuf::from(dir).into()));
+    }
+  }
+}
+
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 mod windows {
   use std::path::PathBuf;


### PR DESCRIPTION
## Why

PR #224 added early-return cache-hit guards to four `CachedPath` hot accessors. The `package_json` warm path correctly replays `ctx.add_file_dependency` / `ctx.add_missing_dependency` on cache hits, but `cached_node_modules` was missed.

On the cold path, `cached_node_modules` → `module_directory` → `is_dir` calls `ctx.add_missing_dependency(node_modules_path)` when the directory doesn't exist. The early-return skipped this, so webpack/rspack file watchers wouldn't receive the signal to rebuild when a `node_modules` directory was later created.

## What

- In the `None` branch of the warm-cache early-return, call `ctx.add_missing_dependency(self.path.join("node_modules"))` — mirroring what `package_json` already does.
- Add a regression test that resolves the same specifier twice (cold then warm) and asserts `missing_dependencies` is identical on both calls, with a spot-check against the two absent `node_modules` paths that enhanced-resolve explicitly tracks.

## Follow-up

A related cold-path divergence from enhanced-resolve was uncovered while validating this fix: `is_dir` does not record a missing-dep when the path exists as a non-directory (e.g., a regular file named `node_modules`). The warm path here happens to handle that case correctly because the `OnceLock<Option<CachedPath>>` folds "absent" and "non-dir" into the same `None`. Tracking the cold-path fix separately in #239.