### PR TITLE
chore: sync renovate config from rspack

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>Boshen/renovate"],
-  "ignorePaths": ["**/node_modules/**", "**/fixtures/**", "benches/**"]
-}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,25 +13,24 @@
   packageRules: [
     // manually update peer dependencies
     {
-      depTypeList: ["peerDependencies"],
+      matchDepTypes: ["peerDependencies"],
       enabled: false
     },
     {
-      matchPackagePatterns: ["*"],
+      // applies to all updates: chore commit + always bump package.json range
+      matchPackageNames: ["*"],
       semanticCommitType: "chore",
-      // always bump package.json
       rangeStrategy: "bump"
     },
     {
       groupName: "patch crates",
       matchManagers: ["cargo"],
-      excludePackagePrefixes: ["napi"],
-      excludePackageNames: ["mimalloc"],
+      matchPackageNames: ["*", "!napi*", "!mimalloc"],
       matchUpdateTypes: ["patch"]
     },
     {
       groupName: "napi",
-      matchPackagePrefixes: ["napi", "@napi-rs/"]
+      matchPackageNames: ["napi*", "@napi-rs/*"]
     },
     {
       groupName: "ignored crates",
@@ -44,7 +43,7 @@
       groupName: "patch npm dependencies",
       matchManagers: ["npm"],
       matchDepTypes: ["dependencies", "devDependencies"],
-      excludePackageNames: ["typescript"],
+      matchPackageNames: ["*", "!typescript"],
       // bump major and minor in a separate PR
       matchUpdateTypes: ["patch"]
     },
@@ -57,9 +56,10 @@
     {
       groupName: "github-actions",
       matchManagers: ["github-actions"],
-      excludePackageNames: [
-        "actions/upload-artifact",
-        "actions/download-artifact"
+      matchPackageNames: [
+        "*",
+        "!actions/upload-artifact",
+        "!actions/download-artifact"
       ]
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,75 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  timezone: "Asia/Shanghai",
+  extends: [
+    ":dependencyDashboard",
+    "helpers:pinGitHubActionDigests",
+    "github>rstackjs/renovate:security"
+  ],
+  schedule: ["before 8am on saturday"],
+  enabledManagers: ["github-actions", "cargo", "npm"],
+  ignorePaths: ["**/node_modules/**", "**/fixtures/**", "benches/**"],
+  labels: ["dependencies"],
+  packageRules: [
+    // manually update peer dependencies
+    {
+      depTypeList: ["peerDependencies"],
+      enabled: false
+    },
+    {
+      matchPackagePatterns: ["*"],
+      semanticCommitType: "chore",
+      // always bump package.json
+      rangeStrategy: "bump"
+    },
+    {
+      groupName: "patch crates",
+      matchManagers: ["cargo"],
+      excludePackagePrefixes: ["napi"],
+      excludePackageNames: ["mimalloc"],
+      matchUpdateTypes: ["patch"]
+    },
+    {
+      groupName: "napi",
+      matchPackagePrefixes: ["napi", "@napi-rs/"]
+    },
+    {
+      groupName: "ignored crates",
+      matchManagers: ["cargo"],
+      // mimalloc is pinned for benchmark allocator alignment with rspack's xtask/benchmark
+      matchPackageNames: ["mimalloc"],
+      enabled: false
+    },
+    {
+      groupName: "patch npm dependencies",
+      matchManagers: ["npm"],
+      matchDepTypes: ["dependencies", "devDependencies"],
+      excludePackageNames: ["typescript"],
+      // bump major and minor in a separate PR
+      matchUpdateTypes: ["patch"]
+    },
+    // Disable Node.js updates
+    {
+      groupName: "node",
+      matchPackageNames: ["node"],
+      enabled: false
+    },
+    {
+      groupName: "github-actions",
+      matchManagers: ["github-actions"],
+      excludePackageNames: [
+        "actions/upload-artifact",
+        "actions/download-artifact"
+      ]
+    },
+    {
+      groupName: "manually managed github-actions",
+      matchManagers: ["github-actions"],
+      matchPackageNames: [
+        "actions/upload-artifact",
+        "actions/download-artifact"
+      ],
+      enabled: false
+    }
+  ]
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 MIT License
 
 Copyright (c) 2024-present Bytedance Inc and its affiliates.
-Copyright (c) 2023-2024 Boshen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2024-present Bytedance Inc and its affiliates.
+Copyright (c) 2023-2024 Boshen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION

## What

- Switch from `renovate.json` to `renovate.json5` to match rspack's format and allow inline comments.
- Schedule weekly (before 8am Saturday, Asia/Shanghai); restrict managers to `github-actions`, `cargo`, `npm`.
- Port only rules that apply to this repo: `patch crates` / `napi` / `patch npm dependencies` grouping, `mimalloc` pin (aligned with rspack's benchmark allocator), disable Node updates, group `github-actions` with `actions/upload-artifact` and `actions/download-artifact` left manual.
- Skip rspack-only rules (swc/babel/react/playwright/Rspack/@rspack, `crate rspack_resolver` self-ref, `crates/rspack_plugin_css`, `linting/`, `lynx-infra/*`, `rstackjs/rust-cache`).

### Before / After

Before:
```json
{
  "extends": ["github>Boshen/renovate"],
  "ignorePaths": ["**/node_modules/**", "**/fixtures/**", "benches/**"]
}
```

After: `renovate.json5` extends the rstackjs shared security preset with the project-relevant grouping rules from rspack.