### PR TITLE
perf: optimize Specifier::parse

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Build Benchmark
         env:
           RUSTFLAGS: "-C debuginfo=1 -C strip=none -g"
-        run: cargo codspeed build
+        run: cargo codspeed build --features __internal_bench
 
       - name: Run CPU benchmark
         uses: CodSpeedHQ/action@281164b0f014a4e7badd2c02cecad9b595b70537 # https://github.com/CodSpeedHQ/action/releases/tag/v4.10.6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,9 @@ version      = "0.9.0"
 doctest = false
 
 [[bench]]
-harness = false
-name    = "resolver"
+harness           = false
+name              = "resolver"
+required-features = ["__internal_bench"]
 
 [lints.clippy]
 all   = { level = "warn", priority = -1 }
@@ -132,6 +133,8 @@ package_json_raw_json_api = []
 yarn_pnp = ["pnp", "arc-swap"]
 # For remove tracing calls in release build
 enable_instrument = []
+# Internal: exposes `Specifier` to criterion benchmarks. Not stable.
+__internal_bench = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -46,8 +46,12 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for NeverGrowInPlaceAllocator<A> {
   }
 }
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use rspack_resolver::{FileSystemOptions, FileSystemOs, ResolveOptions, Resolver};
+use criterion::{
+  black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
+};
+use rspack_resolver::{
+  FileSystemOptions, FileSystemOs, ResolveOptions, Resolver, __BenchSpecifier as Specifier,
+};
 use serde_json::Value;
 use tokio::{
   runtime::{self, Builder},
@@ -404,5 +408,238 @@ fn bench_resolver(c: &mut Criterion) {
   );
 }
 
