### PR TITLE
chore: pin @napi-rs/wasm-runtime through a pnpm catalog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,14 +226,3 @@ jobs:
             git status --short
             exit 1
           fi
-
-  napi-deps-check:
-    name: napi deps check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
-      - uses: ./.github/actions/pnpm
-      - name: Regenerate npm dirs and verify lockfile stays frozen
-        run: |
-          pnpm napi create-npm-dirs --package-json-path npm/package.json --npm-dir bindings
-          pnpm install --frozen-lockfile

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -103,8 +103,8 @@ jobs:
 
       - name: Move artifacts
         run: |
-          pnpm napi create-npm-dirs --package-json-path npm/package.json --npm-dir bindings
-          pnpm napi artifacts       --package-json-path npm/package.json --npm-dir bindings --build-output-dir napi
+          pnpm napi version   --package-json-path npm/package.json --npm-dir bindings
+          pnpm napi artifacts --package-json-path npm/package.json --npm-dir bindings --build-output-dir napi
 
       - name: Show binding packages
         run: ls -R bindings

--- a/bindings/wasm32-wasi/package.json
+++ b/bindings/wasm32-wasi/package.json
@@ -28,7 +28,7 @@
   },
   "browser": "resolver.wasi-browser.js",
   "dependencies": {
-    "@napi-rs/wasm-runtime": "^1.1.6",
+    "@napi-rs/wasm-runtime": "^1.2.0",
     "@emnapi/core": "1.10.0",
     "@emnapi/runtime": "1.10.0"
   }

