### PR TITLE
fix(tsconfig): dedupe project reference dependencies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1618,9 +1618,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
             },
           )
           .await?;
-        tsconfig
-          .file_dependencies
-          .extend(reference_tsconfig.file_dependencies.iter().cloned());
+        TsConfig::extend_file_dependencies(
+          &mut tsconfig.file_dependencies,
+          &reference_tsconfig.file_dependencies,
+        );
         reference.tsconfig.replace(reference_tsconfig);
       }
       Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1270,8 +1270,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       // Complete when resolving to self `{"./a.js": "./a.js"}`
       if new_specifier
         .strip_prefix("./")
-        .filter(|s| path.ends_with(s))
-        .is_some()
+        .is_some_and(|s| path.ends_with(s))
       {
         return if cached_path.is_file(&self.cache.fs, ctx).await {
           if self.check_restrictions(cached_path.path()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1578,6 +1578,7 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       }
       let directory = tsconfig.directory().to_path_buf();
       let current_path = tsconfig.path.clone();
+      let mut flattened_reference_paths = FxHashSet::default();
       visited.insert(current_path.clone());
       for reference in &mut tsconfig.references {
         let reference_tsconfig_path = directory.normalize_with(&reference.path);
@@ -1618,10 +1619,19 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
             },
           )
           .await?;
-        TsConfig::extend_file_dependencies(
-          &mut tsconfig.file_dependencies,
-          &reference_tsconfig.file_dependencies,
-        );
+        tsconfig
+          .file_dependencies
+          .extend(reference_tsconfig.file_dependencies.iter().cloned());
+        for nested in &reference_tsconfig.flattened_references {
+          if flattened_reference_paths.insert(nested.path.clone()) {
+            tsconfig.flattened_references.push(Arc::clone(nested));
+          }
+        }
+        if flattened_reference_paths.insert(reference_tsconfig.path.clone()) {
+          tsconfig
+            .flattened_references
+            .push(Arc::clone(&reference_tsconfig));
+        }
         reference.tsconfig.replace(reference_tsconfig);
       }
       Ok(())

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -2,7 +2,7 @@
 
 use crate::{
   tsconfig::FileDependencies, ResolveContext, ResolveError, ResolveOptions, Resolver, ResolverPath,
-  TsConfig, TsconfigOptions, TsconfigReferences,
+  TsconfigOptions, TsconfigReferences,
 };
 
 #[test]
