### PR TITLE
chore(deps): bump fixtures mathjs to 15.2.0

### DIFF
--- a/fixtures/pnpm/package.json
+++ b/fixtures/pnpm/package.json
@@ -7,7 +7,7 @@
     "ipaddr.js": "2.2.0",
     "postcss": "8.4.33",
     "styled-components": "6.1.1",
-    "mathjs": "13.2.0",
+    "mathjs": "15.2.0",
     "decimal.js": "10.4.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: 2.2.0
         version: 2.2.0
       mathjs:
-        specifier: 13.2.0
-        version: 13.2.0
+        specifier: 15.2.0
+        version: 15.2.0
       postcss:
         specifier: 8.4.33
         version: 8.4.33
@@ -984,8 +984,8 @@ packages:
     resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
     engines: {node: '>= 6'}
 
-  fraction.js@4.3.7:
-    resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1069,8 +1069,8 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  mathjs@13.2.0:
-    resolution: {integrity: sha512-P5PZoiUX2Tkghkv3tsSqlK0B9My/ErKapv1j6wdxd0MOrYQ30cnGE4LH/kzYB2gA5rN46Njqc4cFgJjaxgijoQ==}
+  mathjs@15.2.0:
+    resolution: {integrity: sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==}
     engines: {node: '>= 18'}
     hasBin: true
 
@@ -1979,7 +1979,7 @@ snapshots:
       es-set-tostringtag: 2.1.0
       mime-types: 2.1.35
 
-  fraction.js@4.3.7: {}
+  fraction.js@5.3.4: {}
 
   function-bind@1.1.2: {}
 
@@ -2068,13 +2068,13 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mathjs@13.2.0:
+  mathjs@15.2.0:
     dependencies:
       '@babel/runtime': 7.27.0
       complex.js: 2.4.2
       decimal.js: 10.4.3
       escape-latex: 1.2.0
-      fraction.js: 4.3.7
+      fraction.js: 5.3.4
       javascript-natural-sort: 0.7.1
       seedrandom: 3.0.5
       tiny-emitter: 2.1.0

--- a/tests/resolve_test.rs
+++ b/tests/resolve_test.rs
@@ -186,7 +186,7 @@ async fn decimal_js() {
 #[tokio::test]
 async fn decimal_js_from_mathjs() {
   let dir = dir();
-  let path = dir.join("node_modules/.pnpm/mathjs@13.2.0/node_modules/mathjs/lib/esm");
+  let path = dir.join("node_modules/.pnpm/mathjs@15.2.0/node_modules/mathjs/lib/esm");
   let module_path =
     dir.join("node_modules/.pnpm/decimal.js@10.4.3/node_modules/decimal.js/decimal.mjs");
 


### PR DESCRIPTION
## Why
Dependabot #337/#338/#349/#350: `mathjs@13.2.0` (high, GHSA, patched in 15.2.0). `mathjs` is only a `fixtures/pnpm` test devDependency used by the Rust resolver tests — it is never part of the published `@rspack/resolver` package.

## What
- Bump `fixtures/pnpm` `mathjs` 13.2.0 → 15.2.0 and regenerate the root lockfile. `decimal.js` stays at 10.4.3 (still satisfies mathjs 15's `^10.4.3`).
- Update the version-pinned `.pnpm` path in the `decimal_js_from_mathjs` test (`mathjs@13.2.0` → `mathjs@15.2.0`) so it still locates the module dir.