-criterion_group!(resolver, bench_resolver);
+// ============================================================================
+// Specifier micro-benchmarks
+// ----------------------------------------------------------------------------
+// `parse_query_framgment` lives behind `Specifier::parse`. The wrapper does a
+// single byte read + length check, so benchmarking `parse` is effectively
+// benchmarking the query/fragment scanner. Cases are split into four groups:
+// branch matrix, length sweep, escape scaling, and realistic specimens.
+// ============================================================================
+
+// `path` is repeated to reach `len`, then optional `?query` / `#fragment`
+// suffix is appended. Lets us scale a single shape across short/medium/long
+// inputs without changing branch coverage.
+fn specifier_shaped(base: &str, len: usize, query: Option<&str>, fragment: Option<&str>) -> String {
+  let mut s = String::with_capacity(len + 64);
+  while s.len() < len {
+    s.push_str(base);
+  }
+  s.truncate(len);
+  if let Some(q) = query {
+    s.push('?');
+    s.push_str(q);
+  }
+  if let Some(f) = fragment {
+    s.push('#');
+    s.push_str(f);
+  }
+  s
+}
+
+// Webpack-style synthesized escapes: inserts `\0#` sequences inside the path
+// so the scanner hits the `prev == '\0'` branch and is forced onto the
+// Cow::Owned slow path.
+fn specifier_with_escapes(parts: &[&str]) -> String {
+  parts.join("\0#")
+}
+
+fn specifier_branch_cases() -> Vec<(&'static str, String)> {
+  vec![
+    // 1. (None, None) — fast path, Cow::Borrowed
+    ("none/short", "./foo.js".to_string()),
+    (
+      "none/medium",
+      "./packages/utils/src/internal/helpers/normalizePath.ts".to_string(),
+    ),
+    // 2. (Some, None) — query only
+    ("query/short", "./a.js?vue".to_string()),
+    (
+      "query/medium",
+      "./Button.tsx?vue&type=script&lang=ts&scoped=true&hash=abc12345".to_string(),
+    ),
+    // 3. (None, Some) — fragment only, scanner breaks early
+    ("fragment/short", "./a.js#main".to_string()),
+    (
+      "fragment/medium",
+      "./pages/Home.tsx#section-introduction-to-the-rspack-resolver".to_string(),
+    ),
+    // 4. (Some, Some) — query then fragment
+    ("query+fragment/short", "./a.js?x#y".to_string()),
+    (
+      "query+fragment/medium",
+      "./Widget.vue?vue&type=template&lang=html#root".to_string(),
+    ),
+    // 5. multiple `?`, only first becomes query_start
+    (
+      "multi-question",
+      "./a.js?one?two?three?four?five?six?seven".to_string(),
+    ),
+    // 6. `\0#` escape → slow path (Cow::Owned + char_indices filter)
+    (
+      "escape/single",
+      specifier_with_escapes(&["path/", "real-hash"]),
+    ),
+    // 7. multiple escapes — repeats the slow path several times in one input
+    (
+      "escape/many",
+      specifier_with_escapes(&["./pkg/", "repo", "repo2", "repo3", "repo4#hash"]),
+    ),
+    // 8. leading `/`, `.`, `#` → offset=1; the first char is skipped intentionally
+    ("leading-slash", "/abs/path/to/file.mjs?q#f".to_string()),
+    ("leading-hash", "#alias/module.cjs?q#f".to_string()),
+    // 9. bare module — offset=0, scan starts at index 0
+    (
+      "bare-module",
+      "@scope/package/sub/path/index.js?q#f".to_string(),
+    ),
+    // 10. `?` inside a fragment must NOT be promoted to query — scanner already
+    //     broke at the `#`, but worth pinning so a future refactor can't regress it.
+    (
+      "fragment-with-question",
+      "./a.js#frag?not-a-query&also-not".to_string(),
+    ),
+  ]
+}
+
+// Same shape, four sizes — measures how each branch scales with input length.
+// Sizes chosen at ~5x steps so codspeed renders a clear curve.
+const SPECIFIER_LENGTH_TIERS: &[(&str, usize)] = &[
+  ("len_8", 8),
+  ("len_64", 64),
+  ("len_256", 256),
+  ("len_1536", 1536),
+];
+
+#[allow(clippy::type_complexity)]
+fn specifier_length_shapes() -> Vec<(
+  &'static str,
+  &'static str,
+  Option<&'static str>,
+  Option<&'static str>,
+)> {
+  vec![
+    // Pure path: stresses the loop body without any branch hits.
+    ("path-only", "./a/b/c/d/e/", None, None),
+    // Query at the very end: full scan before query_start is set.
+    (
+      "query-tail",
+      "./a/b/c/d/e/",
+      Some("vue&type=script&lang=ts"),
+      None,
+    ),
+    // Fragment at the very end: full scan, then early break at last char.
+    ("frag-tail", "./a/b/c/d/e/", None, Some("section-end")),
+    // Both at the tail.
+    (
+      "both-tail",
+      "./a/b/c/d/e/",
+      Some("vue&type=script"),
+      Some("hash"),
+    ),
+  ]
+}
+
+// Hand-picked from typical rspack/webpack loader chains; these are what the
+// parser actually sees in a production resolve flow.
+fn specifier_realistic_cases() -> Vec<(&'static str, &'static str)> {
+  vec![
+    ("rw/loader-chain",
+     "./node_modules/.pnpm/vue-loader@17.0.0/node_modules/vue-loader/dist/templateLoader.js?vue&type=template&id=2f8c6e7a&scoped=true&lang=html"),
+    ("rw/css-modules",
+     "./src/components/Sidebar/Sidebar.module.css?ngGlobalStyle&hash=d41d8cd98f00b204e9800998ecf8427e"),
+    ("rw/asset-query",
+     "./public/assets/images/hero@2x.png?as=webp&w=1920&h=1080&quality=80&format=webp"),
+    ("rw/hash-only",
+     "./shared/utils/index.ts#tree-shaken-export-marker-do-not-strip"),
+    ("rw/inline-loader",
+     "!!./node_modules/css-loader/dist/cjs.js??ref--6-oneOf-1-1!./node_modules/postcss-loader/dist/cjs.js??ref--6-oneOf-1-2!./src/App.vue?vue&type=style&index=0&id=7ba5bd90&scoped=true&lang=css"),
+  ]
+}
+
+fn bench_specifier_branches(c: &mut Criterion) {
+  let mut group = c.benchmark_group("specifier/branches");
+  for (label, input) in specifier_branch_cases() {
+    group.throughput(Throughput::Bytes(input.len() as u64));
+    group.bench_with_input(BenchmarkId::from_parameter(label), &input, |b, s| {
+      b.iter(|| {
+        let parsed = Specifier::parse(black_box(s.as_str())).unwrap();
+        black_box(parsed);
+      });
+    });
+  }
+  group.finish();
+}
+
+fn bench_specifier_length_sweep(c: &mut Criterion) {
+  let mut group = c.benchmark_group("specifier/length");
+  for (shape_label, base, query, fragment) in specifier_length_shapes() {
+    for (len_label, len) in SPECIFIER_LENGTH_TIERS {
+      let input = specifier_shaped(base, *len, query, fragment);
+      let id = BenchmarkId::new(shape_label, len_label);
+      group.throughput(Throughput::Bytes(input.len() as u64));
+      group.bench_with_input(id, &input, |b, s| {
+        b.iter(|| {
+          let parsed = Specifier::parse(black_box(s.as_str())).unwrap();
+          black_box(parsed);
+        });
+      });
+    }
+  }
+  group.finish();
+}
+
+fn bench_specifier_escape_scaling(c: &mut Criterion) {
+  // Slow path scales with both input length AND the number of escapes (the
+  // filter closure does an O(n*k) `escaped_indexes.contains(&i)` per char).
+  // Worth a dedicated knob so the optimizer can target it.
+  let mut group = c.benchmark_group("specifier/escapes");
+  for &n in &[1usize, 4, 16, 64] {
+    let mut parts = vec!["./pkg/"];
+    let chunk = "segment";
+    let extras: Vec<&str> = std::iter::repeat(chunk).take(n).collect();
+    parts.extend(extras.iter().copied());
+    parts.push("real#hash");
+    let input = specifier_with_escapes(&parts);
+    group.throughput(Throughput::Bytes(input.len() as u64));
+    group.bench_with_input(
+      BenchmarkId::from_parameter(format!("escapes_{n}")),
+      &input,
+      |b, s| {
+        b.iter_batched(
+          || s.as_str(),
+          |s| {
+            let parsed = Specifier::parse(black_box(s)).unwrap();
+            black_box(parsed);
+          },
+          BatchSize::SmallInput,
+        );
+      },
+    );
+  }
+  group.finish();
+}
+
+fn bench_specifier_realistic(c: &mut Criterion) {
+  let mut group = c.benchmark_group("specifier/realistic");
+  for (label, input) in specifier_realistic_cases() {
+    group.throughput(Throughput::Bytes(input.len() as u64));
+    group.bench_with_input(BenchmarkId::from_parameter(label), input, |b, s| {
+      b.iter(|| {
+        let parsed = Specifier::parse(black_box(s)).unwrap();
+        black_box(parsed);
+      });
+    });
+  }
+  group.finish();
+}
+
+criterion_group!(
+  resolver,
+  bench_resolver,
+  bench_specifier_branches,
+  bench_specifier_length_sweep,
+  bench_specifier_escape_scaling,
+  bench_specifier_realistic
+);
 criterion_main!(resolver);

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -46,9 +46,7 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for NeverGrowInPlaceAllocator<A> {
   }
 }
 
