### PR TITLE
bench: feature-on baseline for raw_json (keeps field stripping)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Build Benchmark
         env:
           RUSTFLAGS: "-C debuginfo=1 -C strip=none -g"
-        run: cargo codspeed build
+        run: cargo codspeed build --features package_json_raw_json_api
 
       - name: Prepare Valgrind temporary directory
         run: mkdir -p "${RUNNER_TEMP}/codspeed-valgrind-tmp"


### PR DESCRIPTION
## Why

Baseline for measuring the cost of `PackageJson::raw_json()`. The benchmark previously built **without** `package_json_raw_json_api`, so the `init_serde_json` materialization path was never compiled and CodSpeed could not see it.

This PR only enables the feature in the benchmark build. **Source behavior is unchanged** — `JSONCell::try_new` still strips `description`/`keywords`/`scripts`/`dependencies`/… (current `main` behavior).

So this PR's CodSpeed numbers are the **feature-on + strip** baseline.

## What

- `benchmark.yml`: `cargo codspeed build` → `cargo codspeed build --features package_json_raw_json_api`
- No source change.

## Companion PR

The change PR #268 is stacked on this branch and **removes** the stripping. Its CodSpeed report compares directly against this baseline, so reviewers see the keep-vs-strip delta in one table.

This pair is for measurement/review only — not intended to merge as-is.
