### PR TITLE
chore(bench): disable mimalloc purge delay for codspeed cpu simulation

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -66,6 +66,7 @@ jobs:
         env:
           TMPDIR: ${{ runner.temp }}/codspeed-valgrind-tmp
           CODSPEED_EXPERIMENTAL_FAIR_SCHED: true
+          MIMALLOC_PURGE_DELAY: "-1"
         with:
           mode: simulation
           run: cargo codspeed run


### PR DESCRIPTION
## Why

Mimalloc delayed purging can call `clock_gettime` during CPU simulation measurements, leaking allocator timing noise into CodSpeed stage benchmarks. Setting `MIMALLOC_PURGE_DELAY=-1` on the simulation run keeps that noise out while leaving the memory run unchanged.

Ports [web-infra-dev/rspack#14321](https://github.com/web-infra-dev/rspack/pull/14321) to this repo. Only the CI workflow change applies here — there is no `bench:rust:local` script or `xtask/benchmark/README.md` to mirror.

This repo uses mimalloc as the global allocator in `benches/resolver.rs`, so the same purge-noise concern applies.