### PR TITLE
chore(deps): bump js-yaml, mathjs & postcss to clear GHSA advisories

### DIFF
--- a/fixtures/pnpm/package.json
+++ b/fixtures/pnpm/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "axios": "1.6.2",
     "ipaddr.js": "2.2.0",
-    "postcss": "8.4.33",
+    "postcss": "8.5.10",
     "styled-components": "6.1.1",
     "mathjs": "15.2.0",
     "decimal.js": "10.4.3"

--- a/fixtures/pnpm/package.json
+++ b/fixtures/pnpm/package.json
@@ -7,7 +7,7 @@
     "ipaddr.js": "2.2.0",
     "postcss": "8.4.33",
     "styled-components": "6.1.1",
-    "mathjs": "13.2.0",
+    "mathjs": "15.2.0",
     "decimal.js": "10.4.3"
   }
 }

--- a/fixtures/pnpm/pnpm-lock.yaml
+++ b/fixtures/pnpm/pnpm-lock.yaml
@@ -9,8 +9,8 @@ devDependencies:
     specifier: 1.6.2
     version: 1.6.2
   postcss:
-    specifier: 8.4.33
-    version: 8.4.33
+    specifier: 8.5.10
+    version: 8.5.10
   styled-components:
     specifier: 6.1.1
     version: 6.1.1(react-dom@18.2.0)(react@18.2.0)
@@ -124,27 +124,27 @@ packages:
       mime-db: 1.52.0
     dev: true
 
-  /nanoid@3.3.7:
-    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+  /nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: true
 
-  /picocolors@1.0.0:
-    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+  /picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
     dev: true
 
   /postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
     dev: true
 
-  /postcss@8.4.33:
-    resolution: {integrity: sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==}
+  /postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
     dev: true
 
   /proxy-from-env@1.1.0:
@@ -178,8 +178,8 @@ packages:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
     dev: true
 
-  /source-map-js@1.0.2:
-    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
+  /source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -195,7 +195,7 @@ packages:
       '@types/stylis': 4.2.4
       css-to-react-native: 3.2.0
       csstype: 3.1.2
-      postcss: 8.4.33
+      postcss: 8.5.10
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       shallowequal: 1.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: 2.2.0
         version: 2.2.0
       mathjs:
-        specifier: 13.2.0
-        version: 13.2.0
+        specifier: 15.2.0
+        version: 15.2.0
       postcss:
         specifier: 8.4.33
         version: 8.4.33
@@ -984,8 +984,8 @@ packages:
     resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
     engines: {node: '>= 6'}
 
-  fraction.js@4.3.7:
-    resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1069,8 +1069,8 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  mathjs@13.2.0:
-    resolution: {integrity: sha512-P5PZoiUX2Tkghkv3tsSqlK0B9My/ErKapv1j6wdxd0MOrYQ30cnGE4LH/kzYB2gA5rN46Njqc4cFgJjaxgijoQ==}
+  mathjs@15.2.0:
+    resolution: {integrity: sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==}
     engines: {node: '>= 18'}
     hasBin: true
 
@@ -1979,7 +1979,7 @@ snapshots:
       es-set-tostringtag: 2.1.0
       mime-types: 2.1.35
 
-  fraction.js@4.3.7: {}
+  fraction.js@5.3.4: {}
 
   function-bind@1.1.2: {}
 
@@ -2068,13 +2068,13 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mathjs@13.2.0:
+  mathjs@15.2.0:
     dependencies:
       '@babel/runtime': 7.27.0
       complex.js: 2.4.2
       decimal.js: 10.4.3
       escape-latex: 1.2.0
-      fraction.js: 4.3.7
+      fraction.js: 5.3.4
       javascript-natural-sort: 0.7.1
       seedrandom: 3.0.5
       tiny-emitter: 2.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: 15.2.0
         version: 15.2.0
       postcss:
-        specifier: 8.4.33
-        version: 8.4.33
+        specifier: 8.5.10
+        version: 8.5.10
       styled-components:
         specifier: 6.1.1
         version: 6.1.1(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
@@ -1115,8 +1115,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.4.33:
-    resolution: {integrity: sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@3.8.3:
@@ -2106,7 +2106,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.4.33:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -2182,7 +2182,7 @@ snapshots:
       '@types/stylis': 4.2.7
       css-to-react-native: 3.2.0
       csstype: 3.1.3
-      postcss: 8.4.33
+      postcss: 8.5.10
       react: 18.3.1
       react-dom: 19.1.0(react@18.3.1)
       shallowequal: 1.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1044,8 +1044,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   lint-staged@17.0.4:
@@ -1445,7 +1445,7 @@ snapshots:
       colorette: 2.0.20
       emnapi: 1.10.0
       es-toolkit: 1.42.0
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       obug: 2.1.1
       semver: 7.7.4
       typanion: 3.14.0
@@ -2033,7 +2033,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.0:
+  js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 

--- a/tests/resolve_test.rs
+++ b/tests/resolve_test.rs
@@ -186,7 +186,7 @@ async fn decimal_js() {
 #[tokio::test]
 async fn decimal_js_from_mathjs() {
   let dir = dir();
-  let path = dir.join("node_modules/.pnpm/mathjs@13.2.0/node_modules/mathjs/lib/esm");
+  let path = dir.join("node_modules/.pnpm/mathjs@15.2.0/node_modules/mathjs/lib/esm");
   let module_path =
     dir.join("node_modules/.pnpm/decimal.js@10.4.3/node_modules/decimal.js/decimal.mjs");
 


### PR DESCRIPTION
## Why
Clears the remaining Dependabot advisories that PR #260 (axios/form-data/follow-redirects) does not cover. All three are dev-tooling / test-fixture dependencies — none ship in the published `@rspack/resolver` package. Combined into one PR (three per-dependency commits) for easier review; supersedes #261, #262, #263.

| Dependency | Bump | Alerts |
|---|---|---|
| js-yaml | 4.1.0 → 4.1.1 | #105 |
| mathjs | 13.2.0 → 15.2.0 | #337/#338/#349/#350 |
| postcss | 8.4.33 → 8.5.10 | #361/#362/#363 |

## What
- **js-yaml**: lockfile-only bump (transitive of `@napi-rs/cli`, `^4.1.0`).
- **mathjs**: bump the `fixtures/pnpm` devDep; `decimal.js` stays 10.4.3 (mathjs 15 still allows `^10.4.3`); update the version-pinned `.pnpm` path in the `decimal_js_from_mathjs` test.
- **postcss**: bump the `fixtures/pnpm` devDep and regenerate the root lockfile; surgically bump postcss (+ its nanoid/picocolors/source-map-js) in the stale standalone `fixtures/pnpm/pnpm-lock.yaml` that Dependabot scans but CI never installs. postcss's `browser` field is unchanged in 8.5.10, so no test changes.