### PR TITLE
ci: restore CodeQL code scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+# Re-enables code scanning after the GitHub-managed default setup was turned off,
+# which left the workflow-permission alerts stranded as "open" with no analysis to
+# close them. A fresh run on main re-evaluates the (now hardened) workflows.
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 0 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
+      security-events: write # upload CodeQL results
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - javascript-typescript
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Why

The 13 open code-scanning alerts (`actions/missing-workflow-permissions`) are **stale**. Their root cause — workflows not declaring least-privilege `GITHUB_TOKEN` permissions — was already fixed in #211; every workflow now sets explicit permissions.

They remain open only because GitHub's **default code-scanning setup was turned off** (`default-setup = not-configured`), so no analysis has run since 2025-12-31 to re-evaluate and close them.

## What

Add an advanced-setup CodeQL workflow scanning `actions` + `javascript-typescript`. Once merged, a run on `main` re-scans the now-hardened workflows, finds 0 `actions` results, and GitHub auto-closes all 13 stale alerts.

- The workflow itself follows least privilege: top-level `permissions: {}` plus narrow per-job grants, so it introduces no new alerts.
- `rust` is intentionally omitted to keep CI light (it needs a full project build); it can be added later if wanted.

| | Code scanning | The 13 alerts |
| --- | --- | --- |
| Before | disabled | stuck open (already fixed in code) |
| After | restored (push / PR / weekly) | auto-closed on the next `main` scan |

> Opened as a draft: the alternative is simply re-enabling GitHub's **default setup** (no workflow file). Happy to close this in favor of that if preferred.
