### PR TITLE
chore(ci): upload simulation-mode valgrind tmp files as artifact

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -54,18 +54,48 @@ jobs:
           RUSTFLAGS: "-C debuginfo=1 -C strip=none -g"
         run: cargo codspeed build
 
+      - name: Prepare Valgrind temporary directory
+        run: mkdir -p "${RUNNER_TEMP}/codspeed-valgrind-tmp"
+
       - name: Run CPU benchmark
-        uses: CodSpeedHQ/action@281164b0f014a4e7badd2c02cecad9b595b70537 # https://github.com/CodSpeedHQ/action/releases/tag/v4.10.6
+        uses: CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2 # https://github.com/CodSpeedHQ/action/releases/tag/v4.13.0
         timeout-minutes: 30
+        env:
+          TMPDIR: ${{ runner.temp }}/codspeed-valgrind-tmp
+          CODSPEED_EXPERIMENTAL_FAIR_SCHED: true
         with:
           mode: simulation
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
+          runner-version: 4.13.0
 
       - name: Run memory benchmark
-        uses: CodSpeedHQ/action@281164b0f014a4e7badd2c02cecad9b595b70537 # https://github.com/CodSpeedHQ/action/releases/tag/v4.10.6
+        uses: CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2 # https://github.com/CodSpeedHQ/action/releases/tag/v4.13.0
         timeout-minutes: 30
+        env:
+          CODSPEED_EXPERIMENTAL_FAIR_SCHED: true
         with:
           mode: memory
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
+          runner-version: 4.13.0
+
+      - name: Prepare Valgrind temporary files artifact
+        if: ${{ always() }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/codspeed-valgrind-tmp"
+          {
+            echo "TMPDIR=${RUNNER_TEMP}/codspeed-valgrind-tmp"
+            echo
+            find "${RUNNER_TEMP}/codspeed-valgrind-tmp" -mindepth 1 -maxdepth 2 -printf '%M %s %p\n' | sort
+          } > "${RUNNER_TEMP}/codspeed-valgrind-tmp/MANIFEST.txt"
+
+      - name: Upload Valgrind temporary files
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: codspeed-valgrind-tmp
+          path: ${{ runner.temp }}/codspeed-valgrind-tmp
+          include-hidden-files: true
+          if-no-files-found: ignore
+          overwrite: true


### PR DESCRIPTION
## Why

When a CodSpeed simulation run misbehaves on CI, we currently have no way to inspect the raw Valgrind/callgrind output — the runner just dumps it to the job's tmpdir, which evaporates with the runner. This mirrors the same pattern [rspack](https://github.com/web-infra-dev/rspack/blob/main/.github/workflows/bench-rust.yml) uses to keep the simulation artifacts around for post-mortem.

## What

- Point the **CPU (simulation)** CodSpeed step's `TMPDIR` at `$RUNNER_TEMP/codspeed-valgrind-tmp`, then upload that directory as a `codspeed-valgrind-tmp` artifact (with `if: always()` so a failed bench still uploads).
- Memory step is intentionally **not** captured — only the simulation run's valgrind data is useful here.
- Bump CodSpeed action + runner to `v4.13.0`, the first version that supports the `CODSPEED_EXPERIMENTAL_FAIR_SCHED` env var. Enable it on both steps for more stable timings.