### PR TITLE
chore(deps): bump fixtures postcss to 8.5.10

### DIFF
--- a/fixtures/pnpm/package.json
+++ b/fixtures/pnpm/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "axios": "1.6.2",
     "ipaddr.js": "2.2.0",
-    "postcss": "8.4.33",
+    "postcss": "8.5.10",
     "styled-components": "6.1.1",
     "mathjs": "13.2.0",
     "decimal.js": "10.4.3"

--- a/fixtures/pnpm/pnpm-lock.yaml
+++ b/fixtures/pnpm/pnpm-lock.yaml
@@ -9,8 +9,8 @@ devDependencies:
     specifier: 1.6.2
     version: 1.6.2
   postcss:
-    specifier: 8.4.33
-    version: 8.4.33
+    specifier: 8.5.10
+    version: 8.5.10
   styled-components:
     specifier: 6.1.1
     version: 6.1.1(react-dom@18.2.0)(react@18.2.0)
@@ -124,27 +124,27 @@ packages:
       mime-db: 1.52.0
     dev: true
 
-  /nanoid@3.3.7:
-    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+  /nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: true
 
-  /picocolors@1.0.0:
-    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+  /picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
     dev: true
 
   /postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
     dev: true
 
-  /postcss@8.4.33:
-    resolution: {integrity: sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==}
+  /postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
     dev: true
 
   /proxy-from-env@1.1.0:
@@ -178,8 +178,8 @@ packages:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
     dev: true
 
-  /source-map-js@1.0.2:
-    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
+  /source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -195,7 +195,7 @@ packages:
       '@types/stylis': 4.2.4
       css-to-react-native: 3.2.0
       csstype: 3.1.2
-      postcss: 8.4.33
+      postcss: 8.5.10
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       shallowequal: 1.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: 13.2.0
         version: 13.2.0
       postcss:
-        specifier: 8.4.33
-        version: 8.4.33
+        specifier: 8.5.10
+        version: 8.5.10
       styled-components:
         specifier: 6.1.1
         version: 6.1.1(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
@@ -1119,6 +1119,10 @@ packages:
     resolution: {integrity: sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
@@ -2107,6 +2111,12 @@ snapshots:
   postcss-value-parser@4.2.0: {}
 
   postcss@8.4.33:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1


### PR DESCRIPTION
## Why
Dependabot #361/#362/#363: `postcss@8.4.33` (medium, GHSA, patched in 8.5.10). `postcss` is only a `fixtures/pnpm` test devDependency used by the Rust resolver tests — never part of the published `@rspack/resolver`.

## What
- Bump `fixtures/pnpm` `postcss` 8.4.33 → 8.5.10 and regenerate the root lockfile (styled-components' deduped postcss edge moves to 8.5.10; it allows `^8.4.31`).
- Surgically bump `postcss` (and its `nanoid`/`picocolors`/`source-map-js` deps to satisfy 8.5.10's ranges) in the stale standalone `fixtures/pnpm/pnpm-lock.yaml`, which Dependabot scans but CI never installs. No test changes (postcss's `browser` field is unchanged in 8.5.10).