### PR TITLE
fix(tsconfig): stop reporting tsconfig files as file dependencies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1490,9 +1490,12 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
         &tsconfig_options.references,
       )
       .await?;
-    for dependency in &tsconfig.file_dependencies {
-      ctx.add_file_dependency(dependency.as_path());
-    }
+    // TODO: restore once these can be reported without costing `module count * tsconfig count`.
+    // Temporarily disabled: a monorepo with project references bursts memory in the consumer,
+    // which keeps this set per module. See `tsconfig_file_as_file_dependencies`, ignored for now.
+    // for dependency in &tsconfig.file_dependencies {
+    //   ctx.add_file_dependency(dependency.as_path());
+    // }
     let paths = tsconfig.resolve(cached_path.path(), specifier);
     for path in paths {
       let cached_path = self.cache.value(&path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1492,7 +1492,8 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       .await?;
     // TODO: restore once these can be reported without costing `module count * tsconfig count`.
     // Temporarily disabled: a monorepo with project references bursts memory in the consumer,
-    // which keeps this set per module. See `tsconfig_file_as_file_dependencies`, ignored for now.
+    // which keeps this set per module. Trade-off: tsconfig edits won't invalidate watch builds.
+    // See `tsconfig_file_as_file_dependencies`, ignored for now.
     // for dependency in &tsconfig.file_dependencies {
     //   ctx.add_file_dependency(dependency.as_path());
     // }

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -45,6 +45,8 @@ async fn auto() {
 }
 
 #[tokio::test]
+#[ignore = "temporary workaround: tsconfig and its references are no longer reported as file dependencies, \
+            because a monorepo with many project references bursts memory in the consumer"]
 async fn tsconfig_file_as_file_dependencies() {
   let f = super::fixture_root().join("tsconfig/cases/project_references");
 


### PR DESCRIPTION
## Why

`load_tsconfig_paths` pushed the whole accumulated `tsconfig.file_dependencies` set — the root tsconfig, everything it `extends`, and every transitive project reference — into `ResolveContext` on every resolution that hit a tsconfig path alias.

In a monorepo with project references that set is large, and the consumer keeps it per module, so the cost scales as `module count × tsconfig count`. That is the memory burst this PR addresses. 
Here is an issue from user  https://github.com/web-infra-dev/rspack/issues/15021


Resolving `@/index.ts` in the `project_references` fixture:

**Before** — 6 tsconfig paths on top of the real dependencies:

```
app/tsconfig.json
tsconfig.base.json
project_a/conf.json
project_b/tsconfig.json
project_c/tsconfig.json
paths_template_variable/tsconfig2.json
project_b/src/aliased/index.ts
fixtures/tsconfig/package.json
```

**After**:

```
project_b/src/aliased/index.ts
fixtures/tsconfig/package.json
```

## Trade-off

This is a temporary workaround, not a fix. Editing a `tsconfig.json`, a config it extends, or a referenced tsconfig no longer invalidates anything in watch mode — a dev server restart is required.

It is written to be undone in one commit:

- the loop in `load_tsconfig_paths` is commented out rather than deleted, with a `TODO` pointing at the test
- `tsconfig_file_as_file_dependencies` is marked `#[ignore]` rather than removed, so the expected dependency set stays recorded
- `TsConfig::file_dependencies` and its accumulation in `extend_tsconfig` / `load_references` are untouched

Restoring means uncommenting the loop and dropping the `#[ignore]`.