### PR TITLE
chore(bench): skip multi-threaded cases in CodSpeed memory mode

### DIFF
--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -292,7 +292,7 @@ fn bench_resolver(c: &mut Criterion) {
   );
 
   group.bench_with_input(
-    BenchmarkId::from_parameter("multi-thread"),
+    BenchmarkId::from_parameter("[multi-threaded]resolve"),
     &data,
     |b, data| {
       let runner = multi_rt();
@@ -346,7 +346,7 @@ fn bench_resolver(c: &mut Criterion) {
   );
 
   group.bench_with_input(
-    BenchmarkId::from_parameter("resolve from symlinks multi thread"),
+    BenchmarkId::from_parameter("[multi-threaded]resolve from symlinks"),
     &symlinks_range,
     |b, data| {
       let runner = multi_rt();

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -228,6 +228,11 @@ fn bench_resolver(c: &mut Criterion) {
 
   let mut group = c.benchmark_group("resolver");
 
+  // CodSpeed memory mode (Valgrind massif) cannot meaningfully measure
+  // multi-threaded throughput — heap snapshots conflate allocations across
+  // worker threads and produce noisy, non-actionable deltas.
+  let skip_threaded = env::var("CODSPEED_RUNNER_MODE").as_deref() == Ok("memory");
+
   // codspeed can only handle to up to 500 threads
   let multi_rt = || {
     Builder::new_multi_thread()
@@ -291,33 +296,35 @@ fn bench_resolver(c: &mut Criterion) {
     },
   );
 
-  group.bench_with_input(
-    BenchmarkId::from_parameter("[multi-threaded]resolve"),
-    &data,
-    |b, data| {
-      let runner = multi_rt();
-      let rspack_resolver = Arc::new(rspack_resolver(false));
+  if !skip_threaded {
+    group.bench_with_input(
+      BenchmarkId::from_parameter("[multi-threaded]resolve"),
+      &data,
+      |b, data| {
+        let runner = multi_rt();
+        let rspack_resolver = Arc::new(rspack_resolver(false));
 
-      b.iter_with_setup(
-        || {
-          rspack_resolver.clear_cache();
-        },
-        |_| {
-          runner.block_on(async {
-            let mut join_set = JoinSet::new();
-            data.iter().for_each(|(path, request)| {
-              join_set.spawn(create_async_resolve_task(
-                rspack_resolver.clone(),
-                path.to_path_buf(),
-                request.to_string(),
-              ));
+        b.iter_with_setup(
+          || {
+            rspack_resolver.clear_cache();
+          },
+          |_| {
+            runner.block_on(async {
+              let mut join_set = JoinSet::new();
+              data.iter().for_each(|(path, request)| {
+                join_set.spawn(create_async_resolve_task(
+                  rspack_resolver.clone(),
+                  path.to_path_buf(),
+                  request.to_string(),
+                ));
+              });
+              let _ = join_set.join_all().await;
             });
-            let _ = join_set.join_all().await;
-          });
-        },
-      );
-    },
-  );
+          },
+        );
+      },
+    );
+  }
 
   group.bench_with_input(
     BenchmarkId::from_parameter("resolve from symlinks"),
@@ -345,29 +352,31 @@ fn bench_resolver(c: &mut Criterion) {
     },
   );
 
-  group.bench_with_input(
-    BenchmarkId::from_parameter("[multi-threaded]resolve from symlinks"),
-    &symlinks_range,
-    |b, data| {
-      let runner = multi_rt();
-      let rspack_resolver = Arc::new(rspack_resolver(false));
+  if !skip_threaded {
+    group.bench_with_input(
+      BenchmarkId::from_parameter("[multi-threaded]resolve from symlinks"),
+      &symlinks_range,
+      |b, data| {
+        let runner = multi_rt();
+        let rspack_resolver = Arc::new(rspack_resolver(false));
 
-      let symlink_test_dir = symlink_test_dir.clone();
+        let symlink_test_dir = symlink_test_dir.clone();
 
-      b.to_async(runner).iter(|| async {
-        let mut join_set = JoinSet::new();
+        b.to_async(runner).iter(|| async {
+          let mut join_set = JoinSet::new();
 
-        data.clone().for_each(|i| {
-          join_set.spawn(create_async_resolve_task(
-            rspack_resolver.clone(),
-            symlink_test_dir.clone(),
-            format!("./file{i}").to_string(),
-          ));
+          data.clone().for_each(|i| {
+            join_set.spawn(create_async_resolve_task(
+              rspack_resolver.clone(),
+              symlink_test_dir.clone(),
+              format!("./file{i}").to_string(),
+            ));
+          });
+          join_set.join_all().await;
         });
-        join_set.join_all().await;
-      });
-    },
-  );
+      },
+    );
+  }
 
   let pnp_workspace = env::current_dir().unwrap().join("fixtures/pnp");
   let root_range = 1..11;


### PR DESCRIPTION
## Why

CodSpeed memory mode runs Valgrind massif, which conflates allocations across worker threads and produces noisy, non-actionable deltas for the multi-threaded resolver benches. Skip them in that mode so memory deltas only come from the single-threaded cases.

## What

1. Rename the two threaded bench cases to share a `[multi-threaded]` prefix (matches the existing `[single-threaded]resolve with many extensions` style):
   - `multi-thread` → `[multi-threaded]resolve`
   - `resolve from symlinks multi thread` → `[multi-threaded]resolve from symlinks`
2. Gate them on the `CODSPEED_RUNNER_MODE` env var (set by the CodSpeed action). They keep running in the simulation step and are skipped only in memory mode.

No workflow change needed — the existing `mode: memory` action already exports `CODSPEED_RUNNER_MODE=memory` into the bench process.