@@ -11,7 +11,7 @@ fn file_dependencies_are_deduplicated() {
   file_dependencies.insert("/repo/app/tsconfig.json".into());
   file_dependencies.insert("/repo/base.json".into());
 
-  let dependencies = [
+  let dependencies: FileDependencies = [
     "/repo/base.json".into(),
     "/repo/shared/tsconfig.json".into(),
     "/repo/shared/tsconfig.json".into(),
@@ -19,7 +19,7 @@ fn file_dependencies_are_deduplicated() {
   .into_iter()
   .collect();
 
-  TsConfig::extend_file_dependencies(&mut file_dependencies, &dependencies);
+  file_dependencies.extend(dependencies.iter().cloned());
 
   assert_eq!(
     file_dependencies

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -1,9 +1,38 @@
 //! Tests for tsconfig project references
 
 use crate::{
-  ResolveContext, ResolveError, ResolveOptions, Resolver, ResolverPath, TsconfigOptions,
-  TsconfigReferences,
+  tsconfig::FileDependencies, ResolveContext, ResolveError, ResolveOptions, Resolver, ResolverPath,
+  TsConfig, TsconfigOptions, TsconfigReferences,
 };
+
+#[test]
+fn file_dependencies_are_deduplicated() {
+  let mut file_dependencies = FileDependencies::default();
+  file_dependencies.insert("/repo/app/tsconfig.json".into());
+  file_dependencies.insert("/repo/base.json".into());
+
+  let dependencies = [
+    "/repo/base.json".into(),
+    "/repo/shared/tsconfig.json".into(),
+    "/repo/shared/tsconfig.json".into(),
+  ]
+  .into_iter()
+  .collect();
+
+  TsConfig::extend_file_dependencies(&mut file_dependencies, &dependencies);
+
+  assert_eq!(
+    file_dependencies
+      .iter()
+      .map(|dependency| dependency.as_str())
+      .collect::<Vec<_>>(),
+    [
+      "/repo/app/tsconfig.json",
+      "/repo/base.json",
+      "/repo/shared/tsconfig.json"
+    ]
+  );
+}
 
 #[tokio::test]
 async fn auto() {

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -1,38 +1,9 @@
 //! Tests for tsconfig project references
 
 use crate::{
-  tsconfig::FileDependencies, ResolveContext, ResolveError, ResolveOptions, Resolver, ResolverPath,
-  TsconfigOptions, TsconfigReferences,
+  ResolveContext, ResolveError, ResolveOptions, Resolver, ResolverPath, TsconfigOptions,
+  TsconfigReferences,
 };
-
-#[test]
-fn file_dependencies_are_deduplicated() {
-  let mut file_dependencies = FileDependencies::default();
-  file_dependencies.insert("/repo/app/tsconfig.json".into());
-  file_dependencies.insert("/repo/base.json".into());
-
-  let dependencies: FileDependencies = [
-    "/repo/base.json".into(),
-    "/repo/shared/tsconfig.json".into(),
-    "/repo/shared/tsconfig.json".into(),
-  ]
-  .into_iter()
-  .collect();
-
-  file_dependencies.extend(dependencies.iter().cloned());
-
-  assert_eq!(
-    file_dependencies
-      .iter()
-      .map(|dependency| dependency.as_str())
-      .collect::<Vec<_>>(),
-    [
-      "/repo/app/tsconfig.json",
-      "/repo/base.json",
-      "/repo/shared/tsconfig.json"
-    ]
-  );
-}
 
 #[tokio::test]
 async fn auto() {

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -2,7 +2,7 @@ use std::{hash::BuildHasherDefault, sync::Arc};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use indexmap::{IndexMap, IndexSet};
-use rustc_hash::{FxHashSet, FxHasher};
+use rustc_hash::FxHasher;
 use serde::Deserialize;
 
 use crate::path::PathUtil;
@@ -43,6 +43,10 @@ pub struct TsConfig {
   /// Bubbled up project references with a reference to their tsconfig.
   #[serde(default)]
   pub references: Vec<ProjectReference>,
+
+  /// Flattened transitive project references in resolution order.
+  #[serde(skip)]
+  pub(crate) flattened_references: Vec<Arc<TsConfig>>,
 }
 
 /// Compiler Options
@@ -158,52 +162,18 @@ impl TsConfig {
         .base_url
         .clone_from(&other_config.compiler_options.base_url);
     }
-    Self::extend_file_dependencies(&mut self.file_dependencies, &other_config.file_dependencies);
-  }
-
-  pub(crate) fn extend_file_dependencies(
-    file_dependencies: &mut FileDependencies,
-    dependencies: &FileDependencies,
-  ) {
-    file_dependencies.extend(dependencies.iter().cloned());
+    self
+      .file_dependencies
+      .extend(other_config.file_dependencies.iter().cloned());
   }
 
   pub fn resolve(&self, path: &Utf8Path, specifier: &str) -> Vec<Utf8PathBuf> {
-    let mut visited = FxHashSet::default();
-    if let Some(matched) = self.find_reference_paths(path, specifier, &mut visited) {
-      return matched;
+    for tsconfig in &self.flattened_references {
+      if path.starts_with(tsconfig.base_path()) {
+        return tsconfig.resolve_path_alias(specifier);
+      }
     }
     self.resolve_path_alias(specifier)
-  }
-
-  // Walks `references` recursively, returning the nearest reference whose
-  // `base_path` contains `path`. Used to honor transitive project references
-  // (A → B → C): a file inside C should resolve via C's own `paths` even
-  // when the entry tsconfig is A and only B is listed directly in A's
-  // references. Matches `tsc`'s "nearest tsconfig wins" semantics.
-  fn find_reference_paths<'a>(
-    &'a self,
-    path: &Utf8Path,
-    specifier: &str,
-    visited: &mut FxHashSet<&'a Utf8Path>,
-  ) -> Option<Vec<Utf8PathBuf>> {
-    if !visited.insert(self.path.as_path()) {
-      return None;
-    }
-
-    for tsconfig in self
-      .references
-      .iter()
-      .filter_map(|reference| reference.tsconfig.as_ref())
-    {
-      if let Some(nested) = tsconfig.find_reference_paths(path, specifier, visited) {
-        return Some(nested);
-      }
-      if path.starts_with(tsconfig.base_path()) {
-        return Some(tsconfig.resolve_path_alias(specifier));
-      }
-    }
-    None
   }
 
   // Copied from parcel

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use crate::path::PathUtil;
 
 pub type CompilerOptionsPathsMap = IndexMap<String, Vec<String>, BuildHasherDefault<FxHasher>>;
-pub(crate) type FileDependencies = IndexSet<Utf8PathBuf, BuildHasherDefault<FxHasher>>;
+pub type FileDependencies = IndexSet<Utf8PathBuf, BuildHasherDefault<FxHasher>>;
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
 #[serde(untagged)]
@@ -46,7 +46,7 @@ pub struct TsConfig {
 
   /// Flattened transitive project references in resolution order.
   #[serde(skip)]
-  pub(crate) flattened_references: Vec<Arc<TsConfig>>,
+  pub(crate) flattened_references: Vec<Arc<Self>>,
 }
 
 /// Compiler Options

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -1,13 +1,14 @@
 use std::{hash::BuildHasherDefault, sync::Arc};
 
 use camino::{Utf8Path, Utf8PathBuf};
-use indexmap::IndexMap;
-use rustc_hash::FxHasher;
+use indexmap::{IndexMap, IndexSet};
+use rustc_hash::{FxHashSet, FxHasher};
 use serde::Deserialize;
 
 use crate::path::PathUtil;
 
 pub type CompilerOptionsPathsMap = IndexMap<String, Vec<String>, BuildHasherDefault<FxHasher>>;
+pub(crate) type FileDependencies = IndexSet<Utf8PathBuf, BuildHasherDefault<FxHasher>>;
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
 #[serde(untagged)]
@@ -31,7 +32,7 @@ pub struct TsConfig {
   pub(crate) path: Utf8PathBuf,
 
   #[serde(skip)]
-  pub(crate) file_dependencies: Vec<Utf8PathBuf>,
+  pub(crate) file_dependencies: FileDependencies,
 
   #[serde(default)]
   pub extends: Option<ExtendsField>,
@@ -82,13 +83,13 @@ impl TsConfig {
       let mut tsconfig: Self = serde_json::from_str("{}")?;
       tsconfig.root = root;
       tsconfig.path = path.to_path_buf();
-      tsconfig.file_dependencies.push(path.to_path_buf());
+      tsconfig.file_dependencies.insert(path.to_path_buf());
       return Ok(tsconfig);
     }
     let mut tsconfig: Self = serde_json::from_str(json)?;
     tsconfig.root = root;
     tsconfig.path = path.to_path_buf();
-    tsconfig.file_dependencies.push(path.to_path_buf());
+    tsconfig.file_dependencies.insert(path.to_path_buf());
     let directory = tsconfig.directory().to_path_buf();
     if let Some(base_url) = &tsconfig.compiler_options.base_url {
       // keep the `${configDir}` template variable in the baseUrl
@@ -157,13 +158,19 @@ impl TsConfig {
         .base_url
         .clone_from(&other_config.compiler_options.base_url);
     }
-    self
-      .file_dependencies
-      .extend(other_config.file_dependencies.iter().cloned());
+    Self::extend_file_dependencies(&mut self.file_dependencies, &other_config.file_dependencies);
+  }
+
+  pub(crate) fn extend_file_dependencies(
+    file_dependencies: &mut FileDependencies,
+    dependencies: &FileDependencies,
+  ) {
+    file_dependencies.extend(dependencies.iter().cloned());
   }
 
   pub fn resolve(&self, path: &Utf8Path, specifier: &str) -> Vec<Utf8PathBuf> {
-    if let Some(matched) = self.find_reference_paths(path, specifier) {
+    let mut visited = FxHashSet::default();
+    if let Some(matched) = self.find_reference_paths(path, specifier, &mut visited) {
       return matched;
     }
     self.resolve_path_alias(specifier)
@@ -174,13 +181,22 @@ impl TsConfig {
   // (A → B → C): a file inside C should resolve via C's own `paths` even
   // when the entry tsconfig is A and only B is listed directly in A's
   // references. Matches `tsc`'s "nearest tsconfig wins" semantics.
-  fn find_reference_paths(&self, path: &Utf8Path, specifier: &str) -> Option<Vec<Utf8PathBuf>> {
+  fn find_reference_paths<'a>(
+    &'a self,
+    path: &Utf8Path,
+    specifier: &str,
+    visited: &mut FxHashSet<&'a Utf8Path>,
+  ) -> Option<Vec<Utf8PathBuf>> {
+    if !visited.insert(self.path.as_path()) {
+      return None;
+    }
+
     for tsconfig in self
       .references
       .iter()
       .filter_map(|reference| reference.tsconfig.as_ref())
     {
-      if let Some(nested) = tsconfig.find_reference_paths(path, specifier) {
+      if let Some(nested) = tsconfig.find_reference_paths(path, specifier, visited) {
         return Some(nested);
       }
       if path.starts_with(tsconfig.base_path()) {


### PR DESCRIPTION
## Summary

- Store tsconfig file dependencies in insertion-ordered sets so extended configs and project references are deduplicated without rebuilding a temporary set on each merge.
- Precompute flattened transitive project references while loading tsconfig references, preserving the existing nested-reference-first resolution order.
- Make `TsConfig::resolve` iterate the flattened reference list directly, removing per-resolve recursive traversal and visited-set hashing.

## Verification

- `cargo fmt --check`
- `cargo test tsconfig_project_references --lib`

`cargo test --lib` was also run; non-tsconfig PnP tests fail in this local environment (`src/tests/pnp.rs`), while 143 other tests pass.

## Local downstream validation

Earlier in this investigation, built a local Rspack binding against the resolver fix and verified the ccweb Platform build with:

```bash
NAPI_RS_NATIVE_LIBRARY_PATH=/Users/bytedance/Projects/rspack/crates/node_binding/rspack.darwin-arm64.node DEBUG=1 IS_OVERSEA=true BUILD_TYPE=online emo run build --filter platform --skip-cache
```

Result: exit 0, peak RSS around 12.6 GB. Before the dependency dedupe fix, the same validation still hit `exit 137` / memory pressure after only adding the reference traversal visited set.