### PR TITLE
perf: reuse owned parent realpath buffer in realpath_uncached

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -9,7 +9,7 @@ use std::{
   sync::Arc,
 };
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
 use dashmap::{DashMap, DashSet};
 use futures::future::BoxFuture;
 use rustc_hash::FxHasher;
@@ -272,12 +272,15 @@ impl CachedPathImpl {
           }
           if let Some(parent) = self.parent() {
             let mut real_path = parent.realpath(fs).await?;
-            // The cache parent is `self.path`'s lexical parent, so its realpath is
-            // just the parent's realpath with `self.path`'s final segment appended.
-            // Reusing the owned `real_path` avoids re-copying the parent buffer and
-            // re-walking components that `strip_prefix` + `normalize_with` would do.
-            if let Some(segment) = self.path.file_name() {
-              real_path.push(segment);
+            // Unnormalized paths (e.g. from alias values or absolute specifiers) can
+            // end in `..`, where `file_name()` returns `None` and would silently drop
+            // the component; POSIX semantics pop it after the parent is resolved.
+            match self.path.components().next_back() {
+              Some(Utf8Component::Normal(segment)) => real_path.push(segment),
+              Some(Utf8Component::ParentDir) => {
+                real_path.pop();
+              }
+              _ => {}
             }
             return Ok(Some(real_path));
           }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -18,7 +18,6 @@ use tokio::sync::OnceCell as OnceLock;
 use crate::{
   context::ResolveContext as Ctx,
   package_json::{off_to_location, PackageJson},
-  path::PathUtil,
   resolver_path::{hash_path, ResolverPath},
   FileMetadata, FileSystem, JSONError, ResolveError, ResolveOptions, TsConfig,
 };
@@ -272,10 +271,15 @@ impl CachedPathImpl {
               .map(|path| Some(Utf8PathBuf::from_path_buf(path).expect("path should be UTF-8")));
           }
           if let Some(parent) = self.parent() {
-            let parent_path = parent.realpath(fs).await?;
-            return Ok(Some(
-              parent_path.normalize_with(self.path.strip_prefix(parent.path()).unwrap()),
-            ));
+            let mut real_path = parent.realpath(fs).await?;
+            // The cache parent is `self.path`'s lexical parent, so its realpath is
+            // just the parent's realpath with `self.path`'s final segment appended.
+            // Reusing the owned `real_path` avoids re-copying the parent buffer and
+            // re-walking components that `strip_prefix` + `normalize_with` would do.
+            if let Some(segment) = self.path.file_name() {
+              real_path.push(segment);
+            }
+            return Ok(Some(real_path));
           }
           Ok(None)
         })

--- a/src/tests/symlink.rs
+++ b/src/tests/symlink.rs
@@ -157,3 +157,27 @@ async fn test() -> io::Result<()> {
 
   Ok(())
 }
+
+// With `symlinks` enabled, realpath must apply `..` components after resolving
+// the parent, not drop them. Unnormalized paths reach the resolver from user
+// input: absolute specifiers (kept verbatim on non-Windows), exact-match alias
+// values, and the `directory` argument of `resolve`.
+#[tokio::test]
+async fn dotdot_in_unnormalized_input() {
+  let root = super::fixture_root().join("enhanced_resolve");
+  let expected = Ok(root.join("lib/index.js"));
+  let resolver = Resolver::default();
+
+  let specifier = root.join("test/../lib/index.js");
+  let resolution = resolver
+    .resolve(root.join("test"), specifier.to_str().unwrap())
+    .await
+    .map(|r| r.full_path());
+  assert_eq!(resolution, expected, "absolute specifier containing `..`");
+
+  let resolution = resolver
+    .resolve(root.join("test/.."), "./lib/index.js")
+    .await
+    .map(|r| r.full_path());
+  assert_eq!(resolution, expected, "directory ending in `..`");
+}


### PR DESCRIPTION
## Why

`CachedPathImpl::realpath_uncached`'s non-symlink branch rebuilt the canonical
path with:

```rust
let parent_path = parent.realpath(fs).await?;
parent_path.normalize_with(self.path.strip_prefix(parent.path()).unwrap())
```

The cache parent is always `self.path`'s **lexical** parent (`Cache::value` sets
`parent = path.parent().map(value)`), so `strip_prefix(parent.path())` is always
exactly `self.path.file_name()` — a single component. The old form therefore paid
for `strip_prefix` (component iteration) plus `normalize_with`, whose first step
(`self.to_path_buf()`) copies the parent buffer we already own.

This is hot: with `symlinks` enabled (the default), `realpath` is computed for
every `package.json` found and recurses up the parent chain, so node_modules
resolution walks it repeatedly.

## What

Reuse the owned `parent.realpath()` buffer and `push` the final segment instead
of allocating a fresh one via `strip_prefix` + `normalize_with`. Net `+9 / -5`,
and the now-unused `PathUtil` import is dropped.

Before/after direction (devbox callgrind, cycles): `single-thread` and
`[multi-threaded]resolve` each drop several percent; symlink scenarios are
unchanged because their leaves are themselves symlinks and take the libc
`canonicalize` branch. See the CodSpeed report on this PR for the measured
per-scenario deltas.
