### PR TITLE
perf(cache): skip Box::pin on realpath cache hit

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -225,11 +225,7 @@ impl CachedPathImpl {
     // Cache hit: avoid the heap-allocated `Box::pin` for the cache-miss state machine
     // by returning before delegating to the boxed recursive helper.
     if let Some(cached) = self.canonicalized.get() {
-      return Ok(
-        cached
-          .clone()
-          .unwrap_or_else(|| self.path.clone().to_path_buf()),
-      );
+      return Ok(cached.clone().unwrap_or_else(|| self.path.to_path_buf()));
     }
     self.realpath_uncached(fs).await
   }
@@ -259,7 +255,7 @@ impl CachedPathImpl {
         })
         .await
         .cloned()
-        .map(|r| r.unwrap_or_else(|| self.path.clone().to_path_buf()))
+        .map(|r| r.unwrap_or_else(|| self.path.to_path_buf()))
     })
   }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -221,20 +221,24 @@ impl CachedPathImpl {
     )
   }
 
-  pub fn realpath<'a, Fs: FileSystem + Send + Sync>(
+  pub async fn realpath<Fs: FileSystem + Send + Sync>(&self, fs: &Fs) -> io::Result<PathBuf> {
+    // Cache hit: avoid the heap-allocated `Box::pin` for the cache-miss state machine
+    // by returning before delegating to the boxed recursive helper.
+    if let Some(cached) = self.canonicalized.get() {
+      return Ok(
+        cached
+          .clone()
+          .unwrap_or_else(|| self.path.clone().to_path_buf()),
+      );
+    }
+    self.realpath_uncached(fs).await
+  }
+
+  fn realpath_uncached<'a, Fs: FileSystem + Send + Sync>(
     &'a self,
     fs: &'a Fs,
   ) -> BoxFuture<'a, io::Result<PathBuf>> {
-    let fut = async move {
-      // Cache hit: return immediately and avoid the recursive parent walk +
-      // `Box::pin` per call on the hot path.
-      if let Some(cached) = self.canonicalized.get() {
-        return Ok(
-          cached
-            .clone()
-            .unwrap_or_else(|| self.path.clone().to_path_buf()),
-        );
-      }
+    Box::pin(async move {
       self
         .canonicalized
         .get_or_try_init(|| async move {
@@ -256,8 +260,7 @@ impl CachedPathImpl {
         .await
         .cloned()
         .map(|r| r.unwrap_or_else(|| self.path.clone().to_path_buf()))
-    };
-    Box::pin(fut)
+    })
   }
 
   pub async fn module_directory<Fs: Send + Sync + FileSystem>(


### PR DESCRIPTION
PR #224 placed the cache-hit early return inside the `async move { ... }` block of `realpath`, so `Box::pin(fut)` still ran on every call — allocating heap space sized for the full cache-miss state machine.

Split `realpath` into:

- `pub async fn realpath(...)` — handles the cache hit, no `Box::pin`, inlines into the caller's state machine.
- `fn realpath_uncached(...) -> BoxFuture<...>` — boxed helper for the recursive cache-miss path.

## CodSpeed

| Status | Benchmark | Base | Head | Change |
|---|---|---|---|---|
| ⚡ | `resolver[multi-thread]` | 58.8 ms | 57 ms | **+3.1%** |

1 improvement, 11 unchanged.

## Test plan

- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo test --lib` — 146 passed
- [x] CodSpeed CI ✓