### PR TITLE
ci(codeql): add rust to code scanning languages

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,7 @@ jobs:
         language:
           - actions
           - javascript-typescript
+          - rust
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
@@ -39,6 +40,7 @@ jobs:
         uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
         with:
           languages: ${{ matrix.language }}
+          build-mode: none
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3


### PR DESCRIPTION
## Why

`rspack-resolver` is a Rust project, but the CodeQL workflow added in #265 only scans `actions` and `javascript-typescript`. The Rust source — the bulk of the codebase — was left uncovered.

## What

Add `rust` to the CodeQL language matrix.

- Uses `build-mode: none` so CodeQL analyzes from source instead of running a full `cargo build`, keeping the job light. (`none` is also the correct mode for the existing no-build languages.)

| | CodeQL coverage |
| --- | --- |
| Before (#265) | actions, javascript-typescript |
| After | actions, javascript-typescript, **rust** |
