### PR TITLE
chore(release): npm 0.5.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ target/
 node_modules
 fuzz/Cargo.lock
 artifacts
-bindings

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ fixtures/enhanced_resolve/test/fixtures/tsconfig-paths/malformed-json/tsconfig.j
 pnpm-lock.yaml
 **/.pnp.cjs
 .claude/worktrees
+bindings

--- a/bindings/.gitignore
+++ b/bindings/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!*/
+!*/package.json

--- a/bindings/darwin-arm64/package.json
+++ b/bindings/darwin-arm64/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@rspack/resolver-binding-darwin-arm64",
+  "version": "0.5.3",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "resolver.darwin-arm64.node",
+  "files": [
+    "resolver.darwin-arm64.node"
+  ],
+  "description": "Rspack Resolver Node API",
+  "homepage": "https://github.com/rstackjs/rspack-resolver",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rstackjs/rspack-resolver.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "darwin"
+  ]
+}

--- a/bindings/darwin-x64/package.json
+++ b/bindings/darwin-x64/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@rspack/resolver-binding-darwin-x64",
+  "version": "0.5.3",
+  "cpu": [
+    "x64"
+  ],
+  "main": "resolver.darwin-x64.node",
+  "files": [
+    "resolver.darwin-x64.node"
+  ],
+  "description": "Rspack Resolver Node API",
+  "homepage": "https://github.com/rstackjs/rspack-resolver",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rstackjs/rspack-resolver.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "darwin"
+  ]
+}

--- a/bindings/linux-arm64-gnu/package.json
+++ b/bindings/linux-arm64-gnu/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@rspack/resolver-binding-linux-arm64-gnu",
+  "version": "0.5.3",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "resolver.linux-arm64-gnu.node",
+  "files": [
+    "resolver.linux-arm64-gnu.node"
+  ],
+  "description": "Rspack Resolver Node API",
+  "homepage": "https://github.com/rstackjs/rspack-resolver",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rstackjs/rspack-resolver.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "glibc"
+  ]
+}

--- a/bindings/linux-arm64-musl/package.json
+++ b/bindings/linux-arm64-musl/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@rspack/resolver-binding-linux-arm64-musl",
+  "version": "0.5.3",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "resolver.linux-arm64-musl.node",
+  "files": [
+    "resolver.linux-arm64-musl.node"
+  ],
+  "description": "Rspack Resolver Node API",
+  "homepage": "https://github.com/rstackjs/rspack-resolver",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rstackjs/rspack-resolver.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "musl"
+  ]
+}

--- a/bindings/linux-x64-gnu/package.json
+++ b/bindings/linux-x64-gnu/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@rspack/resolver-binding-linux-x64-gnu",
+  "version": "0.5.3",
+  "cpu": [
+    "x64"
+  ],
+  "main": "resolver.linux-x64-gnu.node",
+  "files": [
+    "resolver.linux-x64-gnu.node"
+  ],
+  "description": "Rspack Resolver Node API",
+  "homepage": "https://github.com/rstackjs/rspack-resolver",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rstackjs/rspack-resolver.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "glibc"
+  ]
+}

--- a/bindings/linux-x64-musl/package.json
+++ b/bindings/linux-x64-musl/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@rspack/resolver-binding-linux-x64-musl",
+  "version": "0.5.3",
+  "cpu": [
+    "x64"
+  ],
+  "main": "resolver.linux-x64-musl.node",
+  "files": [
+    "resolver.linux-x64-musl.node"
+  ],
+  "description": "Rspack Resolver Node API",
+  "homepage": "https://github.com/rstackjs/rspack-resolver",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rstackjs/rspack-resolver.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "musl"
+  ]
+}

--- a/bindings/wasm32-wasi/package.json
+++ b/bindings/wasm32-wasi/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@rspack/resolver-binding-wasm32-wasi",
+  "version": "0.5.3",
+  "cpu": [
+    "wasm32"
+  ],
+  "main": "resolver.wasi.cjs",
+  "files": [
+    "resolver.wasm32-wasi.wasm",
+    "resolver.wasi.cjs",
+    "resolver.wasi-browser.js",
+    "wasi-worker.mjs",
+    "wasi-worker-browser.mjs"
+  ],
+  "description": "Rspack Resolver Node API",
+  "homepage": "https://github.com/rstackjs/rspack-resolver",
+  "license": "MIT",
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rstackjs/rspack-resolver.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "browser": "resolver.wasi-browser.js",
+  "dependencies": {
+    "@napi-rs/wasm-runtime": "^1.1.5",
+    "@emnapi/core": "1.10.0",
+    "@emnapi/runtime": "1.10.0"
+  }
+}

