### PR TITLE
perf(cache): key tsconfig map by std PathBuf

### DIFF
--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -170,6 +170,21 @@ fn resolver_with_many_extensions() -> rspack_resolver::Resolver {
   })
 }
 
+fn tsconfig_resolver() -> rspack_resolver::Resolver {
+  use rspack_resolver::{ResolveOptions, Resolver, TsconfigOptions, TsconfigReferences};
+  let config_dir = env::current_dir()
+    .unwrap()
+    .join("fixtures/tsconfig/cases/project_references");
+  Resolver::new(ResolveOptions {
+    extensions: vec![".ts".into(), ".js".into()],
+    tsconfig: Some(TsconfigOptions {
+      config_file: config_dir.join("app"),
+      references: TsconfigReferences::Auto,
+    }),
+    ..ResolveOptions::default()
+  })
+}
+
 fn create_async_resolve_task(
   rspack_resolver: Arc<rspack_resolver::Resolver>,
   path: PathBuf,
@@ -407,6 +422,62 @@ fn bench_resolver(c: &mut Criterion) {
                 .await;
             }
           });
+        },
+      );
+    },
+  );
+
+  // tsconfig `paths` + project-references resolution. Each resolve hits the
+  // warm `tsconfigs` cache once (a single key hash of the fixed config path),
+  // so looping the case set keeps that lookup hot — this is the scenario that
+  // exercises the `Utf8PathBuf` vs `PathBuf` map-key question.
+  let tsconfig_dir = env::current_dir()
+    .unwrap()
+    .join("fixtures/tsconfig/cases/project_references");
+  let tsconfig_data = vec![
+    (tsconfig_dir.join("app"), "@/index.ts"),
+    (tsconfig_dir.join("app"), "@/../index.ts"),
+    (tsconfig_dir.join("project_a"), "@/index.ts"),
+    (tsconfig_dir.join("project_b/src"), "@/index.ts"),
+    (tsconfig_dir.join("project_a"), "./index.ts"),
+    (tsconfig_dir.join("project_c"), "./index.ts"),
+  ];
+
+  // check validity
+  runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .unwrap()
+    .block_on(async {
+      let resolver = tsconfig_resolver();
+      for (path, request) in &tsconfig_data {
+        assert!(
+          resolver.resolve(path, request).await.is_ok(),
+          "tsconfig resolve failed {path:?} {request}, fixtures/tsconfig/cases/project_references"
+        );
+      }
+    });
+
+  group.bench_with_input(
+    BenchmarkId::from_parameter("tsconfig resolve"),
+    &tsconfig_data,
+    |b, data| {
+      let runner = runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to create tokio runtime");
+      let rspack_resolver = tsconfig_resolver();
+
+      b.to_async(runner).iter_with_setup(
+        || {
+          rspack_resolver.clear_cache();
+        },
+        |_| async {
+          for _ in 0..100 {
+            for (path, request) in data {
+              _ = rspack_resolver.resolve(path, request).await;
+            }
+          }
         },
       );
     },

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -5,6 +5,7 @@ use std::{
   hash::{BuildHasherDefault, Hash, Hasher},
   io,
   ops::Deref,
+  path::PathBuf,
   sync::Arc,
 };
 
@@ -26,7 +27,7 @@ use crate::{
 pub struct Cache<Fs> {
   pub(crate) fs: Fs,
   paths: DashSet<CachedPath, BuildHasherDefault<IdentityHasher>>,
-  tsconfigs: DashMap<Utf8PathBuf, Arc<TsConfig>, BuildHasherDefault<FxHasher>>,
+  tsconfigs: DashMap<PathBuf, Arc<TsConfig>, BuildHasherDefault<FxHasher>>,
 }
 
 impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
@@ -68,7 +69,7 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
     F: FnOnce(TsConfig) -> Fut + Send,
     Fut: Send + Future<Output = Result<TsConfig, ResolveError>>,
   {
-    if let Some(tsconfig_ref) = self.tsconfigs.get(path) {
+    if let Some(tsconfig_ref) = self.tsconfigs.get(path.as_std_path()) {
       return Ok(Arc::clone(tsconfig_ref.value()));
     }
     let meta = self.fs.metadata(path.as_std_path()).await.ok();
@@ -98,7 +99,7 @@ impl<Fs: Send + Sync + FileSystem> Cache<Fs> {
     let tsconfig = Arc::new(tsconfig.build());
     self
       .tsconfigs
-      .insert(path.to_path_buf(), Arc::clone(&tsconfig));
+      .insert(path.as_std_path().to_path_buf(), Arc::clone(&tsconfig));
     Ok(tsconfig)
   }
 }


### PR DESCRIPTION
Stacked on #259 (which adds the `tsconfig resolve` bench). Base is set to that branch so CodSpeed measures this fix against the bench's `Utf8PathBuf` baseline.

## Why

`Cache`'s `tsconfigs` map is keyed by `Utf8PathBuf` (from the camino refactor) and hashed with `FxHasher`, so every lookup runs the key's own `Hash`, and every `DashMap::get` runs `Eq` to confirm the bucket (not just on collisions). camino's `Utf8Path` routes **both** through the `Components` iterator — `Hash` walks components, `Eq` has no fast path — whereas std `Path` hashes raw bytes and `Eq` gets `Components`' `memcmp` fast path. `Cache::tsconfig` does one lookup per resolve, so the camino key is paid on every tsconfig-enabled resolve.

Same class of regression already fixed for the `CachedPath` cache in `6f70056`; the tsconfig key was the remaining internal map that lost std's byte fast paths.

## Before / after

callgrind on the `tsconfig resolve` bench (`paths` + Auto project references, warm cache):

| metric | `Utf8PathBuf` | `PathBuf` | Δ |
| --- | ---: | ---: | ---: |
| cycles | 21,208,907 | 17,842,269 | **−15.87%** |
| instructions (Ir) | 14,188,716 | 11,635,205 | **−18.0%** |

The bench is warm-lookup-dominated, so this is an upper bound — a cold/mixed build sees a smaller aggregate share. The fix is free regardless: `PathBuf` is the baseline type, **no parallel implementation to maintain**.

## What

`perf(cache)`: revert the `tsconfigs` map key to std `PathBuf`; query/insert via `as_std_path()` (not `as_str()`, to keep per-platform path semantics — Windows `pack1/foo` ≡ `pack1\foo`).
