### PR TITLE
fix(package_json): stop stripping raw_json fields (keep all)

### DIFF
--- a/src/package_json/simd.rs
+++ b/src/package_json/simd.rs
@@ -33,20 +33,7 @@ impl JSONCell {
   pub fn try_new(mut buf: Vec<u8>) -> Result<Self, SimdParseError> {
     let value = to_borrowed_value(&mut buf)?;
     // SAFETY: This is safe because `buf` is owned by the `JSONCell` struct,
-    #[allow(unused_mut)]
-    let mut value =
-      unsafe { std::mem::transmute::<BorrowedValue<'_>, BorrowedValue<'static>>(value) };
-
-    #[cfg(feature = "package_json_raw_json_api")]
-    if let Some(json_object) = value.as_object_mut() {
-      json_object.remove("description");
-      json_object.remove("keywords");
-      json_object.remove("scripts");
-      json_object.remove("dependencies");
-      json_object.remove("devDependencies");
-      json_object.remove("peerDependencies");
-      json_object.remove("optionalDependencies");
-    }
+    let value = unsafe { std::mem::transmute::<BorrowedValue<'_>, BorrowedValue<'static>>(value) };
 
     Ok(Self {
       value,
@@ -209,9 +196,7 @@ impl PackageJson {
   /// * getting the `sideEffects` field
   /// * query in <https://www.rspack.dev/config/module.html#ruledescriptiondata> - search on GitHub indicates query on the `type` field.
   ///
-  /// To reduce overall memory consumption, large fields that useless for pragmatic use are removed.
-  /// They are: `description`, `keywords`, `scripts`,
-  /// `dependencies` and `devDependencies`, `peerDependencies`, `optionalDependencies`.
+  /// The full `package.json` is retained; no fields are stripped.
   #[cfg(feature = "package_json_raw_json_api")]
   pub fn raw_json(&self) -> &std::sync::Arc<serde_json::Value> {
     &self.serde_json


### PR DESCRIPTION
## Why

`PackageJson::raw_json()` exposes the parsed `package.json` to consumers, but `JSONCell::try_new` stripped `description`/`keywords`/`scripts`/`dependencies`/`devDependencies`/`peerDependencies`/`optionalDependencies` before storing it — so the "raw" API was not actually raw. This PR stops stripping; the full document is retained.

## What

This PR is **stacked on #269** (the feature-on baseline that keeps stripping). The only diff against #269 is removing the `json_object.remove(...)` calls, so the CodSpeed report on this PR compares **keep vs strip directly** — one table, same lineage, same runner (no environment warning).

## Strip vs keep (feature on, same environment)

Both built with `package_json_raw_json_api`; the only difference is whether fields are stripped:

| Mode | Benchmark | strip (#269) | keep (this PR) | Δ |
| --- | --- | --- | --- | --- |
| Memory | `single-thread` | 12.8 MB | 19.4 MB | **+6.6 MB (+52%)** |
| Memory | `resolve with many extensions` | 17.9 MB | 24.4 MB | **+6.5 MB (+36%)** |
| CPU | `single-thread` | 62.0 ms | 72.1 ms | +16% |
| CPU | `multi-threaded resolve` | 71.3 ms | 82.9 ms | +16% |
| CPU | `resolve with many extensions` | 137.6 ms | 148.8 ms | +8% |

7 of 12 benchmarks unchanged (`tsconfig`, `pnp`, …). Memory is deterministic heap bytes and reproduced byte-for-byte across runs. Keeping the fields costs ~6.6 MB / ~16% on parse-heavy paths — the price of materializing `dependencies`/`scripts`/… into `serde_json::Value` for every `package.json`.

> Measurement/review pair with #269 — not intended to merge as-is.
