### PR TITLE
chore: release 0.9.2

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -46,9 +46,12 @@ runs:
           ${{ inputs.pre }}
           rustup target add ${{ inputs.target }}
 
-          npm install -g corepack@0.31.0 --force
-          echo "Corepack version: $(corepack --version)"
-          corepack enable
+          # The lts-debian image ships Node 20, whose module loader crashes when
+          # invoking pnpm 11 through the corepack shim (ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING).
+          # Install pnpm as a standalone binary instead of relying on the corepack shim.
+          PNPM_VERSION=$(node -p "require(\"./package.json\").packageManager.replace(\"pnpm@\", \"\")")
+          npm install -g "@pnpm/exe@$PNPM_VERSION" --force
+          pnpm --version
 
           RUST_TARGET=${{ inputs.target }} ${{ inputs.plugin == 'false' && 'DISABLE_PLUGIN=1' || '' }} pnpm build:binding:${{ inputs.profile }}  --target ${{ inputs.target }}
           ${{ inputs.post }}

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -118,7 +118,7 @@ jobs:
           cp napi/{index,browser}.js  npm
           cp napi/index.d.ts          npm
           pnpm node scripts/x.mjs prepublish
-          pnpm node scripts/x.mjs    publish --tag ${{inputs.tag}} ${{inputs.dry_run && '--dry-run' || '--no-dry-run'}} ${{inputs.push_tags && '--push-tags' || '--no-push-tags'}}
+          pnpm --config.verify-deps-before-run=false node scripts/x.mjs    publish --tag ${{inputs.tag}} ${{inputs.dry_run && '--dry-run' || '--no-dry-run'}} ${{inputs.push_tags && '--push-tags' || '--no-push-tags'}}
         env:
           REPOSITORY: ${{ github.repository }}
           REF: ${{ github.ref }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_resolver"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name         = "rspack_resolver"
 readme       = "README.md"
 repository   = "https://github.com/rstackjs/rspack-resolver"
 rust-version = "1.70"
-version      = "0.9.1"
+version      = "0.9.2"
 
 [lib]
 doctest = false

--- a/napi/index.js
+++ b/napi/index.js
@@ -81,12 +81,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-android-arm64/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.1" &&
+          bindingPackageVersion !== "0.5.2" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -104,12 +104,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-android-arm-eabi/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.1" &&
+          bindingPackageVersion !== "0.5.2" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -137,12 +137,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-win32-x64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.1" &&
+            bindingPackageVersion !== "0.5.2" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -160,12 +160,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-win32-x64-msvc/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.1" &&
+            bindingPackageVersion !== "0.5.2" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -184,12 +184,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-win32-ia32-msvc/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.1" &&
+          bindingPackageVersion !== "0.5.2" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -207,12 +207,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-win32-arm64-msvc/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.1" &&
+          bindingPackageVersion !== "0.5.2" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -235,12 +235,12 @@ function requireNative() {
       const bindingPackageVersion =
         require("@rspack/resolver-binding-darwin-universal/package.json").version;
       if (
-        bindingPackageVersion !== "0.5.1" &&
+        bindingPackageVersion !== "0.5.2" &&
         process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
         process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
       ) {
         throw new Error(
-          `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+          `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
         );
       }
       return binding;
@@ -258,12 +258,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-darwin-x64/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.1" &&
+          bindingPackageVersion !== "0.5.2" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -281,12 +281,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-darwin-arm64/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.1" &&
+          bindingPackageVersion !== "0.5.2" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -310,12 +310,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-freebsd-x64/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.1" &&
+          bindingPackageVersion !== "0.5.2" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -333,12 +333,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-freebsd-arm64/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.1" &&
+          bindingPackageVersion !== "0.5.2" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -363,12 +363,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-x64-musl/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.1" &&
+            bindingPackageVersion !== "0.5.2" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -386,12 +386,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-x64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.1" &&
+            bindingPackageVersion !== "0.5.2" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -411,12 +411,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-arm64-musl/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.1" &&
+            bindingPackageVersion !== "0.5.2" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -434,12 +434,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-arm64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.1" &&
+            bindingPackageVersion !== "0.5.2" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -459,12 +459,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-arm-musleabihf/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.1" &&
+            bindingPackageVersion !== "0.5.2" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -482,12 +482,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-arm-gnueabihf/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.1" &&
+            bindingPackageVersion !== "0.5.2" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -507,12 +507,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-loong64-musl/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.1" &&
+            bindingPackageVersion !== "0.5.2" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -530,12 +530,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-loong64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.1" &&
+            bindingPackageVersion !== "0.5.2" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -555,12 +555,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-riscv64-musl/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.1" &&
+            bindingPackageVersion !== "0.5.2" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -578,12 +578,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-riscv64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.1" &&
+            bindingPackageVersion !== "0.5.2" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -602,12 +602,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-linux-ppc64-gnu/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.1" &&
+          bindingPackageVersion !== "0.5.2" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -625,12 +625,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-linux-s390x-gnu/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.1" &&
+          bindingPackageVersion !== "0.5.2" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -654,12 +654,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-openharmony-arm64/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.1" &&
+          bindingPackageVersion !== "0.5.2" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -677,12 +677,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-openharmony-x64/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.1" &&
+          bindingPackageVersion !== "0.5.2" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -700,12 +700,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-openharmony-arm/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.1" &&
+          bindingPackageVersion !== "0.5.2" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/resolver",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Rspack Resolver Node API",
   "main": "index.js",
   "browser": "browser.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,8 +77,14 @@ importers:
 
   bindings/wasm32-wasi:
     dependencies:
+      '@emnapi/core':
+        specifier: 1.10.0
+        version: 1.10.0
+      '@emnapi/runtime':
+        specifier: 1.10.0
+        version: 1.10.0
       '@napi-rs/wasm-runtime':
-        specifier: ^1.1.1
+        specifier: ^1.1.4
         version: 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
 
   bindings/win32-arm64-msvc: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,30 @@ importers:
         specifier: ^8.8.5
         version: 8.8.5
 
+  bindings/darwin-arm64: {}
+
+  bindings/darwin-x64: {}
+
+  bindings/linux-arm64-gnu: {}
+
+  bindings/linux-arm64-musl: {}
+
+  bindings/linux-x64-gnu: {}
+
+  bindings/linux-x64-musl: {}
+
+  bindings/wasm32-wasi:
+    dependencies:
+      '@napi-rs/wasm-runtime':
+        specifier: ^1.1.1
+        version: 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+
+  bindings/win32-arm64-msvc: {}
+
+  bindings/win32-ia32-msvc: {}
+
+  bindings/win32-x64-msvc: {}
+
   fixtures/pnpm:
     devDependencies:
       axios:


### PR DESCRIPTION
Release 0.9.2.

- Crate `rspack_resolver`: 0.9.1 → 0.9.2
- npm `@rspack/resolver`: 0.5.1 → 0.5.2

## What's included since 0.9.1

- perf(cache): memoize package.json dep path per CachedPath (#250)
- perf: optimize Specifier::parse (#241)
- perf(cache): skip Box::pin on realpath cache hit (#237)
- fix(cache): replay missing_dependency tracking in cached_node_modules warm path (#236)
- chore(deps): update dependency webpack to ^5.104.1 [security] (#242)
- chore(deps): update napi (#214)
- chore(deps): upgrade pnpm to 11.3.0 (#248)
- chore(bench): remove specifier parse microbenches (#249)
- chore(bench): split specifier microbenches into a separate bench binary (#247)
- chore(bench): skip multi-threaded cases in CodSpeed memory mode (#244)
- chore(ci): upload simulation-mode valgrind tmp files as artifact (#243)