--- a/bindings/wasm32-wasi/package.json
+++ b/bindings/wasm32-wasi/package.json
@@ -28,7 +28,7 @@
   },
   "browser": "resolver.wasi-browser.js",
   "dependencies": {
-    "@napi-rs/wasm-runtime": "^1.2.0",
+    "@napi-rs/wasm-runtime": "catalog:",
     "@emnapi/core": "1.10.0",
     "@emnapi/runtime": "1.10.0"
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@emnapi/core": "1.10.0",
     "@emnapi/runtime": "1.10.0",
     "@napi-rs/cli": "3.6.2",
-    "@napi-rs/wasm-runtime": "^1.1.5",
+    "@napi-rs/wasm-runtime": "catalog:",
     "@taplo/cli": "^0.7.0",
     "@types/node": "^24.13.1",
     "commander": "^14.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: 1.10.0
         version: 1.10.0
       '@napi-rs/wasm-runtime':
-        specifier: ^1.1.6
-        version: 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: ^1.2.0
+        version: 1.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
 
   bindings/win32-arm64-msvc: {}
 
@@ -580,6 +580,13 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.2.0':
+    resolution: {integrity: sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^2.0.0-alpha.3
+      '@emnapi/runtime': ^2.0.0-alpha.3
 
   '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
     resolution: {integrity: sha512-lr07E/l571Gft5v4aA1dI8koJEmF1F0UigBbsqg9OWNzg80H3lDPO+auv85y3T/NHE3GirDk7x/D3sLO57vayw==}
@@ -1522,7 +1529,7 @@ snapshots:
 
   '@napi-rs/lzma-wasm32-wasi@1.4.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -1598,7 +1605,7 @@ snapshots:
 
   '@napi-rs/tar-wasm32-wasi@1.1.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -1653,6 +1660,13 @@ snapshots:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
 
   '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
     optional: true
@@ -1683,7 +1697,7 @@ snapshots:
 
   '@napi-rs/wasm-tools-wasm32-wasi@1.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@napi-rs/wasm-runtime':
+      specifier: 1.1.6
+      version: 1.1.6
+
 importers:
 
   .:
@@ -21,8 +27,8 @@ importers:
         specifier: 3.6.2
         version: 3.6.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.13.1)
       '@napi-rs/wasm-runtime':
-        specifier: ^1.1.5
-        version: 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: 'catalog:'
+        version: 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@rstest/core':
         specifier: ^0.10.3
         version: 0.10.3
@@ -81,8 +87,8 @@ importers:
         specifier: 1.10.0
         version: 1.10.0
       '@napi-rs/wasm-runtime':
-        specifier: ^1.2.0
-        version: 1.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: 'catalog:'
+        version: 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
 
   bindings/win32-arm64-msvc: {}
 
@@ -569,12 +575,6 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@napi-rs/wasm-runtime@1.1.5':
-    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -822,9 +822,6 @@ packages:
   '@taplo/cli@0.7.0':
     resolution: {integrity: sha512-Ck3zFhQhIhi02Hl6T4ZmJsXdnJE+wXcJz5f8klxd4keRYgenMnip3JDPMGDRLbnC/2iGd8P0sBIQqI3KxfVjBg==}
     hasBin: true
-
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -1529,7 +1526,7 @@ snapshots:
 
   '@napi-rs/lzma-wasm32-wasi@1.4.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -1605,7 +1602,7 @@ snapshots:
 
   '@napi-rs/tar-wasm32-wasi@1.1.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -1646,27 +1643,21 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
+      '@tybys/wasm-util': 0.10.3
     optional: true
-
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.3
-    optional: true
 
   '@napi-rs/wasm-runtime@1.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.3
+    optional: true
 
   '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
     optional: true
@@ -1697,7 +1688,7 @@ snapshots:
 
   '@napi-rs/wasm-tools-wasm32-wasi@1.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -1866,10 +1857,6 @@ snapshots:
       tslib: 2.8.1
 
   '@taplo/cli@0.7.0': {}
-
-  '@tybys/wasm-util@0.10.2':
-    dependencies:
-      tslib: 2.8.1
 
   '@tybys/wasm-util@0.10.3':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,5 +4,5 @@ packages:
   - "fixtures/pnpm"
   - "fixtures/pnpm-workspace/**"
   - "bindings/**"
-minimumReleaseAgeExclude:
-  - "@napi-rs/wasm-runtime@1.2.0"
+catalog:
+  "@napi-rs/wasm-runtime": "1.1.6"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,5 @@ packages:
   - "fixtures/pnpm"
   - "fixtures/pnpm-workspace/**"
   - "bindings/**"
+minimumReleaseAgeExclude:
+  - "@napi-rs/wasm-runtime@1.2.0"


### PR DESCRIPTION
## Why

`@napi-rs/wasm-runtime` was pinned nowhere that survived CI. `napi create-npm-dirs` resolves it from the registry's latest dist-tag at run time and overwrites `bindings/wasm32-wasi/package.json` with `^<latest>`, discarding whatever is committed. So `napi deps check` — which regenerated the manifests and then required a frozen lockfile — broke on every upstream release, twice in the two days `1.2.0` and `1.2.1` landed, and a release published whatever range was latest at that moment rather than the version the tests ran against.

`1.2.x` is why that matters: it carries the stable `latest` dist-tag but peers on `@emnapi/core: ^2.0.0-alpha.3`, and `@emnapi/core` has no stable 2.x, so it fails to load.

## What

The version is now **locked in a pnpm catalog and maintained by renovate**, which already groups `@napi-rs/*` and reads catalog entries from `pnpm-workspace.yaml`. Both consumers — the binding manifest and the root dev dependency — reference `catalog:`.

Nothing regenerates the binding manifests any more, so `napi deps check` is gone. `release-npm.yml` calls `napi version`, which stamps the release version into each manifest without touching dependencies; that is still needed because `scripts/prepublish.mjs` pins each binding in the main package's `optionalDependencies` to `npm/package.json`'s version.

`catalog:` never reaches consumers: `pnpm pack` on `bindings/wasm32-wasi` yields a tarball reading `"@napi-rs/wasm-runtime": "1.1.6"`, and `pnpm publish -r` substitutes the same way.

Split out of #288.
