### PR TITLE
chore(perf): FileSystemOs uses std::fs instead of tokio::fs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ document-features = { version = "0.2.12", optional = true }
 futures           = "0.3.32"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.52.3", default-features = false, features = ["sync", "rt-multi-thread", "macros", "fs"] }
+tokio = { version = "1.52.3", default-features = false, features = ["sync", "rt-multi-thread", "macros"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1.52.3", default-features = false, features = ["sync", "rt", "macros"] }
 

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -153,13 +153,13 @@ impl FileSystem for FileSystemOs {
         if self.options.enable_pnp {
             return match VPath::from(path)? {
                 VPath::Zip(info) => self.pnp_lru.read(info.physical_base_path(), info.zip_path),
-                VPath::Virtual(info) => tokio::fs::read(info.physical_base_path()).await,
-                VPath::Native(path) => tokio::fs::read(&path).await,
+                VPath::Virtual(info) => fs::read(info.physical_base_path()),
+                VPath::Native(path) => fs::read(&path),
             }
         }
     }}
 
-    tokio::fs::read(path).await
+    fs::read(path)
   }
 
   async fn read_to_string(&self, path: &Path) -> io::Result<String> {
@@ -168,13 +168,13 @@ impl FileSystem for FileSystemOs {
         if self.options.enable_pnp {
             return match VPath::from(path)? {
                 VPath::Zip(info) => self.pnp_lru.read_to_string(info.physical_base_path(), info.zip_path),
-                VPath::Virtual(info) => tokio::fs::read_to_string(info.physical_base_path()).await,
-                VPath::Native(path) => tokio::fs::read_to_string(&path).await,
+                VPath::Virtual(info) => fs::read_to_string(info.physical_base_path()),
+                VPath::Native(path) => fs::read_to_string(&path),
                 }
             }
         }
     }
-    tokio::fs::read_to_string(path).await
+    fs::read_to_string(path)
   }
 
   async fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
@@ -187,23 +187,19 @@ impl FileSystem for FileSystemOs {
                         .file_type(info.physical_base_path(), info.zip_path)
                         .map(FileMetadata::from),
                     VPath::Virtual(info) => {
-                        tokio::fs::metadata(info.physical_base_path())
-                            .await
-                            .map(FileMetadata::from)
+                        fs::metadata(info.physical_base_path()).map(FileMetadata::from)
                     }
-                    VPath::Native(path) => tokio::fs::metadata(path).await.map(FileMetadata::from),
+                    VPath::Native(path) => fs::metadata(path).map(FileMetadata::from),
                 }
             }
         }
     }
 
-    tokio::fs::metadata(path).await.map(FileMetadata::from)
+    fs::metadata(path).map(FileMetadata::from)
   }
 
   async fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
-    tokio::fs::symlink_metadata(path)
-      .await
-      .map(FileMetadata::from)
+    fs::symlink_metadata(path).map(FileMetadata::from)
   }
 
   async fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {


### PR DESCRIPTION
## What

`FileSystemOs` — the default `FileSystem` behind `Resolver`
(`pub type Resolver = ResolverGeneric<FileSystemOs>`) — now calls `std::fs`
directly instead of `tokio::fs`. The async `FileSystem` trait is unchanged.

## Who it affects

- **rspack core: not affected.** rspack injects its own async `BoxFS` (over
  `rspack_fs::ReadableFileSystem`) via `new_with_file_system`, so it never uses
  `FileSystemOs`. The `resolver` bench is built on `FileSystemOs`, so for rspack
  this is only a change of benchmark scale, not a runtime change.
- **`@rspack/resolver` (NAPI) npm users: the real beneficiaries.** The npm
  package builds the default `Resolver` (= `FileSystemOs`); both `.sync()` and
  `.async()` go through it.

## Why

Resolution issues many tiny `stat`/`read` syscalls. `tokio::fs` offloads each to
the blocking threadpool (semaphore + task harness + park/unpark), and for
microsecond syscalls that scheduling cost dominates. `std::fs` runs them inline,
matching the wasm impl in the same file.

## Tradeoff

`std::fs` blocks the calling thread for the syscall; a single synchronous resolve
has nothing to overlap, so it is strictly cheaper. A consumer wanting resolution
off an async reactor should inject its own async fs — which rspack already does
via `BoxFS`.

Perf numbers: see the CodSpeed report on this PR.