-use criterion::{
-  black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
-};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use rspack_resolver::{
   FileSystemOptions, FileSystemOs, ResolveOptions, Resolver, __BenchSpecifier as Specifier,
 };
@@ -595,10 +593,14 @@ fn bench_specifier_escape_scaling(c: &mut Criterion) {
   // Worth a dedicated knob so the optimizer can target it.
   let mut group = c.benchmark_group("specifier/escapes");
   for &n in &[1usize, 4, 16, 64] {
+    // `parts.len()` must equal `n + 1` so that `join("\0#")` inserts exactly
+    // `n` separators (= `n` escape markers in the input). The first element
+    // is a path prefix, the last is the real `#fragment`, and we pad the
+    // middle with `n - 1` filler segments.
     let mut parts = vec!["./pkg/"];
-    let chunk = "segment";
-    let extras: Vec<&str> = std::iter::repeat(chunk).take(n).collect();
-    parts.extend(extras.iter().copied());
+    for _ in 0..n.saturating_sub(1) {
+      parts.push("segment");
+    }
     parts.push("real#hash");
     let input = specifier_with_escapes(&parts);
     group.throughput(Throughput::Bytes(input.len() as u64));
@@ -606,14 +608,10 @@ fn bench_specifier_escape_scaling(c: &mut Criterion) {
       BenchmarkId::from_parameter(format!("escapes_{n}")),
       &input,
       |b, s| {
-        b.iter_batched(
-          || s.as_str(),
-          |s| {
-            let parsed = Specifier::parse(black_box(s)).unwrap();
-            black_box(parsed);
-          },
-          BatchSize::SmallInput,
-        );
+        b.iter(|| {
+          let parsed = Specifier::parse(black_box(s.as_str())).unwrap();
+          black_box(parsed);
+        });
       },
     );
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,12 @@ use dashmap::DashSet;
 use futures::future::{try_join_all, BoxFuture};
 use rustc_hash::FxHashSet;
 
+// Exposed for criterion micro-benchmarks only. Gated behind a feature so the
+// type stays out of the public API for normal consumers; benches opt in via
+// `--features __internal_bench` (see [[bench]] required-features in Cargo.toml).
+#[cfg(feature = "__internal_bench")]
+#[doc(hidden)]
+pub use crate::specifier::Specifier as __BenchSpecifier;
 use crate::{
   alias_trie::AliasTrie,
   cache::{Cache, CachedPath},

--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -44,22 +44,27 @@ impl<'a> Specifier<'a> {
   ) -> (Cow<'a, str>, Option<&'a str>, Option<&'a str>) {
     let mut query_start: Option<usize> = None;
     let mut fragment_start: Option<usize> = None;
+    let mut escaped_indexes: Vec<usize> = Vec::new();
 
-    let mut prev = specifier.chars().next().unwrap();
-    let mut escaped_indexes = vec![];
-    for (i, c) in specifier.char_indices().skip(skip) {
-      if c == '?' && query_start.is_none() {
+    // Scan as bytes: `?`, `#`, and `\0` are single-byte ASCII (< 0x80), so their
+    // byte positions coincide with char positions in any UTF-8 input. This skips
+    // the per-step UTF-8 decode that `char_indices()` performs, which dominated
+    // the callgrind baseline.
+    let bytes = specifier.as_bytes();
+    let mut prev = bytes[0];
+    for (i, &b) in bytes.iter().enumerate().skip(skip) {
+      if b == b'?' && query_start.is_none() {
         query_start = Some(i);
       }
-      if c == '#' {
-        if prev == '\0' {
+      if b == b'#' {
+        if prev == 0 {
           escaped_indexes.push(i - 1);
         } else {
           fragment_start = Some(i);
           break;
         }
       }
-      prev = c;
+      prev = b;
     }
 
     let (path, query, fragment) = match (query_start, fragment_start) {
@@ -79,14 +84,18 @@ impl<'a> Specifier<'a> {
     let path = if escaped_indexes.is_empty() {
       Cow::Borrowed(path)
     } else {
-      // Remove the `\0` characters for a legal path.
-      Cow::Owned(
-        path
-          .chars()
-          .enumerate()
-          .filter_map(|(i, c)| (!escaped_indexes.contains(&i)).then_some(c))
-          .collect::<String>(),
-      )
+      // Each escaped index points at a `\0` byte that we need to drop. Copy the
+      // surrounding slices in one pass — O(n) — instead of re-decoding chars and
+      // calling `escaped_indexes.contains(&i)` per char, which was O(n*k).
+      // The slice indices land on char boundaries because `\0` is ASCII.
+      let mut s = String::with_capacity(path.len() - escaped_indexes.len());
+      let mut last = 0;
+      for &esc in &escaped_indexes {
+        s.push_str(&path[last..esc]);
+        last = esc + 1;
+      }
+      s.push_str(&path[last..]);
+      Cow::Owned(s)
     };
 
     (path, query, fragment)

--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -14,6 +14,11 @@ impl<'a> Specifier<'a> {
     self.path.as_ref()
   }
 
+  /// Parse a module specifier into path, query, and fragment.
+  ///
+  /// # Errors
+  ///
+  /// * See [SpecifierError]
   pub fn parse(specifier: &'a str) -> Result<Self, SpecifierError> {
     if specifier.is_empty() {
       return Err(SpecifierError::Empty(specifier.to_string()));


### PR DESCRIPTION
## Why

Adds CodSpeed coverage for `Specifier::parse` / `parse_query_framgment` so an upcoming optimization PR has baseline numbers to compare against. The parser sits on the hot resolve path but has no dedicated benchmark today — improvements (or regressions) get lost in the noise of the full-resolve benches.

## What

Four bench groups under the existing `resolver` harness:

- `specifier/branches` — one input per branch in the parser (no qf / query-only / fragment-only / both / multi-`?` / escaped `\0#` / multi-escape / leading `/`,`#` / bare module / `?`-inside-fragment).
- `specifier/length` — 4 shapes × 4 sizes (8 / 64 / 256 / 1536 bytes).
- `specifier/escapes` — 1 / 4 / 16 / 64 escapes, isolating the slow path.
- `specifier/realistic` — vue-loader, css-modules, asset query, fragment-only, full inline-loader chain — shapes the parser actually sees in production resolve flows.

`Specifier` is re-exported as `__BenchSpecifier` (`#[doc(hidden)]`) behind a `__internal_bench` feature gate, so the type stays out of the public API for normal consumers. The `[[bench]] resolver` entry declares the feature as required, and `benchmark.yml` passes `--features __internal_bench` to `cargo codspeed build`.

`Specifier::parse` gets a `# Errors` doc section because the re-export (when the feature is enabled, e.g. under `--all-features` clippy) promotes it into clippy's pub-API view.

Run locally with `cargo bench --bench resolver --features __internal_bench -- specifier/`.