--- a/bindings/win32-arm64-msvc/package.json
+++ b/bindings/win32-arm64-msvc/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@rspack/resolver-binding-win32-arm64-msvc",
+  "version": "0.5.3",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "resolver.win32-arm64-msvc.node",
+  "files": [
+    "resolver.win32-arm64-msvc.node"
+  ],
+  "description": "Rspack Resolver Node API",
+  "homepage": "https://github.com/rstackjs/rspack-resolver",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rstackjs/rspack-resolver.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "win32"
+  ]
+}

--- a/bindings/win32-ia32-msvc/package.json
+++ b/bindings/win32-ia32-msvc/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@rspack/resolver-binding-win32-ia32-msvc",
+  "version": "0.5.3",
+  "cpu": [
+    "ia32"
+  ],
+  "main": "resolver.win32-ia32-msvc.node",
+  "files": [
+    "resolver.win32-ia32-msvc.node"
+  ],
+  "description": "Rspack Resolver Node API",
+  "homepage": "https://github.com/rstackjs/rspack-resolver",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rstackjs/rspack-resolver.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "win32"
+  ]
+}

--- a/bindings/win32-x64-msvc/package.json
+++ b/bindings/win32-x64-msvc/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@rspack/resolver-binding-win32-x64-msvc",
+  "version": "0.5.3",
+  "cpu": [
+    "x64"
+  ],
+  "main": "resolver.win32-x64-msvc.node",
+  "files": [
+    "resolver.win32-x64-msvc.node"
+  ],
+  "description": "Rspack Resolver Node API",
+  "homepage": "https://github.com/rstackjs/rspack-resolver",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rstackjs/rspack-resolver.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "win32"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
         specifier: 1.10.0
         version: 1.10.0
       '@napi-rs/wasm-runtime':
-        specifier: ^1.1.4
+        specifier: ^1.1.5
         version: 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
 
   bindings/win32-arm64-msvc: {}


### PR DESCRIPTION
## Why

The npm 0.5.3 release (`release-npm.yml`) fails at the `napi artifacts` step with:

```
[ERR_PNPM_OUTDATED_LOCKFILE] ... bindings/wasm32-wasi/package.json
```

`napi create-npm-dirs` generates the per-platform binding workspace packages at release time, but `bindings/` is gitignored, so the lockfile's `bindings/*` importers are not anchored to any committed file. A renovate lockfile regeneration on a clean checkout (where `bindings/` does not exist) silently drops those importers — and even after they were re-added by hand, the `bindings/wasm32-wasi` importer kept a stale `@napi-rs/wasm-runtime` `^1.1.4` specifier that no longer matches the `^1.1.5` that `create-npm-dirs` now generates (root devDep was bumped in #256). Either way `pnpm install --frozen-lockfile` fails during release.

Only `bindings/wasm32-wasi` triggers this — it is the one platform package with real dependencies (`@napi-rs/wasm-runtime`, `@emnapi/*`); the others are dependency-free.

## What

Track the binding `package.json` files in git (the same approach rspack uses for `npm/*`), so a clean checkout always carries the importers and renovate can no longer drop them:

- remove the blanket `bindings` ignore from `.gitignore`
- add `bindings/.gitignore` that tracks only `package.json` (all `.wasm` / `.cjs` / glue / `.node` artifacts stay ignored)
- add `bindings` to `.prettierignore` (the generated files are not prettier-formatted and must not be style-enforced)
- correct the `bindings/wasm32-wasi` lockfile importer to `^1.1.5`

`release-npm.yml` needs no change: `create-npm-dirs` rewrites the version at release time (working-tree only) and version is not a dependency specifier, so `--frozen-lockfile` stays green.

## Verification (local, on a clean checkout)

- `pnpm install --frozen-lockfile` → `Lockfile is up to date`
- renovate-style `pnpm install --lockfile-only` → lockfile byte-identical, importers retained
- full release order `create-npm-dirs` → `artifacts` → `prepublish` → no `ERR_PNPM_OUTDATED_LOCKFILE`
- `prettier --check .` → clean
