### PR TITLE
chore(bench): clear cache in multi threaded resolve from symlinks benchmark

### DIFF
--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -375,18 +375,23 @@ fn bench_resolver(c: &mut Criterion) {
 
         let symlink_test_dir = symlink_test_dir.clone();
 
-        b.to_async(runner).iter(|| async {
-          let mut join_set = JoinSet::new();
+        b.to_async(runner).iter_with_setup(
+          || {
+            rspack_resolver.clear_cache();
+          },
+          |_| async {
+            let mut join_set = JoinSet::new();
 
-          data.clone().for_each(|i| {
-            join_set.spawn(create_async_resolve_task(
-              rspack_resolver.clone(),
-              symlink_test_dir.clone(),
-              format!("./file{i}").to_string(),
-            ));
-          });
-          join_set.join_all().await;
-        });
+            data.clone().for_each(|i| {
+              join_set.spawn(create_async_resolve_task(
+                rspack_resolver.clone(),
+                symlink_test_dir.clone(),
+                format!("./file{i}").to_string(),
+              ));
+            });
+            join_set.join_all().await;
+          },
+        );
       },
     );
   }


### PR DESCRIPTION
## Why

`[multi-threaded]resolve from symlinks` was the only bench using plain
`.iter()` without `clear_cache()`. Every other scenario (including its
single-threaded twin `resolve from symlinks`) clears the cache each iteration.

Because it never cleared, after the first iteration every resolve hit a warm
cache and exercised almost no filesystem work, so its result was dominated by
multi-threaded scheduling noise rather than real resolution — which is why it
was the only scenario showing a ~0.4% wobble while the others moved
consistently.

## What

Clear the cache each iteration (via `iter_with_setup`), matching the other six
scenarios, so it measures cold concurrent resolution like `[mt]resolve` does.

## Expected CodSpeed "regression" — please acknowledge

CodSpeed will flag `[multi-threaded]resolve from symlinks` as ~+254 ms / "‑70%"
(74.9 ms → 254.2 ms). This is **not** a code regression — it is the whole point
of this PR: the scenario now clears the cache each iteration, so it does real
cold resolution (~3.4× the work) instead of warm cache hits. The other 11
benchmarks are untouched. Please acknowledge the new baseline on CodSpeed.
