### PR TITLE
chore: release 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_resolver"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name         = "rspack_resolver"
 readme       = "README.md"
 repository   = "https://github.com/rstackjs/rspack-resolver"
 rust-version = "1.70"
-version      = "0.9.2"
+version      = "0.9.3"
 
 [lib]
 doctest = false

--- a/napi/index.js
+++ b/napi/index.js
@@ -81,12 +81,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-android-arm64/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.2" &&
+          bindingPackageVersion !== "0.5.3" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -104,12 +104,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-android-arm-eabi/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.2" &&
+          bindingPackageVersion !== "0.5.3" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -137,12 +137,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-win32-x64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.2" &&
+            bindingPackageVersion !== "0.5.3" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -160,12 +160,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-win32-x64-msvc/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.2" &&
+            bindingPackageVersion !== "0.5.3" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -184,12 +184,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-win32-ia32-msvc/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.2" &&
+          bindingPackageVersion !== "0.5.3" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -207,12 +207,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-win32-arm64-msvc/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.2" &&
+          bindingPackageVersion !== "0.5.3" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -235,12 +235,12 @@ function requireNative() {
       const bindingPackageVersion =
         require("@rspack/resolver-binding-darwin-universal/package.json").version;
       if (
-        bindingPackageVersion !== "0.5.2" &&
+        bindingPackageVersion !== "0.5.3" &&
         process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
         process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
       ) {
         throw new Error(
-          `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+          `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
         );
       }
       return binding;
@@ -258,12 +258,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-darwin-x64/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.2" &&
+          bindingPackageVersion !== "0.5.3" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -281,12 +281,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-darwin-arm64/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.2" &&
+          bindingPackageVersion !== "0.5.3" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -310,12 +310,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-freebsd-x64/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.2" &&
+          bindingPackageVersion !== "0.5.3" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -333,12 +333,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-freebsd-arm64/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.2" &&
+          bindingPackageVersion !== "0.5.3" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -363,12 +363,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-x64-musl/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.2" &&
+            bindingPackageVersion !== "0.5.3" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -386,12 +386,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-x64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.2" &&
+            bindingPackageVersion !== "0.5.3" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -411,12 +411,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-arm64-musl/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.2" &&
+            bindingPackageVersion !== "0.5.3" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -434,12 +434,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-arm64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.2" &&
+            bindingPackageVersion !== "0.5.3" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -459,12 +459,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-arm-musleabihf/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.2" &&
+            bindingPackageVersion !== "0.5.3" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -482,12 +482,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-arm-gnueabihf/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.2" &&
+            bindingPackageVersion !== "0.5.3" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -507,12 +507,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-loong64-musl/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.2" &&
+            bindingPackageVersion !== "0.5.3" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -530,12 +530,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-loong64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.2" &&
+            bindingPackageVersion !== "0.5.3" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -555,12 +555,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-riscv64-musl/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.2" &&
+            bindingPackageVersion !== "0.5.3" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -578,12 +578,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@rspack/resolver-binding-linux-riscv64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "0.5.2" &&
+            bindingPackageVersion !== "0.5.3" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+              `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
             );
           }
           return binding;
@@ -602,12 +602,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-linux-ppc64-gnu/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.2" &&
+          bindingPackageVersion !== "0.5.3" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -625,12 +625,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-linux-s390x-gnu/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.2" &&
+          bindingPackageVersion !== "0.5.3" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -654,12 +654,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-openharmony-arm64/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.2" &&
+          bindingPackageVersion !== "0.5.3" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -677,12 +677,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-openharmony-x64/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.2" &&
+          bindingPackageVersion !== "0.5.3" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;
@@ -700,12 +700,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@rspack/resolver-binding-openharmony-arm/package.json").version;
         if (
-          bindingPackageVersion !== "0.5.2" &&
+          bindingPackageVersion !== "0.5.3" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.5.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
+            `Native binding package version mismatch, expected 0.5.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`
           );
         }
         return binding;

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/resolver",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Rspack Resolver Node API",
   "main": "index.js",
   "browser": "browser.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,36 @@ importers:
         specifier: ^8.8.5
         version: 8.8.5
 
+  bindings/darwin-arm64: {}
+
+  bindings/darwin-x64: {}
+
+  bindings/linux-arm64-gnu: {}
+
+  bindings/linux-arm64-musl: {}
+
+  bindings/linux-x64-gnu: {}
+
+  bindings/linux-x64-musl: {}
+
+  bindings/wasm32-wasi:
+    dependencies:
+      '@emnapi/core':
+        specifier: 1.10.0
+        version: 1.10.0
+      '@emnapi/runtime':
+        specifier: 1.10.0
+        version: 1.10.0
+      '@napi-rs/wasm-runtime':
+        specifier: ^1.1.4
+        version: 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+
+  bindings/win32-arm64-msvc: {}
+
+  bindings/win32-ia32-msvc: {}
+
+  bindings/win32-x64-msvc: {}
+
   fixtures/pnpm:
     devDependencies:
       axios:
@@ -1483,7 +1513,7 @@ snapshots:
 
   '@napi-rs/lzma-wasm32-wasi@1.4.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -1559,7 +1589,7 @@ snapshots:
 
   '@napi-rs/tar-wasm32-wasi@1.1.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -1638,7 +1668,7 @@ snapshots:
 
   '@napi-rs/wasm-tools-wasm32-wasi@1.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'


### PR DESCRIPTION
Release 0.9.3.

- Crate `rspack_resolver`: 0.9.2 → 0.9.3
- npm `@rspack/resolver`: 0.5.2 → 0.5.3

## What's included since 0.9.2

### Performance
- refactor: use camino Utf8Path for internal path representation (#253)
- perf(cache): key tsconfig map by std PathBuf (#258)
- perf: reuse owned parent realpath buffer in realpath_uncached (#278)
- perf(package_json): skip building unused heavy fields during parse (#279)

### Dependencies & security
- chore(deps): update dependency enhanced-resolve to ^5.23.0 (#273)
- chore(deps): update dependency typescript to ^6.0.3 (#254)
- chore(deps): update dependency @rstest/core to ^0.10.3 (#271)
- chore(deps): update dependency @types/node to ^24.13.1 (#272)
- chore(deps): update patch crates (#255, #270)
- chore(deps): update patch npm dependencies (#256)
- chore(sec): remediate form-data/axios advisories in dev & fixture deps (#260)
- chore(deps): bump js-yaml, mathjs & postcss to clear GHSA advisories (#264)

### CI & benches
- chore(fuzz): revive the fuzz target and run it nightly in CI (#281)
- chore(bench): FileSystemOs uses std::fs instead of tokio::fs (#275)
- chore(bench): clear cache in multi threaded resolve from symlinks benchmark (#277)
- chore(bench): add tsconfig resolve scenario (#259)
- ci: disable mimalloc purge delay for codspeed cpu simulation (#274)
- ci(codeql): add rust to code scanning languages (#266)
- ci: restore CodeQL code scanning workflow (#265)
